### PR TITLE
chore: update packaging to set platform-specific agentsync binary in package.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -312,6 +312,11 @@ jobs:
           export node_os="${{ matrix.config.os }}"
           export node_arch="${{ matrix.config.arch }}"
           export node_pkg="agentsync-${{ matrix.config.name }}"
+          if [[ "${{ matrix.config.os }}" == "win32" ]]; then
+            export node_bin="agentsync.exe"
+          else
+            export node_bin="agentsync"
+          fi
           
           # Create package directory
           mkdir -p "${node_pkg}/bin"

--- a/npm/package.json.tmpl
+++ b/npm/package.json.tmpl
@@ -17,6 +17,9 @@
   "engines": {
     "node": ">=18"
   },
+  "bin": {
+    "agentsync": "bin/${node_bin}"
+  },
   "files": [
     "bin"
   ],


### PR DESCRIPTION
This pull request introduces improvements to the packaging and distribution process for the `agentsync` Node.js package, ensuring the correct executable is referenced for different operating systems. The most important changes are:

**Cross-platform executable handling:**

* Updated the release workflow in `.github/workflows/release.yml` to set the `node_bin` variable to `agentsync.exe` for Windows (`win32`) and `agentsync` for other platforms, ensuring the correct binary name is used during packaging.

**Package configuration updates:**

* Modified `npm/package.json.tmpl` to define the `bin` field dynamically, referencing the correct executable (`agentsync` or `agentsync.exe`) based on the platform, which improves compatibility for users installing the package on different operating systems.