### PR TITLE
docs: update CLI reference for accuracy and supported technologies

### DIFF
--- a/website/docs/src/content/docs/reference/cli.mdx
+++ b/website/docs/src/content/docs/reference/cli.mdx
@@ -139,7 +139,7 @@ agentsync skill [OPTIONS] <COMMAND>
 ```
 
 **Global Options**:
-- `--project-root <PROJECT_ROOT>`: Root of the project (defaults to CWD).
+- `-p, --project-root <PROJECT_ROOT>`: Root of the project (defaults to CWD).
 
 #### `install`
 
@@ -167,7 +167,7 @@ agentsync skill suggest [--json] [--install [--all]]
 Behavior:
 
 - `skill suggest` is read-only by default.
-- Detection scope is currently limited to Rust, Node/TypeScript, Astro, GitHub Actions, Docker, Make, and Python.
+- Detection scope currently supports 70+ technologies. See the [Skills guide](/guides/skills/#supported-repository-technology-detection-current-scope) for a representative list.
 - Detection comes from Rust repository scanning, while recommendation mapping comes from AgentSync's curated catalog.
 - Recommendations are opinionated, not exhaustive.
 - The runtime loads an embedded declarative catalog first, then optionally overlays valid provider metadata.


### PR DESCRIPTION
This PR synchronizes the CLI reference documentation with the actual codebase implementation.

- Added the missing `-p` short flag alias to the `skill` command group's `--project-root` option in `website/docs/src/content/docs/reference/cli.mdx`.
- Updated the `skill suggest` detection scope description from a hardcoded list of 7 technologies to "70+ technologies" (verified 73 technologies in `src/skills/catalog.v1.toml`).
- Added a link from the CLI reference to the detailed technology detection list in the Skills guide.
- Verified that the documentation site builds without errors using `pnpm run build`.
- Ensured no unrelated changes (like `pnpm-lock.yaml`) are included in the submission.

---
*PR created automatically by Jules for task [4215389757489638229](https://jules.google.com/task/4215389757489638229) started by @yacosta738*