### PR TITLE
fix(ci): grant checks:write permission to audit job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,9 @@ jobs:
   # Security audit
   # ==========================================================================
   audit:
+    permissions:
+      contents: read
+      checks: write
     name: Security Audit
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The rustsec/audit-check action requires checks: write permission to create a Check Run and report its results. This PR explicitly grants contents: read and checks: write permissions to the audit job in the CI workflow.

---
*PR created automatically by Jules for task [17724533698155304121](https://jules.google.com/task/17724533698155304121) started by @yacosta738*