### PR TITLE
fix: detect technologies in multi-project repositories (issue #409)

### DIFF
--- a/src/skills/detect.rs
+++ b/src/skills/detect.rs
@@ -26,11 +26,24 @@ const IGNORED_DIRS: &[&str] = &[
 
 /// Known project manifest files for nested project discovery (issue #409)
 const PROJECT_MANIFEST_FILES: &[&str] = &[
-    "pom.xml", "build.gradle", "build.gradle.kts", "settings.gradle",
-    "settings.gradle.kts", "Cargo.toml", "go.mod", "package.json",
-    "pyproject.toml", "Pipfile", "requirements.txt", "setup.py",
-    "composer.json", "Gemfile", "mix.exs", "pubspec.yaml",
-    "Package.swift", "Dockerfile",
+    "pom.xml",
+    "build.gradle",
+    "build.gradle.kts",
+    "settings.gradle",
+    "settings.gradle.kts",
+    "Cargo.toml",
+    "go.mod",
+    "package.json",
+    "pyproject.toml",
+    "Pipfile",
+    "requirements.txt",
+    "setup.py",
+    "composer.json",
+    "Gemfile",
+    "mix.exs",
+    "pubspec.yaml",
+    "Package.swift",
+    "Dockerfile",
 ];
 
 /// Detection rules parsed from the catalog's `[technologies.detect]` block.

--- a/src/skills/detect.rs
+++ b/src/skills/detect.rs
@@ -1008,4 +1008,49 @@ pytest = "*"
         assert!(packages.contains("celery"));
         assert!(packages.contains("pytest"));
     }
+
+    #[test]
+    fn discover_nested_projects_finds_dockerfile_in_subdirectory() {
+        let temp = TempDir::new().unwrap();
+        fs::create_dir_all(temp.path().join("services/api")).unwrap();
+        fs::write(temp.path().join("services/api/Dockerfile"), "FROM node:20").unwrap();
+
+        let projects = discover_nested_projects(temp.path());
+
+        assert!(projects.iter().any(|p| p.ends_with("services/api")));
+    }
+
+    #[test]
+    fn discover_nested_projects_finds_multiple_manifests() {
+        let temp = TempDir::new().unwrap();
+        fs::create_dir_all(temp.path().join("backend")).unwrap();
+        fs::create_dir_all(temp.path().join("frontend")).unwrap();
+        fs::write(temp.path().join("backend/pom.xml"), "<project/>").unwrap();
+        fs::write(temp.path().join("frontend/package.json"), "{}").unwrap();
+
+        let projects = discover_nested_projects(temp.path());
+
+        assert_eq!(projects.len(), 2);
+    }
+
+    #[test]
+    fn collect_package_names_with_nested_includes_nested_packages() {
+        let temp = TempDir::new().unwrap();
+        fs::write(
+            temp.path().join("package.json"),
+            r#"{"dependencies": {"express": "^4.0"}}"#,
+        )
+        .unwrap();
+        fs::create_dir_all(temp.path().join("services/api")).unwrap();
+        fs::write(
+            temp.path().join("services/api/package.json"),
+            r#"{"dependencies": {"axios": "^1.0"}}"#,
+        )
+        .unwrap();
+
+        let packages = collect_package_names_with_nested(temp.path());
+
+        assert!(packages.contains("express"));
+        assert!(packages.contains("axios"));
+    }
 }

--- a/src/skills/detect.rs
+++ b/src/skills/detect.rs
@@ -24,6 +24,15 @@ const IGNORED_DIRS: &[&str] = &[
     ".pnpm-store",
 ];
 
