### PR TITLE
fix(security): prevent path traversal via symlinks in skill archives

### DIFF
--- a/.agents/journal/sentinel.md
+++ b/.agents/journal/sentinel.md
@@ -26,3 +26,8 @@ tool that are known to contain user-provided credentials or sensitive environmen
 **Vulnerability:** The `copy_dir_recursively` function used during local skill installation followed symbolic links. A malicious skill source could include a symlink to a sensitive file (e.g., `~/.ssh/id_rsa`), causing its content to be copied into the project.
 **Learning:** Rust's `std::fs::copy` follows symbolic links by default, copying the target's content rather than the link itself. Similarly, `DirEntry::metadata()` follows links, while `DirEntry::file_type()` does not.
 **Prevention:** Explicitly check `file_type.is_symlink()` and skip or handle symlinks appropriately when performing recursive copies of untrusted directory structures.
+
+## 2025-05-18 - Path Traversal via Symlinks in Skill Archives
+**Vulnerability:** Tar and Zip archive extraction was vulnerable to path traversal. While the code checked for `..` in filenames, an archive could contain a symbolic link to an outside directory (e.g., `link -> /etc`), followed by a file entry that uses that link (e.g., `link/passwd`), causing `tar::Entry::unpack` to follow the link and overwrite files outside the extraction root.
+**Learning:** Checking for `..` is insufficient for archive security if symbolic links are allowed. The `tar` crate's `unpack` methods will faithfully recreate and then follow symbolic links contained within the same archive.
+**Prevention:** Explicitly skip symbolic link and hard link entries when extracting untrusted archives. Only allow regular files and directories.

--- a/src/skills/install.rs
+++ b/src/skills/install.rs
@@ -317,6 +317,16 @@ pub async fn fetch_and_unpack_to_tempdir(url: &str) -> Result<TempDir, SkillInst
 
         for i in 0..zip.len() {
             let mut file = zip.by_index(i).map_err(SkillInstallError::ZipArchive)?;
+
+            // SECURITY: Skip symlinks to prevent path traversal attacks.
+            #[cfg(unix)]
+            if file
+                .unix_mode()
+                .is_some_and(|mode| (mode & 0o120000) == 0o120000)
+            {
+                continue;
+            }
+
             let full_name = file.name();
 
             // Reject absolute paths and path traversal attempts
@@ -406,6 +416,14 @@ pub async fn fetch_and_unpack_to_tempdir(url: &str) -> Result<TempDir, SkillInst
 
         for entry in entries {
             let mut entry = entry.map_err(SkillInstallError::Io)?;
+
+            // SECURITY: Skip symlinks, hardlinks and other non-regular files to prevent
+            // path traversal attacks where a symlink is created and then followed.
+            let entry_type = entry.header().entry_type();
+            if !entry_type.is_file() && !entry_type.is_dir() {
+                continue;
+            }
+
             let full_path = entry.path().map_err(SkillInstallError::Io)?;
 
             if full_path.components().any(|c| {


### PR DESCRIPTION
### Security Hardening: Archive Path Traversal

**Severity:** CRITICAL
**Vulnerability:** Path traversal via symbolic links during archive extraction.
**Impact:** Malicious skill archives could overwrite arbitrary files on the developer's machine. By including a symbolic link entry pointing to a sensitive location (e.g., `~/.ssh`) followed by a file entry within that link (e.g., `link/authorized_keys`), an attacker could traverse out of the temporary extraction directory.
**Fix:** Modified `src/skills/install.rs` to explicitly skip symbolic link and hard link entries during both Tar and Zip extraction. Only regular files and directories are now permitted.
**Source:** `src/skills/install.rs` in `fetch_and_unpack_to_tempdir`.
**Verification:** 
- Created a reproduction test case with a malicious Tar archive containing a symlink traversal payload.
- Confirmed the fix prevents the traversal and the sensitive file remains untouched.
- Verified that all 180+ existing tests pass.
- Verified code quality with `cargo fmt` and `cargo clippy`.
- Received security code review (#Correct#).

This change follows the "Fail Closed" philosophy by rejecting potentially dangerous entry types from untrusted sources.

---
*PR created automatically by Jules for task [10872364684059001679](https://jules.google.com/task/10872364684059001679) started by @yacosta738*