### PR TITLE
ci: install ripgrep and make packaged binary exec-bit check robust

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -397,15 +397,15 @@ jobs:
           # The pattern below matches: ^-.{2}x.{6}\s+.*bin/<name>$
           # Use double quotes and escape the trailing $ so the shell redirect works correctly.
           # Prefer rg if available, otherwise fall back to grep -E
+          PATTERN="^-..x.{6}[[:space:]]+.*bin/${BINARY_NAME}\$"
+
           if command -v rg >/dev/null 2>&1; then
-            SEARCHER="rg -E"
+            SEARCHER=(rg)
           else
-            SEARCHER="grep -E"
+            SEARCHER=(grep -E)
           fi
 
-          PATTERN='^-..x.{6}[[:space:]]+.*bin/'"$BINARY_NAME""$'
-
-          if ! tar -tzvf "$PKG_TGZ" | eval "$SEARCHER" "$PATTERN" >/dev/null; then
+          if ! tar -tzvf "$PKG_TGZ" | "${SEARCHER[@]}" "$PATTERN" >/dev/null; then
             echo "Error: packaged binary does not have executable bit set. Aborting publish."
             tar -tzvf "$PKG_TGZ"
             exit 1


### PR DESCRIPTION
This pull request updates the release workflow to improve binary verification and compatibility with different environments. The main changes ensure that the workflow can use either `ripgrep` (`rg`) or `grep` for searching, and installs `ripgrep` on Linux runners to provide a faster search tool.

**Release workflow improvements:**

* Added a step to install `ripgrep` (`rg`) on Linux runners to ensure it is available for use in later steps.
* Updated the binary verification script to prefer `rg` for searching tarball contents, with a fallback to `grep` if `rg` is not available. This approach is used both for displaying the binary entry and for checking executable permissions, improving compatibility and reliability.