+/// Known project manifest files for nested project discovery (issue #409)
+const PROJECT_MANIFEST_FILES: &[&str] = &[
+    "pom.xml", "build.gradle", "build.gradle.kts", "settings.gradle",
+    "settings.gradle.kts", "Cargo.toml", "go.mod", "package.json",
+    "pyproject.toml", "Pipfile", "requirements.txt", "setup.py",
+    "composer.json", "Gemfile", "mix.exs", "pubspec.yaml",
+    "Package.swift", "Dockerfile",
+];
+
 /// Detection rules parsed from the catalog's `[technologies.detect]` block.
 #[derive(Debug, Clone, Default, Deserialize, PartialEq)]
 pub struct DetectionRules {
@@ -250,18 +259,60 @@ impl RepoDetector for CatalogDrivenDetector {
             return Ok(Vec::new());
         }
 
-        // Phase 1: Collect metadata and package names
+        // Collect metadata and packages (including nested projects for issue #409)
         let metadata = RepoMetadata::collect(project_root);
-        let all_packages = collect_package_names(project_root);
+        let all_packages = collect_package_names_with_nested(project_root);
 
         let mut detections = Vec::new();
 
-        // Phase 2: Evaluate each technology's rules
+        // Phase 1: Evaluate root project
         for (tech_id, compiled) in &self.rules {
             if let Some(detection) =
                 evaluate_rules(project_root, tech_id, compiled, &all_packages, &metadata)
             {
                 detections.push(detection);
+            }
+        }
+
+        // Phase 2: Scan nested projects (issue #409)
+        for nested_dir in discover_nested_projects(project_root) {
+            let nested_meta = RepoMetadata::collect(&nested_dir);
+            let nested_pkgs = collect_package_names(&nested_dir);
+
+            for (tech_id, compiled) in &self.rules {
+                // Skip if already detected at root
+                if detections.iter().any(|d| d.technology == *tech_id) {
+                    continue;
+                }
+
+                if let Some(detection) =
+                    evaluate_rules(&nested_dir, tech_id, compiled, &nested_pkgs, &nested_meta)
+                {
+                    // Convert path to relative for display
+                    let adjusted = TechnologyDetection {
+                        technology: detection.technology,
+                        confidence: detection.confidence,
+                        root_relative_paths: detection
+                            .root_relative_paths
+                            .iter()
+                            .map(|p| p.strip_prefix(project_root).unwrap_or(p).to_path_buf())
+                            .collect(),
+                        evidence: detection
+                            .evidence
+                            .iter()
+                            .map(|e| DetectionEvidence {
+                                marker: e.marker.clone(),
+                                path: e
+                                    .path
+                                    .strip_prefix(project_root)
+                                    .unwrap_or(&e.path)
+                                    .to_path_buf(),
+                                notes: e.notes.clone(),
+                            })
+                            .collect(),
+                    };
+                    detections.push(adjusted);
+                }
             }
         }
 
@@ -779,6 +830,55 @@ fn expand_workspace_patterns(project_root: &Path, patterns: &[String]) -> Vec<Pa
     }
 
     dirs
+}
+
+/// Discovers standalone projects in subdirectories (issue #409)
+fn discover_nested_projects(project_root: &Path) -> Vec<PathBuf> {
+    let mut projects = Vec::new();
+    let max_depth = 4;
+
+    for entry in WalkDir::new(project_root)
+        .max_depth(max_depth)
+        .follow_links(false)
+        .into_iter()
+        .filter_entry(|e| !should_ignore_entry(project_root, e))
+        .flatten()
+    {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+
+        if !PROJECT_MANIFEST_FILES.contains(&name) {
+            continue;
+        }
+
+        let Some(dir) = path.parent() else {
+            continue;
+        };
+
+        if dir != project_root && !projects.contains(&dir.to_path_buf()) {
+            projects.push(dir.to_path_buf());
+        }
+    }
+
+    projects.sort();
+    projects
+}
+
+/// Collects package names including from nested projects
+fn collect_package_names_with_nested(project_root: &Path) -> BTreeSet<String> {
+    let mut pkgs = collect_package_names(project_root);
+    for nested in discover_nested_projects(project_root) {
+        if let Some(deps) = parse_package_json_deps(&nested.join("package.json")) {
+            pkgs.extend(deps);
+        }
+    }
+    pkgs
 }
 
 #[cfg(test)]

--- a/src/skills/detect.rs
+++ b/src/skills/detect.rs
@@ -46,6 +46,10 @@ const PROJECT_MANIFEST_FILES: &[&str] = &[
     "Dockerfile",
 ];
 
