### PR TITLE
docs: fix CLI reference drift and missing flags

### DIFF
--- a/.agents/journal/scribe-journal.md
+++ b/.agents/journal/scribe-journal.md
@@ -7,6 +7,11 @@
 - [ ] Add architecture diagrams for the Rust core.
 - [ ] Create a "Known Issues" page for edge cases in symlink creation on Windows.
 
+## 2025-05-20 - CLI Flag Inaccuracies
+
+**Learning:** The `version` command was documented as a standalone subcommand in the CLI reference, but it is actually a root-level flag (`-V, --version`). Additionally, the `--experimental-tui` flag for `agentsync init` was missing from the documentation despite being implemented in the code.
+**Action:** Always verify command structure (subcommand vs flag) against `src/main.rs` and the output of `cargo run -- --help`. Ensure all flags for each command are documented.
+
 ## Planned Improvements
 
 - [ ] Automate synchronization between `CONTRIBUTING.md` and Starlight docs.

--- a/website/docs/src/content/docs/reference/cli.mdx
+++ b/website/docs/src/content/docs/reference/cli.mdx
@@ -23,6 +23,7 @@ agentsync init [OPTIONS]
 - `-p, --path <PATH>`: Project root directory (defaults to current dir). Also aliased as `--project-root`.
 - `-f, --force`: Overwrite existing configuration without prompting.
 - `-w, --wizard`: Run interactive configuration wizard to migrate existing files.
+- `--experimental-tui`: Run the init wizard with an experimental full-screen TUI intro. Requires `--wizard`.
 
 **Actions**:
 - Creates the `.agents/` directory if it doesn't exist.
@@ -250,7 +251,7 @@ agentsync doctor [OPTIONS]
 
 ---
 
-### `version`
+### `--version`
 
 Shows the current version of the AgentSync CLI.
 


### PR DESCRIPTION
I have updated the CLI reference to correct documentation drift and include missing information:

1.  **Corrected the `version` Command:** The documentation previously listed `version` as a standalone subcommand. After verifying against `src/main.rs` and the CLI's `--help` output, I've updated the heading to `### --version` to accurately reflect that it is a root-level flag (`-V, --version`).
2.  **Documented `--experimental-tui` Flag:** The `init` command's `--experimental-tui` flag was missing from the CLI reference. I've added it to the options list, noting that it requires the `--wizard` flag.
3.  **Updated Scribe Journal:** I've added a new entry to `.agents/journal/scribe-journal.md` documenting these inaccuracies as part of my mission to keep AgentSync's documentation synchronized with the source code.

I've verified these changes by building the documentation site (`pnpm run build` in `website/docs`) and running workspace-wide verification (`make verify-all`).


---
*PR created automatically by Jules for task [11332188668273457765](https://jules.google.com/task/11332188668273457765) started by @yacosta738*