### PR TITLE
docs: Update combo evaluation status from deferred to active

### DIFF
--- a/.agents/journal/scribe-journal.md
+++ b/.agents/journal/scribe-journal.md
@@ -27,3 +27,8 @@
 
 **Learning:** The `agentsync skill suggest` command's technology detection shifted from a small hard-coded set to a data-driven catalog (`src/skills/catalog.v1.toml`) now supporting 73+ technologies. The documentation had drifted significantly (claiming only 7 supported).
 **Action:** When documenting "supported" lists that are data-driven, use "N+" terminology and refer to the source-of-truth catalog file to ensure long-term accuracy.
+
+## 2026-05-20 - Implemented Combo Evaluation Documented as Deferred
+
+**Learning:** Both the CLI reference and the Skills guide claimed that active evaluation of multi-technology "combo" entries was deferred. However, Phase 2 of `recommend_skills` in `src/skills/suggest.rs` already implements this logic, providing specific recommendations for combinations like `react-hook-form` + `zod`.
+**Action:** Before claiming a feature is "deferred" or "planned," verify the relevant logic phases in the implementation (e.g., Phase 2 evaluation loops).

--- a/website/docs/src/content/docs/guides/skills.mdx
+++ b/website/docs/src/content/docs/guides/skills.mdx
@@ -183,7 +183,7 @@ Recommendation metadata now comes from a hybrid catalog model:
 - Providers may expose an **optional catalog overlay**. Valid provider entries extend or override matching embedded entries by stable ids.
 - Invalid provider entries are ignored individually; if provider metadata is missing, unreadable, or invalid at the top level, AgentSync falls back to the embedded catalog.
 - A single technology can recommend **multiple skills**. For example, the embedded catalog currently maps `astro` to `frontend-design`, `accessibility`, `performance`, `core-web-vitals`, and `seo`, and maps `github_actions` to both `github-actions` and `pinned-tag`.
-- The schema also supports explicit **combo** entries (multi-technology recommendations). Those entries are loaded and preserved now, but active combo evaluation is currently deferred.
+- The schema also supports explicit **combo** entries (multi-technology recommendations). Phase 2 combo evaluation is functional and used to recommend specific skills when multiple technologies (e.g., `react-hook-form` + `zod`) are detected.
 
 ### Compatibility bridge: canonical ids vs current runtime ids
 

--- a/website/docs/src/content/docs/reference/cli.mdx
+++ b/website/docs/src/content/docs/reference/cli.mdx
@@ -173,7 +173,7 @@ Behavior:
 - Recommendations are opinionated, not exhaustive.
 - The runtime loads an embedded declarative catalog first, then optionally overlays valid provider metadata.
 - One detected technology may map to multiple recommended skills.
-- Combo catalog entries are supported in schema and loading, but active combo evaluation is currently deferred.
+- Combo catalog entries allow recommending specific skills when a combination of technologies is detected (e.g., React + shadcn/ui).
 - `--install` opens an interactive selector in a TTY.
 - `--install --all` is the explicit non-interactive path and installs every not-yet-installed recommendation.
 - Recommendation-driven installs reuse the same install pipeline and registry updates as `skill install`, and they skip recommendations that are already installed.


### PR DESCRIPTION
Corrected the documentation regarding "combo" evaluation in the skill suggestion system. Both the CLI reference and the Skills guide incorrectly stated that this feature was deferred, while it is actually functional and implemented in Phase 2 of `recommend_skills` in `src/skills/suggest.rs`. Verified the fix by reviewing the code and performing manual tests. Added a journal entry to track this learning.

---
*PR created automatically by Jules for task [17707275698707877239](https://jules.google.com/task/17707275698707877239) started by @yacosta738*