+/// Maximum depth for nested project discovery (issue #409).
+/// Limit to 4 levels to avoid scanning too deep and hitting test/fixture directories.
+const MAX_DISCOVER_DEPTH: usize = 4;
+
 /// Detection rules parsed from the catalog's `[technologies.detect]` block.
 #[derive(Debug, Clone, Default, Deserialize, PartialEq)]
 pub struct DetectionRules {
@@ -272,9 +276,12 @@ impl RepoDetector for CatalogDrivenDetector {
             return Ok(Vec::new());
         }
 
+        // Collect nested projects once to avoid double WalkDir traversal (issue #409)
+        let nested_dirs = discover_nested_projects(project_root);
+
         // Collect metadata and packages (including nested projects for issue #409)
         let metadata = RepoMetadata::collect(project_root);
-        let all_packages = collect_package_names_with_nested(project_root);
+        let all_packages = collect_package_names_with_nested(project_root, &nested_dirs);
 
         let mut detections = Vec::new();
 
@@ -288,9 +295,15 @@ impl RepoDetector for CatalogDrivenDetector {
         }
 
         // Phase 2: Scan nested projects (issue #409)
-        for nested_dir in discover_nested_projects(project_root) {
-            let nested_meta = RepoMetadata::collect(&nested_dir);
-            let nested_pkgs = collect_package_names(&nested_dir);
+        for nested_dir in &nested_dirs {
+            let nested_meta = RepoMetadata::collect(nested_dir);
+            let nested_pkgs = collect_package_names(nested_dir);
+
+            // Compute offset for path adjustment
+            let offset = nested_dir
+                .strip_prefix(project_root)
+                .ok()
+                .map(|p| p.to_path_buf());
 
             for (tech_id, compiled) in &self.rules {
                 // Skip if already detected at root
@@ -299,27 +312,33 @@ impl RepoDetector for CatalogDrivenDetector {
                 }
 
                 if let Some(detection) =
-                    evaluate_rules(&nested_dir, tech_id, compiled, &nested_pkgs, &nested_meta)
+                    evaluate_rules(nested_dir, tech_id, compiled, &nested_pkgs, &nested_meta)
                 {
-                    // Convert path to relative for display
+                    // Adjust paths: detections are relative to nested_dir, need to prepend offset
                     let adjusted = TechnologyDetection {
                         technology: detection.technology,
                         confidence: detection.confidence,
                         root_relative_paths: detection
                             .root_relative_paths
                             .iter()
-                            .map(|p| p.strip_prefix(project_root).unwrap_or(p).to_path_buf())
+                            .map(|p| {
+                                if let Some(ref off) = offset {
+                                    off.join(p)
+                                } else {
+                                    p.clone()
+                                }
+                            })
                             .collect(),
                         evidence: detection
                             .evidence
                             .iter()
                             .map(|e| DetectionEvidence {
                                 marker: e.marker.clone(),
-                                path: e
-                                    .path
-                                    .strip_prefix(project_root)
-                                    .unwrap_or(&e.path)
-                                    .to_path_buf(),
+                                path: if let Some(ref off) = offset {
+                                    off.join(&e.path)
+                                } else {
+                                    e.path.clone()
+                                },
                                 notes: e.notes.clone(),
                             })
                             .collect(),
@@ -847,11 +866,16 @@ fn expand_workspace_patterns(project_root: &Path, patterns: &[String]) -> Vec<Pa
 
 /// Discovers standalone projects in subdirectories (issue #409)
 fn discover_nested_projects(project_root: &Path) -> Vec<PathBuf> {
-    let mut projects = Vec::new();
-    let max_depth = 4;
+    use std::collections::BTreeSet;
+
+    let mut projects_set = BTreeSet::new();
+
+    // Directory names that indicate test/fixture content, not standalone projects
+    // Note: these are at the project root level, not nested (e.g., `tests/e2e/app` is still a valid project)
+    const TEST_DIR_NAMES: &[&str] = &["tests", "test", "__tests__", "fixtures", "examples"];
 
     for entry in WalkDir::new(project_root)
-        .max_depth(max_depth)
+        .max_depth(MAX_DISCOVER_DEPTH)
         .follow_links(false)
         .into_iter()
         .filter_entry(|e| !should_ignore_entry(project_root, e))
@@ -874,19 +898,34 @@ fn discover_nested_projects(project_root: &Path) -> Vec<PathBuf> {
             continue;
         };
 
-        if dir != project_root && !projects.contains(&dir.to_path_buf()) {
-            projects.push(dir.to_path_buf());
+        // Skip if the DIRECTORY itself (not parent) is a test/fixture directory
+        if dir != project_root {
+            let dir_name = dir.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            if TEST_DIR_NAMES.contains(&dir_name) {
+                continue;
+            }
+        }
+
+        if dir != project_root {
+            projects_set.insert(dir.to_path_buf());
         }
     }
 
-    projects.sort();
-    projects
+    projects_set.into_iter().collect()
 }
 
-/// Collects package names including from nested projects
-fn collect_package_names_with_nested(project_root: &Path) -> BTreeSet<String> {
+/// Collects package names including from nested projects.
+///
+/// NOTE: At root-phase (Phase 1), only package.json deps are merged from nested projects
+/// because they're needed for package_patterns detection (e.g., "@azure/*" matches).
+/// Other ecosystems (Python, Java, etc.) are handled later in Phase 2
+/// where each nested project gets full `collect_package_names()` processing.
+fn collect_package_names_with_nested(
+    project_root: &Path,
+    nested_dirs: &[PathBuf],
+) -> BTreeSet<String> {
     let mut pkgs = collect_package_names(project_root);
-    for nested in discover_nested_projects(project_root) {
+    for nested in nested_dirs {
         if let Some(deps) = parse_package_json_deps(&nested.join("package.json")) {
             pkgs.extend(deps);
         }
@@ -1048,7 +1087,8 @@ pytest = "*"
         )
         .unwrap();
 
-        let packages = collect_package_names_with_nested(temp.path());
+        let nested_dirs = discover_nested_projects(temp.path());
+        let packages = collect_package_names_with_nested(temp.path(), &nested_dirs);
 
         assert!(packages.contains("express"));
         assert!(packages.contains("axios"));

--- a/tests/contracts/test_skill_suggest_output.rs
+++ b/tests/contracts/test_skill_suggest_output.rs
@@ -362,7 +362,11 @@ fn skill_suggest_detects_technologies_from_nested_projects() {
         .output()
         .expect("failed to run agentsync skill suggest --json");
 
-    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 
     let value: serde_json::Value =
         serde_json::from_slice(&output.stdout).expect("invalid JSON output");

--- a/tests/contracts/test_skill_suggest_output.rs
+++ b/tests/contracts/test_skill_suggest_output.rs
@@ -388,9 +388,10 @@ fn skill_suggest_detects_technologies_from_nested_projects() {
     let has_docker = technologies.contains(&"docker");
     let has_nodejs = technologies.contains(&"node_typescript");
 
+    // All three technologies should be detected from nested projects
     assert!(
-        has_java || has_docker || has_nodejs,
-        "Expected java/docker/node_typescript from nested projects, got: {:?}",
+        has_java && has_docker && has_nodejs,
+        "Expected java AND docker AND node_typescript from nested projects, got: {:?}",
         technologies
     );
 }

--- a/tests/contracts/test_skill_suggest_output.rs
+++ b/tests/contracts/test_skill_suggest_output.rs
@@ -332,3 +332,61 @@ fn skill_suggest_install_json_error_contract_has_no_human_progress_lines() {
     let value: serde_json::Value = serde_json::from_str(trimmed).unwrap();
     assert_eq!(value["code"], "interactive_tty_required");
 }
+
+/// E2E test for issue #409: detect technologies in nested projects
+#[test]
+fn skill_suggest_detects_technologies_from_nested_projects() {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+
+    // project-alpha: Java/Maven
+    fs::create_dir_all(root.join("project-alpha/src/main/java")).unwrap();
+    fs::write(
+        root.join("project-alpha/pom.xml"),
+        r#"<?xml version="1.0"?><project><artifactId>alpha</artifactId></project>"#,
+    )
+    .unwrap();
+    fs::write(root.join("project-alpha/Dockerfile"), "FROM openjdk:17\n").unwrap();
+
+    // project-beta: Node.js
+    fs::create_dir_all(root.join("project-beta")).unwrap();
+    fs::write(
+        root.join("project-beta/package.json"),
+        r#"{"name": "beta", "dependencies": {"express": "^4.0.0"}}"#,
+    )
+    .unwrap();
+
+    let output = Command::new(agentsync_bin())
+        .current_dir(root)
+        .args(["skill", "suggest", "--json"])
+        .output()
+        .expect("failed to run agentsync skill suggest --json");
+
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+
+    let value: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+
+    let detections = value["detections"]
+        .as_array()
+        .expect("detections should be array");
+    assert!(
+        !detections.is_empty(),
+        "Expected detections from nested projects, got empty"
+    );
+
+    let technologies: Vec<&str> = detections
+        .iter()
+        .map(|d| d["technology"].as_str().unwrap())
+        .collect();
+
+    let has_java = technologies.contains(&"java");
+    let has_docker = technologies.contains(&"docker");
+    let has_nodejs = technologies.contains(&"node_typescript");
+
+    assert!(
+        has_java || has_docker || has_nodejs,
+        "Expected java/docker/node_typescript from nested projects, got: {:?}",
+        technologies
+    );
+}

--- a/tests/unit/suggest_detector.rs
+++ b/tests/unit/suggest_detector.rs
@@ -85,13 +85,6 @@ fn prunes_ignored_directories_and_does_not_detect_nested_config_files() {
         "{\"name\":\"fake\"}\n",
     )
     .unwrap();
-    // node_modules should be ignored
-    fs::create_dir_all(root.join("node_modules/fake-app")).unwrap();
-    fs::write(
-        root.join("node_modules/fake-app/package.json"),
-        "{\"name\":\"fake\"}\n",
-    )
-    .unwrap();
     // Dockerfile in subdirectory - WITH issue #409, SHOULD be detected
     fs::create_dir_all(root.join("tests/e2e")).unwrap();
     fs::write(root.join("tests/e2e/Dockerfile"), "FROM scratch\n").unwrap();

--- a/tests/unit/suggest_detector.rs
+++ b/tests/unit/suggest_detector.rs
@@ -85,8 +85,14 @@ fn prunes_ignored_directories_and_does_not_detect_nested_config_files() {
         "{\"name\":\"fake\"}\n",
     )
     .unwrap();
-    // Dockerfile only in a non-root subdir — catalog checks root config_files only,
-    // so Docker should NOT be detected.
+    // node_modules should be ignored
+    fs::create_dir_all(root.join("node_modules/fake-app")).unwrap();
+    fs::write(
+        root.join("node_modules/fake-app/package.json"),
+        "{\"name\":\"fake\"}\n",
+    )
+    .unwrap();
+    // Dockerfile in subdirectory - WITH issue #409, SHOULD be detected
     fs::create_dir_all(root.join("tests/e2e")).unwrap();
     fs::write(root.join("tests/e2e/Dockerfile"), "FROM scratch\n").unwrap();
 
@@ -101,11 +107,13 @@ fn prunes_ignored_directories_and_does_not_detect_nested_config_files() {
         "node_modules/fake-app/package.json should not trigger node_typescript detection"
     );
 
+    // With issue #409 fix, nested Docker IS now detected
+    let has_docker = detections
+        .iter()
+        .any(|detection| detection.technology == TechnologyId::new(TechnologyId::DOCKER));
     assert!(
-        detections
-            .iter()
-            .all(|detection| detection.technology != TechnologyId::new(TechnologyId::DOCKER)),
-        "Dockerfile in tests/e2e/ should not trigger docker detection (only root config_files checked)"
+        has_docker,
+        "Dockerfile in tests/e2e/ should trigger docker detection"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes issue #409.

## Changes

- Add PROJECT_MANIFEST_FILES constant
- Add discover_nested_projects() function
- Add collect_package_names_with_nested() function  
- Extend CatalogDrivenDetector for nested project scanning
- Add E2E test