### PR TITLE
Update technology and skill counts in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,7 +602,7 @@ If you need agentsync in CI, you can download the latest version automatically u
 
 ## Skills
 
-AgentSync includes a curated skill catalog with 100+ skills across 40+ technologies. Skills are small bundles of AI-agent instructions that can be installed into your project.
+AgentSync includes a curated skill catalog with 200+ skills across 110+ technologies. Skills are small bundles of AI-agent instructions that can be installed into your project.
 
 - **[dallay/agents-skills](https://github.com/dallay/agents-skills)** — Canonical home for all dallay-maintained skills. Community contributions welcome via PR.
 - **External providers** — Skills from Angular, Vercel, Cloudflare, Expo, Stripe, and many more are resolved from their respective repositories.

--- a/website/docs/src/content/docs/guides/skills.mdx
+++ b/website/docs/src/content/docs/guides/skills.mdx
@@ -146,7 +146,7 @@ This is intentionally **opinionated and curated by AgentSync**. It is not a gene
 
 ### Supported repository technology detection (current scope)
 
-AgentSync supports detection for **70+ technologies**. Detection rules are defined in the catalog and include config file existence, package dependencies, and file extensions.
+AgentSync supports detection for **110+ technologies**. Detection rules are defined in the catalog and include config file existence, package dependencies, and file extensions.
 
 A representative set of supported technologies and markers includes:
 

--- a/website/docs/src/content/docs/reference/cli.mdx
+++ b/website/docs/src/content/docs/reference/cli.mdx
@@ -167,7 +167,7 @@ agentsync skill suggest [--json] [--install [--all]]
 Behavior:
 
 - `skill suggest` is read-only by default.
-- Detection scope currently supports 70+ technologies. See the [Skills guide](/guides/skills/#supported-repository-technology-detection-current-scope) for a representative list.
+- Detection scope currently supports 110+ technologies. See the [Skills guide](/guides/skills/#supported-repository-technology-detection-current-scope) for a representative list.
 - Detection comes from Rust repository scanning, while recommendation mapping comes from AgentSync's curated catalog.
 - Recommendations are opinionated, not exhaustive.
 - The runtime loads an embedded declarative catalog first, then optionally overlays valid provider metadata.


### PR DESCRIPTION
This documentation update fixes an inaccuracy where the number of supported technologies and skills reported in the docs was outdated. 

Audit of `src/skills/catalog.v1.toml` revealed:
- 111 technologies (previously documented as 70+ or 40+)
- 209 skills (previously documented as 100+)

The documentation across the guides, reference, and root README has been synchronized to reflect these verified counts.

Verified by:
- Grepping `src/skills/catalog.v1.toml` for `[[technologies]]` and `[[skills]]`
- Running `pnpm run docs:build` to ensure site integrity
- Running `make rust-test` and `make js-test`

---
*PR created automatically by Jules for task [9799502325551557700](https://jules.google.com/task/9799502325551557700) started by @yacosta738*