### PR TITLE
fix: security vulnerability in bytes crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,7 @@ name = "agentsync"
 version = "1.23.0"
 dependencies = [
  "anyhow",
+ "bytes",
  "chrono",
  "clap",
  "colored",
@@ -201,9 +202,9 @@ checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bzip2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ exclude = [
 ]
 
 [dependencies]
+bytes = "1.11.1"
 # CLI
 clap = { version = "4.5", features = ["derive", "env"] }
 

--- a/npm/agentsync/package.json
+++ b/npm/agentsync/package.json
@@ -1,61 +1,61 @@
 {
-  "name": "@dallay/agentsync",
-  "version": "1.23.0",
-  "description": "A fast CLI tool to sync AI agent configurations and MCP servers across Claude, Copilot, Cursor, and more using symbolic links.",
-  "author": "Yuniel Acosta <yunielacosta738@gmail.com>",
-  "license": "MIT",
-  "publishConfig": {
-    "access": "public"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/dallay/agentsync.git"
-  },
-  "homepage": "https://github.com/dallay/agentsync#readme",
-  "bugs": {
-    "url": "https://github.com/dallay/agentsync/issues"
-  },
-  "keywords": [
-    "ai",
-    "agents",
-    "symlink",
-    "configuration",
-    "cli",
-    "claude",
-    "copilot",
-    "gemini",
-    "cursor",
-    "opencode",
-    "mcp",
-    "mcp-server"
-  ],
-  "bin": {
-    "agentsync": "lib/index.js"
-  },
-  "main": "lib/index.js",
-  "files": [
-    "lib"
-  ],
-  "scripts": {
-    "test": "pnpm run typecheck",
-    "typecheck": "tsc --noEmit",
-    "build": "tsc",
-    "clean": "node -e \"require('fs').rmSync('lib', {recursive: true, force: true})\"",
-    "prepublishOnly": "npm run build"
-  },
-  "devDependencies": {
-    "@types/node": "^24.1.0",
-    "typescript": "^5.9.3"
-  },
-  "optionalDependencies": {
-    "@dallay/agentsync-linux-x64": "1.23.0",
-    "@dallay/agentsync-linux-arm64": "1.23.0",
-    "@dallay/agentsync-darwin-x64": "1.23.0",
-    "@dallay/agentsync-darwin-arm64": "1.23.0",
-    "@dallay/agentsync-windows-x64": "1.23.0",
-    "@dallay/agentsync-windows-arm64": "1.23.0"
-  },
-  "engines": {
-    "node": ">=18"
-  }
+	"name": "@dallay/agentsync",
+	"version": "1.23.0",
+	"description": "A fast CLI tool to sync AI agent configurations and MCP servers across Claude, Copilot, Cursor, and more using symbolic links.",
+	"author": "Yuniel Acosta <yunielacosta738@gmail.com>",
+	"license": "MIT",
+	"publishConfig": {
+		"access": "public"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/dallay/agentsync.git"
+	},
+	"homepage": "https://github.com/dallay/agentsync#readme",
+	"bugs": {
+		"url": "https://github.com/dallay/agentsync/issues"
+	},
+	"keywords": [
+		"ai",
+		"agents",
+		"symlink",
+		"configuration",
+		"cli",
+		"claude",
+		"copilot",
+		"gemini",
+		"cursor",
+		"opencode",
+		"mcp",
+		"mcp-server"
+	],
+	"bin": {
+		"agentsync": "lib/index.js"
+	},
+	"main": "lib/index.js",
+	"files": [
+		"lib"
+	],
+	"scripts": {
+		"test": "pnpm run typecheck",
+		"typecheck": "tsc --noEmit",
+		"build": "tsc",
+		"clean": "node -e \"require('fs').rmSync('lib', {recursive: true, force: true})\"",
+		"prepublishOnly": "npm run build"
+	},
+	"devDependencies": {
+		"@types/node": "^24.1.0",
+		"typescript": "^5.9.3"
+	},
+	"optionalDependencies": {
+		"@dallay/agentsync-linux-x64": "1.23.0",
+		"@dallay/agentsync-linux-arm64": "1.23.0",
+		"@dallay/agentsync-darwin-x64": "1.23.0",
+		"@dallay/agentsync-darwin-arm64": "1.23.0",
+		"@dallay/agentsync-windows-x64": "1.23.0",
+		"@dallay/agentsync-windows-arm64": "1.23.0"
+	},
+	"engines": {
+		"node": ">=18"
+	}
 }


### PR DESCRIPTION
Updated 'bytes' to version 1.11.1 in 'Cargo.toml' and 'Cargo.lock' to address a critical security vulnerability related to unchecked addition in 'BytesMut::reserve'. Verified with 'make verify-all'.

---
*PR created automatically by Jules for task [11000418985869910492](https://jules.google.com/task/11000418985869910492) started by @yacosta738*