### PR TITLE
docs: update documentation for CLI accuracy and supported agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ agentsync status
 agentsync doctor [--project-root <path>]
 
 # Manage skills
+agentsync skill suggest
 agentsync skill install <skill-id>
 agentsync skill update <skill-id>
 agentsync skill uninstall <skill-id>
@@ -442,7 +443,7 @@ AgentSync supports the following agents and will synchronize corresponding files
 - **VS Code** — `.vscode/mcp.json` (agent id: `vscode`)
 - **OpenCode** — `opencode.json` (agent id: `opencode`)
 
-AgentSync also supports 32+ agents (7 native MCP agents and 25+ configurable agents) including Windsurf, Cline, Amazon Q, Aider, RooCode, Trae, and more. See the [full list in the documentation](https://dallay.github.io/agentsync/reference/configuration/).
+AgentSync also supports 32 agents (7 native MCP agents and 25 configurable agents) including Windsurf, Cline, Amazon Q, Aider, RooCode, Trae, and more. See the [full list in the documentation](https://dallay.github.io/agentsync/reference/configuration/).
 
 See the [MCP Integration Guide](https://dallay.github.io/agentsync/guides/mcp/) for formatter details and merge behavior.
 
@@ -602,7 +603,7 @@ If you need agentsync in CI, you can download the latest version automatically u
 
 ## Skills
 
-AgentSync includes a curated skill catalog with 100+ skills across 40+ technologies. Skills are small bundles of AI-agent instructions that can be installed into your project.
+AgentSync includes a curated skill catalog with 150+ skills across 70+ technologies. Skills are small bundles of AI-agent instructions that can be installed into your project.
 
 - **[dallay/agents-skills](https://github.com/dallay/agents-skills)** — Canonical home for all dallay-maintained skills. Community contributions welcome via PR.
 - **External providers** — Skills from Angular, Vercel, Cloudflare, Expo, Stripe, and many more are resolved from their respective repositories.

--- a/website/docs/src/content/docs/reference/cli.mdx
+++ b/website/docs/src/content/docs/reference/cli.mdx
@@ -64,7 +64,7 @@ agentsync apply [OPTIONS]
 ```
 
 **Options**:
-- `-p, --path <PATH>`: Project root directory. Also aliased as `--project-root`.
+- `-p, --path <PATH>`: Project root directory (defaults to current dir). Also aliased as `--project-root`.
 - `-c, --config <CONFIG>`: Use a custom configuration file path instead of the default `.agents/agentsync.toml`.
 - `--clean`: Deletes existing symbolic links before applying.
 - `--dry-run`: Shows what actions would be taken without actually making any changes, including pending `.gitignore` writes or cleanup when gitignore reconciliation is active.
@@ -119,11 +119,11 @@ Preview without any gitignore writes or cleanup:
 Removes all symbolic links managed by AgentSync.
 
 ```bash
-agentsync clean [FLAGS]
+agentsync clean [OPTIONS]
 ```
 
-**Flags**:
-- `-p, --path <PATH>`: Path to the project root. Also aliased as `--project-root`.
+**Options**:
+- `-p, --path <PATH>`: Project root directory (defaults to current dir). Also aliased as `--project-root`.
 - `-c, --config <PATH>`: Path to a custom configuration file.
 - `--dry-run`: Shows what would be removed without actually deleting anything.
 - `-v, --verbose`: Enable verbose logging.
@@ -250,34 +250,16 @@ agentsync doctor [OPTIONS]
 
 ---
 
-### `version`
-
-Shows the current version of the AgentSync CLI.
-
-<CommandTabs command="--version" />
-
----
-
-### `--help`
-
-Shows help information for the CLI or a specific command.
-
-<CommandTabs command="--help" />
-
-<CommandTabs command="apply --help" />
-
----
-
 ### `status`
 
 Verify the status of AgentSync-managed targets and report drift.
 
 ```bash
-agentsync status [--project-root <path>] [--json]
+agentsync status [OPTIONS]
 ```
 
-**Flags**:
-- `-p, --project-root <path>`: Optional. Path to the project root to locate the agentsync config. If omitted, the current working directory is used.
+**Options**:
+- `-p, --project-root <PROJECT_ROOT>`: Project root (defaults to CWD).
 - `--json`: Output machine-readable JSON (pretty-printed) describing each managed target. Useful for CI.
 
 **Behavior**:
@@ -319,3 +301,21 @@ Examples
   - <CommandTabs command="status --project-root /path/to/repo --json" />
 
 On Windows, `status` is also a practical post-setup verification step after you fix symlink permissions or switch to WSL. See the <a href="/guides/windows-symlink-setup/">Windows Symlink Setup guide</a> for the broader verification flow.
+
+---
+
+### `--version`
+
+Shows the current version of the AgentSync CLI. This is a global flag available at the root.
+
+<CommandTabs command="--version" />
+
+---
+
+### `--help`
+
+Shows help information for the CLI or a specific command.
+
+<CommandTabs command="--help" />
+
+<CommandTabs command="apply --help" />

--- a/website/docs/src/content/docs/reference/configuration.mdx
+++ b/website/docs/src/content/docs/reference/configuration.mdx
@@ -187,7 +187,7 @@ Those destinations stay as real directories:
 
 ## Agent Compatibility Matrix
 
-AgentSync has two support levels:
+AgentSync supports 32 agents across two levels:
 
 - **Native MCP generation** (built-in formatter + merge behavior): `claude`, `copilot`, `codex`, `gemini`, `cursor`, `vscode`, `opencode`.
 - **Configurable sync targets** (rules/skills via symlink): any agent as long as you declare `[agents.<name>.targets.*]` entries.
@@ -203,33 +203,37 @@ The matrix below documents common agent locations and whether AgentSync can hand
 | Pi Coding Agent | - | No native MCP formatter | Configurable |
 | Jules | - | No native MCP formatter | Configurable |
 | Cursor | `.cursor/rules/agentsync.mdc` | `.cursor/mcp.json` (native MCP) | Configurable; `.cursor/skills/` |
-| Windsurf | `.windsurfrules` | No native MCP formatter; `.windsurf/mcp_config.json` ignore | Configurable |
+| VS Code | - | `.vscode/mcp.json` (native MCP) | Configurable |
+| Windsurf | `.windsurfrules` | `.windsurf/mcp_config.json` ignore | Configurable |
 | Cline | `.clinerules` | No native MCP formatter | Configurable |
-| Crush | `CRUSH.md` | No native MCP formatter; `.crush.json` ignore | Configurable |
+| Crush | `CRUSH.md` | `CRUSH.md`, `.crush.json` ignore | Configurable |
 | Amp | `AMPCODE.md` | No native MCP formatter | Configurable |
-| Antigravity | - | No native MCP formatter; `.agent/rules/`, `.agent/skills/` ignores | Configurable |
-| Amazon Q CLI | - | No native MCP formatter; `.amazonq/rules/`, `.amazonq/mcp.json` ignores | Configurable |
-| Aider | - | No native MCP formatter; `.aider.conf.yml`, `.aiderignore` ignores | Configurable |
-| Firebase Studio | - | No native MCP formatter; `.idx/airules.md`, `.idx/mcp.json` ignores | Configurable |
-| Open Hands | - | No native MCP formatter; `.openhands/microagents/` ignore | Configurable |
+| Antigravity | - | `.agent/rules/`, `.agent/skills/` ignores | Configurable; `.agent/skills/` |
+| Amazon Q CLI | - | `.amazonq/rules/`, `.amazonq/mcp.json` ignores | Configurable |
+| Aider | - | `.aider.conf.yml`, `.aiderignore` ignores | Configurable |
+| Firebase Studio | - | `.idx/airules.md`, `.idx/mcp.json` ignores | Configurable |
+| Open Hands | - | `.openhands/microagents/` ignore | Configurable |
 
 **Note (Cursor rules filename):** `.cursor/rules/agentsync.mdc` is the documented example path used by AgentSync for Cursor rules. You may use a different `.mdc` filename/path if you configure it explicitly under your `[agents.<name>.targets.*]` entries.
+
+| Agent | Rules File(s) | MCP Configuration / Notes | Skills Support / Location |
+| :--- | :--- | :--- | :--- |
 | Gemini CLI | `GEMINI.md` | `.gemini/settings.json` (native MCP, adds `"trust": true`) | Configurable; `.gemini/skills/` |
-| Junie | - | No native MCP formatter; `.junie/` ignore | Configurable |
-| AugmentCode | - | No native MCP formatter; `.augment/rules/` ignore | Configurable |
-| Kilo Code | - | No native MCP formatter; `.kilocode/mcp.json` ignore | Configurable |
+| Junie | - | `.junie/` ignore | Configurable |
+| AugmentCode | - | `.augment/rules/` ignore | Configurable |
+| Kilo Code | - | `.kilocode/mcp.json` ignore | Configurable |
 | OpenCode | `OPENCODE.md` | `opencode.json` (native MCP) | Configurable; `.opencode/skills/` |
-| Goose | - | No native MCP formatter; `.goosehints` ignore | Configurable |
-| Qwen Code | - | No native MCP formatter; `.qwen/settings.json` ignore | Configurable |
-| RooCode | - | No native MCP formatter; `.roo/mcp.json`, `.roo/rules/`, `.roo/skills/` ignores | Configurable |
-| Zed | - | No native MCP formatter; `.zed/settings.json` ignore | Configurable |
-| Trae AI | - | No native MCP formatter; `.trae/rules/` ignore | Configurable |
-| Warp | `WARP.md` | No native MCP formatter | Configurable |
-| Kiro | - | No native MCP formatter; `.kiro/steering/`, `.kiro/settings/mcp.json` ignores | Configurable |
-| Firebender | - | No native MCP formatter; `firebender.json` ignore | Configurable |
-| Factory Droid | - | No native MCP formatter; `.factory/mcp.json`, `.factory/skills/` ignores | Configurable |
-| Mistral Vibe | - | No native MCP formatter; `.vibe/config.toml`, `.vibe/skills/` ignores | Configurable |
-| JetBrains AI Assistant | - | No native MCP formatter; `.aiassistant/rules/` ignore | Configurable |
+| Goose | `.goosehints` | `.goosehints` ignore | Configurable |
+| Qwen Code | - | `.qwen/settings.json` ignore | Configurable |
+| RooCode | - | `.roo/mcp.json`, `.roo/rules/`, `.roo/skills/` ignores | Configurable; `.roo/skills/` |
+| Zed | - | `.zed/settings.json` ignore | Configurable |
+| Trae AI | - | `.trae/rules/` ignore | Configurable |
+| Warp | `WARP.md` | `WARP.md` ignore | Configurable |
+| Kiro | - | `.kiro/steering/`, `.kiro/settings/mcp.json` ignores | Configurable |
+| Firebender | - | `firebender.json` ignore | Configurable |
+| Factory Droid | - | `.factory/mcp.json`, `.factory/skills/` ignores | Configurable; `.factory/skills/` |
+| Mistral Vibe | - | `.vibe/config.toml`, `.vibe/skills/` ignores | Configurable; `.vibe/skills/` |
+| JetBrains AI Assistant | - | `.aiassistant/rules/` ignore | Configurable |
 
 ### What "configurable" means in practice
 


### PR DESCRIPTION
I have synchronized the documentation with the current state of the AgentSync codebase. This includes updating agent, skill, and technology counts in the README and technical reference, as well as refining the Agent Compatibility Matrix to include VS Code and accurate file locations for several assistants. I also standardized the documentation of CLI flags across all subcommands to match their implementation in `src/main.rs`.

---
*PR created automatically by Jules for task [496983832583212034](https://jules.google.com/task/496983832583212034) started by @yacosta738*