### PR TITLE
Update Agent Support Table in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ Different AI coding tools expect configuration files in various locations:
 |--------------------|-----------------------------------|----------------------|--------------------|
 | **Claude Code**    | `CLAUDE.md`                       | `.claude/commands/`  | `.claude/skills/`  |
 | **GitHub Copilot** | `.github/copilot-instructions.md` | `.github/agents/`    | -                  |
+| **Gemini CLI**     | `.gemini/settings.json` (MCP)     | -                    | -                  |
+| **VS Code**        | `.vscode/mcp.json` (MCP)          | -                    | -                  |
 | **OpenCode**       | `AGENTS.md`                       | `.opencode/command/` | `.opencode/skill/` |
+| **Cursor**         | `AGENTS.md`                       | `.cursor/commands/`  | -                  |
 
 AgentSync maintains a **single source of truth** in `.agents/` and creates symlinks to all required
 locations.


### PR DESCRIPTION
The `README.md` file has been updated to accurately reflect the currently supported agents. The agent support table now includes "Gemini CLI", "VS Code", and "Cursor", aligning the documentation with the codebase. No other files were modified.

---
*PR created automatically by Jules for task [7712440149786281200](https://jules.google.com/task/7712440149786281200) started by @yacosta738*