### PR TITLE
Update README.md for CLI accuracy and supported agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,11 @@ cargo install agentsync
 
 Download the latest release for your platform from the [GitHub Releases](https://github.com/dallay/agentsync/releases) page.
 
-To install via terminal, you can use the following script (replace `VERSION` with the latest version number, e.g., `1.27.2`):
+To install via terminal, you can use the following script (replace `VERSION` with the latest version number, e.g., `1.28.0`):
 
 ```bash
 # Define version and platform
-VERSION="1.27.2"
+VERSION="1.28.0"
 PLATFORM="x86_64-apple-darwin" # e.g., aarch64-apple-darwin, x86_64-unknown-linux-gnu
 TARBALL="agentsync-${VERSION}-${PLATFORM}.tar.gz"
 
@@ -237,6 +237,7 @@ agentsync doctor
 # Manage skills
 agentsync skill install <skill-id>
 agentsync skill update <skill-id>
+agentsync skill uninstall <skill-id>
 ```
 
 ### Status
@@ -272,11 +273,7 @@ default_agents = ["claude", "copilot"]
 enabled = true
 marker = "AI Agent Symlinks"
 # Additional entries to add to .gitignore (target destinations are added automatically)
-entries = [
-    "CLAUDE.md",
-    "GEMINI.md",
-    ".github/copilot-instructions.md",
-]
+entries = []
 
 # Agent definitions
 [agents.claude]


### PR DESCRIPTION
This submission updates the `README.md` to accurately reflect the current state of the AgentSync project. 

Key changes include:
1. **Version Correction:** Updated hardcoded version strings from `1.27.2` to `1.28.0` in the installation script example.
2. **CLI Documentation:** Added the missing `agentsync skill uninstall` command to the Usage summary, ensuring users are aware of all core skill management capabilities.
3. **Configuration Clarity:** Removed redundant file entries from the `[gitignore].entries` example. Since AgentSync automatically handles target destinations in `.gitignore`, listing them manually in the example was misleading.

These changes ensure that the documentation is factually correct and aligned with the latest release (v1.28.0).

---
*PR created automatically by Jules for task [14770035539513639096](https://jules.google.com/task/14770035539513639096) started by @yacosta738*