### PR TITLE
chore: add Makefile with common JS, Rust, and docs workflow targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,15 +30,15 @@ help:
 	@echo "  make fmt             -> rustfmt + prettier (si está instalado)"
 	@echo "  make docs-dev        -> iniciar docs en modo dev"
 	@echo "  make docs-build      -> build docs"
-	@echo "  make agents-sync     -> pnpm exec agentsync apply"
-	@echo "  make agents-sync-clean -> pnpm exec agentsync apply --clean"
+  	@echo "  make agents-sync     -> pnpm run agents:sync"
+  	@echo "  make agents-sync-clean -> pnpm run agents:sync:clean"
 	@echo "  make clean           -> limpia artefactos comunes"
 	@echo ""
 	@echo "Ejemplos:"
 	@echo "  make js-test"
 	@echo "  make rust-test"
 
-all: install js-build rust-build
+all: install js-build
 
 install: js-install rust-build
 	@echo "Instalación completa."
@@ -58,8 +58,8 @@ js-test:
 
 js-build:
 	@echo "Running JS build (workspace scripts if present)..."
-	# Intent: prefer a workspace build script; ajusta si tu workspace tiene scripts distintos.
-	-$(JS_WORKSPACE) run build
+ 	# Intent: prefer a workspace build script; ajusta si tu workspace tiene scripts distintos.
+ 	$(JS_WORKSPACE) run --if-present build
 
 js-release:
 	@echo "Running JS release (semantic-release)..."


### PR DESCRIPTION
This pull request introduces a new `Makefile` to the project, providing a unified set of commands for building, testing, formatting, and managing both JavaScript and Rust components. The `Makefile` streamlines development workflows by defining shortcuts for common tasks and improving developer experience with clear documentation and helpful commands.

Key additions in the new `Makefile`:

**Unified build and test commands:**
* Added targets for installing dependencies, building, testing, and releasing both JavaScript (via `pnpm`) and Rust (via `cargo`) projects, making it easier to manage a polyglot codebase.

**Formatting and code quality:**
* Introduced a `fmt` target that runs `rustfmt` for Rust code and `prettier` for JavaScript, ensuring consistent code style across the project.

**Documentation helpers:**
* Added commands to build, develop, and preview documentation, simplifying the process of maintaining and viewing project docs.

**Agentsync workflow shortcuts:**
* Provided shortcuts for running `agentsync` commands (such as `apply` and `apply --clean`) through the `Makefile`, improving workflow efficiency.

**Developer guidance:**
* Included a `help` target with descriptions and usage examples for all available commands, making it easier for new contributors to