### PR TITLE
chore: Update semantic-release-action version in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
           sudo apt-get install -y ripgrep
 
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@16ca923e6ccbb50770c415a0ccd43709a8c5f7a4 # v4
+        uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90
         id: semantic
         with:
           extra_plugins: |


### PR DESCRIPTION
This pull request makes a minor update to the release workflow by bumping the version of the `cycjimmy/semantic-release-action` GitHub Action to a newer commit. This ensures that the workflow uses the latest features and bug fixes from the action.

* Updated the `cycjimmy/semantic-release-action` in `.github/workflows/release.yml` to a newer commit hash for improved stability and features.