### PR TITLE
docs: update project structure example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,9 +380,12 @@ project-root/
 ├── AGENTS.md           → .agents/AGENTS.md
 ├── .mcp.json           (Generated from agentsync.toml)
 ├── .claude/
-│   └── commands/       → symlinks to .agents/command/*.agent.md
+│   ├── commands/       → symlinks to .agents/command/*.agent.md
+│   └── skills/         → symlinks to .agents/skills/*
 ├── .gemini/
-│   └── commands/       → symlinks to .agents/command/*.agent.md
+│   ├── settings.json   (Generated from agentsync.toml)
+│   ├── commands/       → symlinks to .agents/command/*.agent.md
+│   └── skills/         → symlinks to .agents/skills/*
 └── .github/
     ├── copilot-instructions.md → .agents/AGENTS.md
     └── agents/         → symlinks to .agents/command/*.agent.md


### PR DESCRIPTION
This PR updates the README.md to include the missing skills/ directories and Gemini configuration in the project structure example. This ensures that users have a clear understanding of the expected output after running `agentsync apply`.

---
*PR created automatically by Jules for task [2279277276540671585](https://jules.google.com/task/2279277276540671585) started by @yacosta738*