### PR TITLE
fix: use plural .opencode/skills/ directory for OpenCode

### DIFF
--- a/.agents/agentsync.toml
+++ b/.agents/agentsync.toml
@@ -69,7 +69,7 @@ type = "symlink"
 
 [agents.opencode.targets.skills]
 source = "skills"
-destination = ".opencode/skill"
+destination = ".opencode/skills"
 type = "symlink-contents"
 
 [agents.opencode.targets.commands]

--- a/.gitignore
+++ b/.gitignore
@@ -35,12 +35,28 @@ node_modules/
 .pnpm-store/
 pnpm-debug.log
 # START AI Agent Symlinks
+.agents/skills/*.bak
+.claude/commands/
+.claude/skills/
 .github/agents
+.github/agents.bak.*
 .github/copilot-instructions.md
+.github/copilot-instructions.md.bak.*
 .github/prompts
+.github/prompts.bak.*
 .github/skills
+.github/skills.bak.*
+.mcp.json
 .opencode/command
-.opencode/skill
+.opencode/command.bak.*
+.opencode/command/
+.opencode/skills
+.opencode/skills.bak.*
+.opencode/skills/
+.vscode/mcp.json
 AGENTS.md
+AGENTS.md.bak.*
 CLAUDE.md
+CLAUDE.md.bak.*
+opencode.json
 # END AI Agent Symlinks

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Different AI coding tools expect configuration files in various locations:
 | **Gemini CLI**     | `GEMINI.md`                       | `.gemini/commands/`  | `.gemini/skills/`  |
 | **Cursor**         | `AGENTS.md`                       | `.cursor/commands/`  | `.cursor/skills/`  |
 | **VS Code**        | `AGENTS.md` (or `.vscode/*`)      | `.vscode/`           | -                  |
-| **OpenCode**       | `AGENTS.md`                       | `.opencode/command/` | `.opencode/skill/` |
+| **OpenCode**       | `AGENTS.md`                       | `.opencode/command/` | `.opencode/skills/` |
 | **OpenAI Codex**   | -                                 | -                    | `.codex/skills/`   |
 
 AgentSync maintains a **single source of truth** in `.agents/` and creates symlinks to all required

--- a/src/agent_ids.rs
+++ b/src/agent_ids.rs
@@ -76,7 +76,7 @@ pub fn known_ignore_patterns(agent_name: &str) -> &'static [&'static str] {
                 ".gemini/commands/",
                 ".gemini/skills/",
             ],
-            "opencode" => &["opencode.json", ".opencode/command/", ".opencode/skill/"],
+            "opencode" => &["opencode.json", ".opencode/command/", ".opencode/skills/"],
             "cursor" => &[".cursor/mcp.json", ".cursor/skills/"],
             "vscode" => &[".vscode/mcp.json"],
             _ => &[],
@@ -430,7 +430,7 @@ mod tests {
         let patterns = known_ignore_patterns("opencode");
         assert!(patterns.contains(&"opencode.json"));
         assert!(patterns.contains(&".opencode/command/"));
-        assert!(patterns.contains(&".opencode/skill/"));
+        assert!(patterns.contains(&".opencode/skills/"));
     }
 
     #[test]

--- a/website/docs/src/content/docs/reference/configuration.mdx
+++ b/website/docs/src/content/docs/reference/configuration.mdx
@@ -80,7 +80,7 @@ AgentSync automatically adds the following patterns to `.gitignore` based on whi
 | **gemini** | `GEMINI.md`, `.gemini/settings.json`, `.gemini/commands/`, `.gemini/skills/` |
 | **cursor** | `.cursor/mcp.json`, `.cursor/skills/` |
 | **vscode** | `.vscode/mcp.json` |
-| **opencode** | `opencode.json`, `.opencode/command/`, `.opencode/skill/` |
+| **opencode** | `opencode.json`, `.opencode/command/`, `.opencode/skills/` |
 
 **Notes:**
 - The `entries` field in your config is only needed for additional files not covered by the patterns above
@@ -133,7 +133,7 @@ The matrix below documents common agent locations and whether AgentSync can hand
 | Junie | `.junie/guidelines.md` (if configured) | No native MCP formatter | Configurable |
 | AugmentCode | `.augment/rules/ruler_augment_instructions.md` (if configured) | No native MCP formatter | Configurable |
 | Kilo Code | `AGENTS.md` (if configured) | No native MCP formatter (`.kilocode/mcp.json` can be symlinked manually) | Configurable |
-| OpenCode | `AGENTS.md` (if configured) | `opencode.json` (native MCP) | Configurable; common target `.opencode/skill/` |
+| OpenCode | `AGENTS.md` (if configured) | `opencode.json` (native MCP) | Configurable; common target `.opencode/skills/` |
 | Goose | `.goosehints` (if configured) | No native MCP formatter | Configurable; e.g. `.agents/skills/` |
 | Qwen Code | `AGENTS.md` (if configured) | No native MCP formatter (`.qwen/settings.json` can be symlinked manually) | Configurable |
 | RooCode | `AGENTS.md` (if configured) | No native MCP formatter (`.roo/mcp.json` can be symlinked manually) | Configurable; e.g. `.roo/skills/` |


### PR DESCRIPTION
Migrated OpenCode configuration from singular .opencode/skill/ to plural .opencode/skills/ to match the official OpenCode documentation. Updated src/agent_ids.rs, .agents/agentsync.toml, .gitignore, README.md, and Starlight guides. Verified that .opencode/command/ remains singular as per OpenCode docs.

---
*PR created automatically by Jules for task [13269321519345626665](https://jules.google.com/task/13269321519345626665) started by @yacosta738*