### PR TITLE
fix: use AGENTS.md for OpenCode instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Different AI coding tools expect configuration files in various locations:
 | **Gemini CLI**     | `GEMINI.md`                       | `.gemini/commands/`  | `.gemini/skills/`  |
 | **Cursor**         | `.cursor/rules/agentsync.mdc`     | -                    | `.cursor/skills/`  |
 | **VS Code**        | -                                 | -                    | -                  |
-| **OpenCode**       | `OPENCODE.md`                     | `.opencode/command/` | `.opencode/skills/` |
+| **OpenCode**       | `AGENTS.md`                       | `.opencode/command/` | `.opencode/skills/` |
 | **OpenAI Codex**   | `AGENTS.md`                       | -                    | `.codex/skills/`   |
 
 AgentSync maintains a **single source of truth** in `.agents/` and creates symlinks to all required

--- a/openspec/specs/nested-agent-context/spec.md
+++ b/openspec/specs/nested-agent-context/spec.md
@@ -50,7 +50,7 @@ A new function `agent_convention_filename(agent_name: &str) -> Option<&'static s
 | `gemini`   | `GEMINI.md`                                                  |
 | `cursor`   | `.cursor/rules/agentsync.mdc`                                |
 | `windsurf` | `.windsurfrules`                                             |
-| `opencode` | `OPENCODE.md`                                                |
+| `opencode` | `AGENTS.md`                                                  |
 | (unknown)  | `None` (fallback handled by `resolve_module_map_filename()`) |
 
 ---

--- a/openspec/specs/skill-adoption/spec.md
+++ b/openspec/specs/skill-adoption/spec.md
@@ -545,7 +545,7 @@ The `scan_agent_files()` function MUST detect the following instruction files wh
 project root:
 
 - `.windsurfrules` → `AgentFileType::WindsurfRules`
-- `OPENCODE.md` → a new `AgentFileType::OpenCodeInstructions` variant
+- `OPENCODE.md` → `AgentFileType::OpenCodeInstructions` for migration of legacy OpenCode instruction files
 - `AMPCODE.md` → `AgentFileType::AmpInstructions` (already in enum, wire scan)
 
 These instruction files, when detected, MUST be included in the merged `AGENTS.md` during wizard
@@ -559,13 +559,14 @@ migration, following the same pattern as existing instruction file types.
   `AgentFileType::WindsurfRules`
 - AND the `path` field MUST be `.windsurfrules`
 
-#### Scenario: Scan detects OPENCODE.md file
+#### Scenario: Scan detects legacy OPENCODE.md file
 
 - GIVEN a project directory containing an `OPENCODE.md` file with content
 - WHEN `scan_agent_files()` is called on that project root
 - THEN the result MUST include a `DiscoveredFile` with `file_type` equal to
   `AgentFileType::OpenCodeInstructions`
 - AND the `path` field MUST be `OPENCODE.md`
+- AND the wizard MAY merge that legacy file into `.agents/AGENTS.md` during migration
 
 #### Scenario: Scan detects AMPCODE.md file
 

--- a/openspec/specs/skill-adoption/spec.md
+++ b/openspec/specs/skill-adoption/spec.md
@@ -548,8 +548,10 @@ project root:
 - `OPENCODE.md` → `AgentFileType::OpenCodeInstructions` for migration of legacy OpenCode instruction files
 - `AMPCODE.md` → `AgentFileType::AmpInstructions` (already in enum, wire scan)
 
-These instruction files, when detected, MUST be included in the merged `AGENTS.md` during wizard
-migration, following the same pattern as existing instruction file types.
+Detected modern instruction files, when selected for migration, MUST be included in the merged
+`AGENTS.md` during wizard migration, following the same pattern as existing instruction file
+types. Legacy `OPENCODE.md` detection remains optional migration input and MAY be merged by the
+wizard into `.agents/AGENTS.md`.
 
 #### Scenario: Scan detects .windsurfrules file
 

--- a/openspec/specs/skill-adoption/spec.md
+++ b/openspec/specs/skill-adoption/spec.md
@@ -545,13 +545,11 @@ The `scan_agent_files()` function MUST detect the following instruction files wh
 project root:
 
 - `.windsurfrules` → `AgentFileType::WindsurfRules`
-- `OPENCODE.md` → `AgentFileType::OpenCodeInstructions` for migration of legacy OpenCode instruction files
 - `AMPCODE.md` → `AgentFileType::AmpInstructions` (already in enum, wire scan)
 
-Detected modern instruction files, when selected for migration, MUST be included in the merged
+Detected instruction files, when selected for migration, MUST be included in the merged
 `AGENTS.md` during wizard migration, following the same pattern as existing instruction file
-types. Legacy `OPENCODE.md` detection remains optional migration input and MAY be merged by the
-wizard into `.agents/AGENTS.md`.
+types.
 
 #### Scenario: Scan detects .windsurfrules file
 
@@ -560,15 +558,6 @@ wizard into `.agents/AGENTS.md`.
 - THEN the result MUST include a `DiscoveredFile` with `file_type` equal to
   `AgentFileType::WindsurfRules`
 - AND the `path` field MUST be `.windsurfrules`
-
-#### Scenario: Scan detects legacy OPENCODE.md file
-
-- GIVEN a project directory containing an `OPENCODE.md` file with content
-- WHEN `scan_agent_files()` is called on that project root
-- THEN the result MUST include a `DiscoveredFile` with `file_type` equal to
-  `AgentFileType::OpenCodeInstructions`
-- AND the `path` field MUST be `OPENCODE.md`
-- AND the wizard MAY merge that legacy file into `.agents/AGENTS.md` during migration
 
 #### Scenario: Scan detects AMPCODE.md file
 
@@ -588,10 +577,10 @@ wizard into `.agents/AGENTS.md`.
 
 #### Scenario: Scan finds instruction files alongside existing detections
 
-- GIVEN a project with `CLAUDE.md`, `.windsurfrules`, and `OPENCODE.md`
+- GIVEN a project with `CLAUDE.md`, `.windsurfrules`, and `AMPCODE.md`
 - WHEN `scan_agent_files()` is called on that project root
 - THEN the result MUST include entries for `ClaudeInstructions`, `WindsurfRules`, and
-  `OpenCodeInstructions`
+  `AmpInstructions`
 
 ---
 
@@ -717,7 +706,7 @@ The `DEFAULT_CONFIG` MUST remain valid TOML that parses into a `Config` struct w
 - WHEN it is parsed as TOML into a `Config` struct
 - THEN there MUST be an `agents` entry keyed `"opencode"`
 - AND the `opencode` agent MUST have an `instructions` target with `destination` containing
-  `"OPENCODE.md"`
+  `"AGENTS.md"`
 - AND the `opencode` agent MUST have a `skills` target with `destination` containing
   `".opencode/skills"`
 
@@ -1166,7 +1155,7 @@ rerunning `agentsync apply`.
 - THEN the managed `Agent config layout` section MUST describe `.agents/AGENTS.md` as the canonical
   instructions source
 - AND the section MUST include the generated instruction destinations `CLAUDE.md`,
-  `.github/copilot-instructions.md`, `GEMINI.md`, `OPENCODE.md`, and `AGENTS.md`
+  `.github/copilot-instructions.md`, `GEMINI.md`, and `AGENTS.md`
 - AND the section MUST include the generated skills destinations `.claude/skills`, `.codex/skills`,
   `.gemini/skills`, and `.opencode/skills`
 - AND the section MUST include the generated commands destinations `.claude/commands`,
@@ -1279,8 +1268,7 @@ as the public contract.
     empty or absent.
 16. `scan_agent_files()` detects command directories for Claude, Gemini, and OpenCode when they
     exist with content.
-17. `scan_agent_files()` detects `.windsurfrules`, `OPENCODE.md`, and `AMPCODE.md` as instruction
-    files.
+17. `scan_agent_files()` detects `.windsurfrules` and `AMPCODE.md` as instruction files.
 18. `scan_agent_files()` detects the presence of 10 agent-specific MCP configuration files/settings
     paths (e.g., `.cursor/mcp.json`, `.vscode/mcp.json`) when present.
 19. The wizard migrates command directories into `.agents/commands/` with collision detection.

--- a/src/agent_ids.rs
+++ b/src/agent_ids.rs
@@ -78,7 +78,7 @@ pub fn agent_convention_filename(agent_name: &str) -> Option<&'static str> {
         "gemini" => Some("GEMINI.md"),
         "cursor" => Some(".cursor/rules/agentsync.mdc"),
         "windsurf" => Some(".windsurfrules"),
-        "opencode" => Some("OPENCODE.md"),
+        "opencode" => Some("AGENTS.md"),
         "crush" => Some("CRUSH.md"),
         "warp" => Some("WARP.md"),
         "amp" => Some("AMPCODE.md"),
@@ -487,7 +487,7 @@ mod tests {
             agent_convention_filename("windsurf"),
             Some(".windsurfrules")
         );
-        assert_eq!(agent_convention_filename("opencode"), Some("OPENCODE.md"));
+        assert_eq!(agent_convention_filename("opencode"), Some("AGENTS.md"));
         assert_eq!(agent_convention_filename("crush"), Some("CRUSH.md"));
         assert_eq!(agent_convention_filename("warp"), Some("WARP.md"));
         assert_eq!(agent_convention_filename("amp"), Some("AMPCODE.md"));
@@ -504,7 +504,7 @@ mod tests {
         );
         assert_eq!(agent_convention_filename("codex-cli"), Some("AGENTS.md"));
         assert_eq!(agent_convention_filename("gemini-cli"), Some("GEMINI.md"));
-        assert_eq!(agent_convention_filename("open-code"), Some("OPENCODE.md"));
+        assert_eq!(agent_convention_filename("open-code"), Some("AGENTS.md"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1629,6 +1629,23 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_module_map_filename_convention_opencode() {
+        let mapping = ModuleMapping {
+            source: "api-context.md".to_string(),
+            destination: "src/api".to_string(),
+            filename_override: None,
+        };
+        assert_eq!(
+            resolve_module_map_filename(&mapping, "opencode"),
+            "AGENTS.md"
+        );
+        assert_eq!(
+            resolve_module_map_filename(&mapping, "open-code"),
+            "AGENTS.md"
+        );
+    }
+
+    #[test]
     fn test_resolve_module_map_filename_fallback_unknown_agent() {
         let mapping = ModuleMapping {
             source: "api-context.md".to_string(),

--- a/src/init.rs
+++ b/src/init.rs
@@ -144,7 +144,7 @@ description = "OpenCode - Open-source AI coding assistant"
 
 [agents.opencode.targets.instructions]
 source = "AGENTS.md"
-destination = "OPENCODE.md"
+destination = "AGENTS.md"
 type = "symlink"
 
 [agents.opencode.targets.skills]
@@ -3770,11 +3770,7 @@ mod tests {
         assert!(opencode.targets.contains_key("instructions"));
         assert!(opencode.targets.contains_key("skills"));
         assert!(opencode.targets.contains_key("commands"));
-        assert!(
-            opencode.targets["instructions"]
-                .destination
-                .contains("OPENCODE.md")
-        );
+        assert_eq!(opencode.targets["instructions"].destination, "AGENTS.md");
         assert!(
             opencode.targets["skills"]
                 .destination
@@ -4020,7 +4016,7 @@ mod tests {
             facts
                 .instructions
                 .iter()
-                .any(|target| target.destination == "OPENCODE.md")
+                .any(|target| target.destination == "AGENTS.md")
         );
         assert!(
             facts

--- a/src/init.rs
+++ b/src/init.rs
@@ -302,7 +302,6 @@ enum AgentFileType {
     VibeDirectory,
     JetBrainsRules,
     GeminiInstructions,
-    OpenCodeInstructions,
     // Skill directories (contents merged into .agents/skills/ on migration)
     ClaudeSkills,
     CursorSkills,
@@ -475,16 +474,6 @@ fn scan_agent_files(project_root: &Path) -> Result<Vec<DiscoveredFile>> {
                 display_name: "Gemini commands (.gemini/commands/)".to_string(),
             });
         }
-    }
-
-    // OpenCode: OPENCODE.md
-    let opencode_path = project_root.join("OPENCODE.md");
-    if opencode_path.exists() {
-        discovered.push(DiscoveredFile {
-            path: "OPENCODE.md".into(),
-            file_type: AgentFileType::OpenCodeInstructions,
-            display_name: "OPENCODE.md (OpenCode instructions)".to_string(),
-        });
     }
 
     // OpenCode: .opencode/skills/ directory
@@ -1769,7 +1758,6 @@ pub fn init_wizard(project_root: &Path, force: bool) -> Result<()> {
                     | AgentFileType::GooseHints
                     | AgentFileType::WarpInstructions
                     | AgentFileType::GeminiInstructions
-                    | AgentFileType::OpenCodeInstructions
             )
         })
         .collect();
@@ -1825,8 +1813,7 @@ pub fn init_wizard(project_root: &Path, force: bool) -> Result<()> {
             | AgentFileType::AmpInstructions
             | AgentFileType::GooseHints
             | AgentFileType::WarpInstructions
-            | AgentFileType::GeminiInstructions
-            | AgentFileType::OpenCodeInstructions => {
+            | AgentFileType::GeminiInstructions => {
                 // Already handled above — content merged into AGENTS.md
                 continue;
             }
@@ -3271,18 +3258,17 @@ mod tests {
     }
 
     #[test]
-    fn test_scan_agent_files_finds_opencode_instructions() {
+    fn test_scan_agent_files_ignores_opencode_md() {
         let temp_dir = TempDir::new().unwrap();
         fs::write(temp_dir.path().join("OPENCODE.md"), "# OpenCode").unwrap();
 
         let discovered = scan_agent_files(temp_dir.path()).unwrap();
 
-        let entry: Vec<_> = discovered
-            .iter()
-            .filter(|f| f.file_type == AgentFileType::OpenCodeInstructions)
-            .collect();
-        assert_eq!(entry.len(), 1);
-        assert_eq!(entry[0].path.to_str().unwrap(), "OPENCODE.md");
+        assert!(
+            discovered
+                .iter()
+                .all(|f| f.path.to_str().unwrap() != "OPENCODE.md")
+        );
     }
 
     #[test]

--- a/tests/e2e/fixtures/repos/ai-adoption/OPENCODE.md
+++ b/tests/e2e/fixtures/repos/ai-adoption/OPENCODE.md
@@ -1,3 +1,0 @@
-# OpenCode adoption instructions
-
-Use OpenCode-specific project rules.

--- a/tests/e2e/scenarios/01-init-blank.sh
+++ b/tests/e2e/scenarios/01-init-blank.sh
@@ -24,7 +24,7 @@ agentsync apply --verbose
 
 assert_symlink_exists "CLAUDE.md"
 assert_symlink_exists "GEMINI.md"
-assert_symlink_exists "OPENCODE.md"
+assert_symlink_exists "AGENTS.md"
 assert_symlink_exists ".github/copilot-instructions.md"
 
 echo "✅ init blank repository scenario passed"

--- a/tests/e2e/scenarios/02-init-adoption.sh
+++ b/tests/e2e/scenarios/02-init-adoption.sh
@@ -27,18 +27,16 @@ for command_name in review.md analyze.md fix.md; do
 done
 
 assert_file_contains ".agents/AGENTS.md" "# Instructions from GEMINI.md"
-assert_file_contains ".agents/AGENTS.md" "# Instructions from OPENCODE.md"
 assert_file_contains ".agents/AGENTS.md" "# Instructions from .github/copilot-instructions.md"
 
 log_step "Removing original agent files to verify apply recreates them"
 rm -rf .claude .gemini .codex .cursor .opencode .github .vscode
-rm -f CLAUDE.md GEMINI.md OPENCODE.md AGENTS.md opencode.json
+rm -f CLAUDE.md GEMINI.md AGENTS.md opencode.json
 
 agentsync apply --verbose
 
 assert_symlink_exists "CLAUDE.md"
 assert_symlink_exists "GEMINI.md"
-assert_symlink_exists "OPENCODE.md"
 assert_symlink_exists "AGENTS.md"
 assert_symlink_exists ".claude/skills"
 assert_symlink_exists ".gemini/skills"

--- a/website/docs/src/content/docs/guides/getting-started.mdx
+++ b/website/docs/src/content/docs/guides/getting-started.mdx
@@ -110,7 +110,7 @@ If you already have agent configuration files (like `CLAUDE.md`, `.cursor/`, or 
 <CommandTabs command="init --wizard" />
 
 The wizard will:
-1. **Scan** your project for existing agent-related files — instruction files (CLAUDE.md, AGENTS.md, GEMINI.md, OPENCODE.md (legacy), .windsurfrules, AMPCODE.md, etc.), skill directories (.claude/skills/, .cursor/skills/, .codex/skills/, and more), command directories (.claude/commands/, .gemini/commands/, .opencode/command/), and MCP configurations
+1. **Scan** your project for existing agent-related files — instruction files (CLAUDE.md, AGENTS.md, GEMINI.md, .windsurfrules, AMPCODE.md, etc.), skill directories (.claude/skills/, .cursor/skills/, .codex/skills/, and more), command directories (.claude/commands/, .gemini/commands/, .opencode/command/), and MCP configurations
 2. **Let you select** which files to migrate to `.agents/`
 3. **Migrate skills** from any detected agent into `.agents/skills/` (with collision detection — duplicates are skipped with a warning)
 4. **Migrate commands** into `.agents/commands/` as the canonical location

--- a/website/docs/src/content/docs/guides/getting-started.mdx
+++ b/website/docs/src/content/docs/guides/getting-started.mdx
@@ -110,7 +110,7 @@ If you already have agent configuration files (like `CLAUDE.md`, `.cursor/`, or 
 <CommandTabs command="init --wizard" />
 
 The wizard will:
-1. **Scan** your project for existing agent-related files — instruction files (CLAUDE.md, .windsurfrules, OPENCODE.md, etc.), skill directories (.claude/skills/, .cursor/skills/, .codex/skills/, and more), command directories (.claude/commands/, .gemini/commands/, .opencode/command/), and MCP configurations
+1. **Scan** your project for existing agent-related files — instruction files (CLAUDE.md, AGENTS.md, GEMINI.md, .windsurfrules, AMPCODE.md, etc.), skill directories (.claude/skills/, .cursor/skills/, .codex/skills/, and more), command directories (.claude/commands/, .gemini/commands/, .opencode/command/), and MCP configurations
 2. **Let you select** which files to migrate to `.agents/`
 3. **Migrate skills** from any detected agent into `.agents/skills/` (with collision detection — duplicates are skipped with a warning)
 4. **Migrate commands** into `.agents/commands/` as the canonical location

--- a/website/docs/src/content/docs/guides/getting-started.mdx
+++ b/website/docs/src/content/docs/guides/getting-started.mdx
@@ -110,7 +110,7 @@ If you already have agent configuration files (like `CLAUDE.md`, `.cursor/`, or 
 <CommandTabs command="init --wizard" />
 
 The wizard will:
-1. **Scan** your project for existing agent-related files — instruction files (CLAUDE.md, AGENTS.md, GEMINI.md, .windsurfrules, AMPCODE.md, etc.), skill directories (.claude/skills/, .cursor/skills/, .codex/skills/, and more), command directories (.claude/commands/, .gemini/commands/, .opencode/command/), and MCP configurations
+1. **Scan** your project for existing agent-related files — instruction files (CLAUDE.md, AGENTS.md, GEMINI.md, OPENCODE.md (legacy), .windsurfrules, AMPCODE.md, etc.), skill directories (.claude/skills/, .cursor/skills/, .codex/skills/, and more), command directories (.claude/commands/, .gemini/commands/, .opencode/command/), and MCP configurations
 2. **Let you select** which files to migrate to `.agents/`
 3. **Migrate skills** from any detected agent into `.agents/skills/` (with collision detection — duplicates are skipped with a warning)
 4. **Migrate commands** into `.agents/commands/` as the canonical location

--- a/website/docs/src/content/docs/reference/cli.mdx
+++ b/website/docs/src/content/docs/reference/cli.mdx
@@ -31,7 +31,7 @@ agentsync init [OPTIONS]
 
 **Wizard Mode**:
 When using the `--wizard` flag, AgentSync will guide you through the same initialization flow described in the Getting Started guide, and this section provides the detailed, step‑by‑step reference for that wizard:
-1. Scan your project for existing agent-related files — including instruction files (CLAUDE.md, AGENTS.md, GEMINI.md, .windsurfrules, AMPCODE.md, etc.), skill directories (.claude/skills/, .cursor/skills/, .codex/skills/, .gemini/skills/, .opencode/skills/, .roo/skills/, .factory/skills/, .vibe/skills/, .agent/skills/), command directories (.claude/commands/, .gemini/commands/, .opencode/command/), MCP configs (.cursor/mcp.json, .windsurf/mcp_config.json, .roo/mcp.json, etc.), and agent directories (.cursor/, .windsurf/, etc.)
+1. Scan your project for existing agent-related files — including instruction files (CLAUDE.md, AGENTS.md, GEMINI.md, OPENCODE.md (legacy), .windsurfrules, AMPCODE.md, etc.), skill directories (.claude/skills/, .cursor/skills/, .codex/skills/, .gemini/skills/, .opencode/skills/, .roo/skills/, .factory/skills/, .vibe/skills/, .agent/skills/), command directories (.claude/commands/, .gemini/commands/, .opencode/command/), MCP configs (.cursor/mcp.json, .windsurf/mcp_config.json, .roo/mcp.json, etc.), and agent directories (.cursor/, .windsurf/, etc.)
 2. Interactively prompt you to select which files to migrate
 3. For **instruction files**: Read their content and merge into `.agents/AGENTS.md`
 4. For **skill directories**: Copy contents into `.agents/skills/` (with collision detection — duplicates are skipped with a warning)

--- a/website/docs/src/content/docs/reference/cli.mdx
+++ b/website/docs/src/content/docs/reference/cli.mdx
@@ -31,7 +31,7 @@ agentsync init [OPTIONS]
 
 **Wizard Mode**:
 When using the `--wizard` flag, AgentSync will guide you through the same initialization flow described in the Getting Started guide, and this section provides the detailed, step‑by‑step reference for that wizard:
-1. Scan your project for existing agent-related files — including instruction files (CLAUDE.md, .windsurfrules, OPENCODE.md, AMPCODE.md, etc.), skill directories (.claude/skills/, .cursor/skills/, .codex/skills/, .gemini/skills/, .opencode/skills/, .roo/skills/, .factory/skills/, .vibe/skills/, .agent/skills/), command directories (.claude/commands/, .gemini/commands/, .opencode/command/), MCP configs (.cursor/mcp.json, .windsurf/mcp_config.json, .roo/mcp.json, etc.), and agent directories (.cursor/, .windsurf/, etc.)
+1. Scan your project for existing agent-related files — including instruction files (CLAUDE.md, AGENTS.md, GEMINI.md, .windsurfrules, AMPCODE.md, etc.), skill directories (.claude/skills/, .cursor/skills/, .codex/skills/, .gemini/skills/, .opencode/skills/, .roo/skills/, .factory/skills/, .vibe/skills/, .agent/skills/), command directories (.claude/commands/, .gemini/commands/, .opencode/command/), MCP configs (.cursor/mcp.json, .windsurf/mcp_config.json, .roo/mcp.json, etc.), and agent directories (.cursor/, .windsurf/, etc.)
 2. Interactively prompt you to select which files to migrate
 3. For **instruction files**: Read their content and merge into `.agents/AGENTS.md`
 4. For **skill directories**: Copy contents into `.agents/skills/` (with collision detection — duplicates are skipped with a warning)

--- a/website/docs/src/content/docs/reference/cli.mdx
+++ b/website/docs/src/content/docs/reference/cli.mdx
@@ -31,7 +31,7 @@ agentsync init [OPTIONS]
 
 **Wizard Mode**:
 When using the `--wizard` flag, AgentSync will guide you through the same initialization flow described in the Getting Started guide, and this section provides the detailed, step‑by‑step reference for that wizard:
-1. Scan your project for existing agent-related files — including instruction files (CLAUDE.md, AGENTS.md, GEMINI.md, OPENCODE.md (legacy), .windsurfrules, AMPCODE.md, etc.), skill directories (.claude/skills/, .cursor/skills/, .codex/skills/, .gemini/skills/, .opencode/skills/, .roo/skills/, .factory/skills/, .vibe/skills/, .agent/skills/), command directories (.claude/commands/, .gemini/commands/, .opencode/command/), MCP configs (.cursor/mcp.json, .windsurf/mcp_config.json, .roo/mcp.json, etc.), and agent directories (.cursor/, .windsurf/, etc.)
+1. Scan your project for existing agent-related files — including instruction files (CLAUDE.md, AGENTS.md, GEMINI.md, .windsurfrules, AMPCODE.md, etc.), skill directories (.claude/skills/, .cursor/skills/, .codex/skills/, .gemini/skills/, .opencode/skills/, .roo/skills/, .factory/skills/, .vibe/skills/, .agent/skills/), command directories (.claude/commands/, .gemini/commands/, .opencode/command/), MCP configs (.cursor/mcp.json, .windsurf/mcp_config.json, .roo/mcp.json, etc.), and agent directories (.cursor/, .windsurf/, etc.)
 2. Interactively prompt you to select which files to migrate
 3. For **instruction files**: Read their content and merge into `.agents/AGENTS.md`
 4. For **skill directories**: Copy contents into `.agents/skills/` (with collision detection — duplicates are skipped with a warning)

--- a/website/docs/src/content/docs/reference/configuration.mdx
+++ b/website/docs/src/content/docs/reference/configuration.mdx
@@ -218,7 +218,7 @@ The matrix below documents common agent locations and whether AgentSync can hand
 | Junie | - | No native MCP formatter; `.junie/` ignore | Configurable |
 | AugmentCode | - | No native MCP formatter; `.augment/rules/` ignore | Configurable |
 | Kilo Code | - | No native MCP formatter; `.kilocode/mcp.json` ignore | Configurable |
-| OpenCode | `OPENCODE.md` | `opencode.json` (native MCP) | Configurable; `.opencode/skills/` |
+| OpenCode | `AGENTS.md` | `opencode.json` (native MCP) | Configurable; `.opencode/skills/` |
 | Goose | - | No native MCP formatter; `.goosehints` ignore | Configurable |
 | Qwen Code | - | No native MCP formatter; `.qwen/settings.json` ignore | Configurable |
 | RooCode | - | No native MCP formatter; `.roo/mcp.json`, `.roo/rules/`, `.roo/skills/` ignores | Configurable |


### PR DESCRIPTION
# Description

Align OpenCode with its current root `AGENTS.md` convention so `agentsync init --wizard` no longer generates an incorrect `OPENCODE.md` instructions target. This also updates the shared filename convention, targeted specs, and public docs so generation, module-map behavior, and documentation all tell the same story while keeping legacy `OPENCODE.md` migration support documented.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Targeted Rust tests covering the wizard template, OpenCode filename convention, and module-map resolution now expect `AGENTS.md` for OpenCode while preserving legacy `OPENCODE.md` scan support for migration.

- [x] `cargo test test_default_config_contains_opencode_agent -- --nocapture`
- [x] `cargo test test_build_wizard_layout_facts_uses_rendered_config_targets_and_modes -- --nocapture`
- [x] `cargo test test_agent_convention_filename -- --nocapture`
- [x] `cargo test test_resolve_module_map_filename_convention_opencode -- --nocapture`

**Test Configuration**:
* OS/Distribution: macOS (darwin)
* Rust version: local toolchain from repository environment
* Node/pnpm version: not used for verification
* Test command used: targeted `cargo test` commands above
* Environment variables: none
* Reproduction steps: run `pnpm dlx @dallay/agentsync init --wizard`, inspect generated `.agents/agentsync.toml`, and confirm `[agents.opencode.targets.instructions]` now points to `AGENTS.md`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
