### PR TITLE
fix(security): harden path traversal validation and validate sources

### DIFF
--- a/src/linker.rs
+++ b/src/linker.rs
@@ -659,7 +659,10 @@ impl Linker {
                         relative_source.display()
                     );
                 } else {
-                    self.revalidate_path(dest)?;
+                    // SECURITY: Use revalidate_unlink_path here (not revalidate_path) so that a
+                    // symlink whose target points outside project_root can still be safely removed.
+                    // revalidate_path would canonicalize through the symlink and reject the path.
+                    self.revalidate_unlink_path(dest)?;
                     remove_symlink(dest)?;
                     self.invalidate_discovery_caches();
                     if options.verbose {
@@ -1343,7 +1346,9 @@ impl Linker {
                             if options.dry_run {
                                 println!("  {} Would remove: {}", "→".cyan(), dest.display());
                             } else {
-                                self.revalidate_path(&dest)?;
+                                // SECURITY: Use revalidate_unlink_path so a symlink whose target
+                                // points outside project_root can still be removed safely.
+                                self.revalidate_unlink_path(&dest)?;
                                 remove_symlink(&dest)?;
                                 self.invalidate_discovery_caches();
                                 println!("  {} Removed: {}", "✔".green(), dest.display());

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -205,6 +205,118 @@ impl Linker {
             .map(|_| ())
     }
 
+    /// Re-validate a path before unlinking (remove_file/remove_dir).
+    /// Unlike revalidate_path, this does NOT canonicalize the final component,
+    /// allowing safe removal of symlinks that point outside project_root.
+    /// The symlink entry itself must be within project_root, but its target can be anywhere.
+    fn revalidate_unlink_path(&self, path: &Path) -> Result<()> {
+        let display_path = path.display().to_string();
+
+        // SECURITY: Reject absolute paths
+        if path.is_absolute() {
+            // If path is already absolute and under project_root, validate parent only
+            if !path.starts_with(&self.project_root) {
+                anyhow::bail!("Path is outside project root: {}", display_path);
+            }
+            // For absolute paths under project_root, validate the parent directory
+            if let Some(parent) = path.parent() {
+                let canonical_parent = self.canonicalize_uncached(parent).with_context(|| {
+                    format!("Failed to canonicalize parent: {}", parent.display())
+                })?;
+
+                let canonical_root = {
+                    let mut root_cache = self.canonical_project_root.borrow_mut();
+                    if let Some(ref root) = *root_cache {
+                        root.clone()
+                    } else {
+                        let root = self
+                            .canonicalize_uncached(&self.project_root)
+                            .with_context(|| {
+                                format!(
+                                    "Failed to canonicalize project root: {}",
+                                    self.project_root.display()
+                                )
+                            })?;
+                        *root_cache = Some(root.clone());
+                        root
+                    }
+                };
+
+                if !canonical_parent.starts_with(&canonical_root) {
+                    anyhow::bail!(
+                        "Path parent resolves outside project root: {}",
+                        display_path
+                    );
+                }
+            }
+            return Ok(());
+        }
+
+        // SECURITY: Reject paths with ParentDir components before resolution
+        for component in path.components() {
+            if matches!(component, Component::ParentDir) {
+                anyhow::bail!(
+                    "Path contains parent directory (..) component: {}",
+                    display_path
+                );
+            }
+        }
+
+        // Validate that the parent directory (if any) is within project_root
+        // We canonicalize the parent but NOT the final component (which might be a symlink)
+        if let Some(parent) = path.parent() {
+            if parent.as_os_str().is_empty() {
+                // Path has no parent (e.g., just a filename), it's relative to project_root
+                return Ok(());
+            }
+
+            let parent_absolute = if parent.is_absolute() {
+                parent.to_path_buf()
+            } else {
+                self.project_root.join(parent)
+            };
+
+            // Only canonicalize if the parent exists; for cleanup operations the parent might not exist yet
+            if parent_absolute.exists() {
+                let canonical_parent =
+                    self.canonicalize_uncached(&parent_absolute)
+                        .with_context(|| {
+                            format!(
+                                "Failed to canonicalize parent: {}",
+                                parent_absolute.display()
+                            )
+                        })?;
+
+                let canonical_root = {
+                    let mut root_cache = self.canonical_project_root.borrow_mut();
+                    if let Some(ref root) = *root_cache {
+                        root.clone()
+                    } else {
+                        let root = self
+                            .canonicalize_uncached(&self.project_root)
+                            .with_context(|| {
+                                format!(
+                                    "Failed to canonicalize project root: {}",
+                                    self.project_root.display()
+                                )
+                            })?;
+                        *root_cache = Some(root.clone());
+                        root
+                    }
+                };
+
+                if !canonical_parent.starts_with(&canonical_root) {
+                    anyhow::bail!(
+                        "Path parent resolves outside project root: {}",
+                        display_path
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     /// Resolve the expected source path for status checks.
     pub fn expected_source_path(&self, source: &Path, target: &TargetConfig) -> Option<PathBuf> {
         // expected_source_path feeds status/entry_is_problematic; when should_compress_agents_md
@@ -501,6 +613,9 @@ impl Linker {
             }
         };
 
+        // SECURITY: Validate destination path before any filesystem operation
+        self.revalidate_path(dest)?;
+
         if let Ok(existing) = fs::read_to_string(dest)
             && existing.as_str() == compressed.as_ref()
         {
@@ -513,8 +628,6 @@ impl Linker {
         if let Some(parent) = dest.parent() {
             self.ensure_directory(parent, options)?;
         }
-
-        self.revalidate_path(dest)?;
         fs::write(dest, compressed.as_bytes())
             .with_context(|| format!("Failed to write compressed AGENTS.md: {}", dest.display()))?;
         self.invalidate_discovery_caches();
@@ -731,6 +844,8 @@ impl Linker {
             let dest_path = dest_dir.join(entry.file_name());
 
             let resolved = self.resolve_source_path(&source_path, target, options)?;
+            // SECURITY: Validate each child source entry before creating symlink
+            self.revalidate_path(&resolved.path)?;
             let item_result = self.create_symlink(&resolved, &dest_path, options)?;
             result.created += item_result.created;
             result.updated += item_result.updated;
@@ -1194,7 +1309,7 @@ impl Linker {
                                             dest.display()
                                         );
                                     } else {
-                                        self.revalidate_path(&dest)?;
+                                        self.revalidate_unlink_path(&dest)?;
                                         fs::remove_file(&dest)?;
                                         self.invalidate_discovery_caches();
                                         println!("  {} Removed: {}", "✔".green(), dest.display());
@@ -1227,7 +1342,7 @@ impl Linker {
                                             entry.path().display()
                                         );
                                     } else {
-                                        self.revalidate_path(&entry.path())?;
+                                        self.revalidate_unlink_path(&entry.path())?;
                                         fs::remove_file(entry.path())?;
                                         self.invalidate_discovery_caches();
                                         println!(
@@ -1241,7 +1356,7 @@ impl Linker {
                             }
                             // Try to remove the directory if empty
                             if !options.dry_run {
-                                self.revalidate_path(&dest)?;
+                                self.revalidate_unlink_path(&dest)?;
                                 let _ = fs::remove_dir(&dest);
                             }
                         }
@@ -1289,7 +1404,7 @@ impl Linker {
                                 if options.dry_run {
                                     println!("  {} Would remove: {}", "→".cyan(), dest.display());
                                 } else {
-                                    self.revalidate_path(&dest)?;
+                                    self.revalidate_unlink_path(&dest)?;
                                     fs::remove_file(&dest)?;
                                     self.invalidate_discovery_caches();
                                     println!("  {} Removed: {}", "✔".green(), dest.display());

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -116,17 +116,22 @@ impl Linker {
             .with_context(|| format!("Failed to canonicalize path: {}", path.display()))
     }
 
-    /// Validate that an absolute destination path resolves within the project root.
-    fn ensure_safe_destination_path(&self, joined: &Path, display_path: &str) -> Result<PathBuf> {
-        let existing_ancestor = joined
-            .ancestors()
-            .find(|ancestor| ancestor.exists())
-            .with_context(|| {
-                format!(
-                    "Failed to resolve destination path within project root: {}",
-                    joined.display()
-                )
-            })?;
+    /// Validate that a path resolves within the project root and contains no traversal.
+    fn ensure_safe_path(&self, joined: &Path, display_path: &str) -> Result<PathBuf> {
+        // SECURITY: Check for traversal components before canonicalization to prevent bypasses.
+        if joined
+            .components()
+            .any(|c| matches!(c, Component::ParentDir))
+        {
+            anyhow::bail!("Path resolves outside project root: {}", display_path);
+        }
+
+        let existing_ancestor = joined.ancestors().find(|a| a.exists()).with_context(|| {
+            format!(
+                "Failed to resolve path within project root: {}",
+                joined.display()
+            )
+        })?;
 
         let mut root_cache = self.canonical_project_root.borrow_mut();
         let canonical_project_root = if let Some(ref root) = *root_cache {
@@ -148,16 +153,13 @@ impl Linker {
             self.canonicalize_uncached(existing_ancestor)
                 .with_context(|| {
                     format!(
-                        "Failed to canonicalize destination ancestor: {}",
+                        "Failed to canonicalize path ancestor: {}",
                         existing_ancestor.display()
                     )
                 })?;
 
         if !canonical_ancestor.starts_with(&canonical_project_root) {
-            anyhow::bail!(
-                "Destination path resolves outside project root: {}",
-                display_path
-            );
+            anyhow::bail!("Path resolves outside project root: {}", display_path);
         }
 
         Ok(joined.to_path_buf())
@@ -194,12 +196,12 @@ impl Linker {
         }
 
         let joined = self.project_root.join(path);
-        self.ensure_safe_destination_path(&joined, dest_path)
+        self.ensure_safe_path(&joined, dest_path)
     }
 
-    /// Re-validate a previously joined destination immediately before filesystem mutation.
-    fn revalidate_destination_path(&self, dest: &Path) -> Result<()> {
-        self.ensure_safe_destination_path(dest, &dest.display().to_string())
+    /// Re-validate a previously joined path immediately before filesystem mutation.
+    fn revalidate_path(&self, dest: &Path) -> Result<()> {
+        self.ensure_safe_path(dest, &dest.display().to_string())
             .map(|_| ())
     }
 
@@ -368,11 +370,13 @@ impl Linker {
         match target.sync_type {
             SyncType::Symlink => {
                 let dest = self.ensure_safe_destination(&target.destination)?;
+                self.revalidate_path(&source)?; // SECURITY: Validate source
                 let resolved = self.resolve_source_path(&source, target, options)?;
                 self.create_symlink(&resolved, &dest, options)
             }
             SyncType::SymlinkContents => {
                 let dest = self.ensure_safe_destination(&target.destination)?;
+                self.revalidate_path(&source)?; // SECURITY: Validate source
                 self.create_symlinks_for_contents(
                     &source,
                     &dest,
@@ -382,20 +386,14 @@ impl Linker {
                 )
             }
             SyncType::NestedGlob => {
-                // SECURITY: Validate destination template for traversal/absolute paths.
-                // We validate the template itself before expansion.
                 let _ = self.ensure_safe_destination(&target.destination)?;
-
-                // For NestedGlob, `source` is relative to the project root (not source_dir).
                 let search_root = self.project_root.join(&target.source);
-                // SECURITY: Validate search root to prevent traversal/absolute escapes.
-                self.revalidate_destination_path(&search_root)
-                    .with_context(|| {
-                        format!(
-                            "NestedGlob source resolves outside project root: {}",
-                            target.source
-                        )
-                    })?;
+                self.revalidate_path(&search_root).with_context(|| {
+                    format!(
+                        "NestedGlob source resolves outside project root: {}",
+                        target.source
+                    )
+                })?;
 
                 self.process_nested_glob(
                     &search_root,
@@ -462,7 +460,7 @@ impl Linker {
                         println!("  {} Would create directory: {}", "→".cyan(), dir.display());
                     }
                 } else {
-                    self.revalidate_destination_path(dir)?;
+                    self.revalidate_path(dir)?;
                     fs::create_dir_all(dir).with_context(|| {
                         format!("Failed to create directory: {}", dir.display())
                     })?;
@@ -516,7 +514,7 @@ impl Linker {
             self.ensure_directory(parent, options)?;
         }
 
-        self.revalidate_destination_path(dest)?;
+        self.revalidate_path(dest)?;
         fs::write(dest, compressed.as_bytes())
             .with_context(|| format!("Failed to write compressed AGENTS.md: {}", dest.display()))?;
         self.invalidate_discovery_caches();
@@ -575,7 +573,7 @@ impl Linker {
                         relative_source.display()
                     );
                 } else {
-                    self.revalidate_destination_path(dest)?;
+                    self.revalidate_path(dest)?;
                     remove_symlink(dest)?;
                     self.invalidate_discovery_caches();
                     if options.verbose {
@@ -599,8 +597,8 @@ impl Linker {
                 );
             } else {
                 let backup = backup_path_for_destination(dest);
-                self.revalidate_destination_path(dest)?;
-                self.revalidate_destination_path(&backup)?;
+                self.revalidate_path(dest)?;
+                self.revalidate_path(&backup)?;
                 remove_existing_path(&backup)?;
                 fs::rename(dest, &backup)?;
                 self.invalidate_discovery_caches();
@@ -627,7 +625,7 @@ impl Linker {
                 );
             }
         } else {
-            self.revalidate_destination_path(dest)?;
+            self.revalidate_path(dest)?;
             #[cfg(unix)]
             std::os::unix::fs::symlink(&relative_source, dest)
                 .with_context(|| format!("Failed to create symlink: {}", dest.display()))?;
@@ -1055,6 +1053,7 @@ impl Linker {
 
         for mapping in &target.mappings {
             let source_path = self.source_dir.join(&mapping.source);
+            self.revalidate_path(&source_path)?; // SECURITY: Validate source
 
             // Resolve destination filename
             let filename = crate::config::resolve_module_map_filename(mapping, agent_name);
@@ -1160,7 +1159,7 @@ impl Linker {
                         // Re-discover the same files and remove the corresponding symlinks.
                         let search_root = self.project_root.join(&target_config.source);
                         // SECURITY: Validate search root to prevent traversal/absolute escapes.
-                        if self.revalidate_destination_path(&search_root).is_err() {
+                        if self.revalidate_path(&search_root).is_err() {
                             continue;
                         }
                         if !search_root.exists() || !search_root.is_dir() {
@@ -1195,7 +1194,7 @@ impl Linker {
                                             dest.display()
                                         );
                                     } else {
-                                        self.revalidate_destination_path(&dest)?;
+                                        self.revalidate_path(&dest)?;
                                         fs::remove_file(&dest)?;
                                         self.invalidate_discovery_caches();
                                         println!("  {} Removed: {}", "✔".green(), dest.display());
@@ -1228,7 +1227,7 @@ impl Linker {
                                             entry.path().display()
                                         );
                                     } else {
-                                        self.revalidate_destination_path(&entry.path())?;
+                                        self.revalidate_path(&entry.path())?;
                                         fs::remove_file(entry.path())?;
                                         self.invalidate_discovery_caches();
                                         println!(
@@ -1242,7 +1241,7 @@ impl Linker {
                             }
                             // Try to remove the directory if empty
                             if !options.dry_run {
-                                self.revalidate_destination_path(&dest)?;
+                                self.revalidate_path(&dest)?;
                                 let _ = fs::remove_dir(&dest);
                             }
                         }
@@ -1256,7 +1255,7 @@ impl Linker {
                             if options.dry_run {
                                 println!("  {} Would remove: {}", "→".cyan(), dest.display());
                             } else {
-                                self.revalidate_destination_path(&dest)?;
+                                self.revalidate_path(&dest)?;
                                 remove_symlink(&dest)?;
                                 self.invalidate_discovery_caches();
                                 println!("  {} Removed: {}", "✔".green(), dest.display());
@@ -1290,7 +1289,7 @@ impl Linker {
                                 if options.dry_run {
                                     println!("  {} Would remove: {}", "→".cyan(), dest.display());
                                 } else {
-                                    self.revalidate_destination_path(&dest)?;
+                                    self.revalidate_path(&dest)?;
                                     fs::remove_file(&dest)?;
                                     self.invalidate_discovery_caches();
                                     println!("  {} Removed: {}", "✔".green(), dest.display());

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -116,6 +116,25 @@ impl Linker {
             .with_context(|| format!("Failed to canonicalize path: {}", path.display()))
     }
 
+    /// Get or compute the canonical project root path, using cache.
+    fn get_canonical_project_root(&self) -> Result<PathBuf> {
+        let mut root_cache = self.canonical_project_root.borrow_mut();
+        if let Some(ref root) = *root_cache {
+            return Ok(root.clone());
+        }
+
+        let root = self
+            .canonicalize_uncached(&self.project_root)
+            .with_context(|| {
+                format!(
+                    "Failed to canonicalize project root: {}",
+                    self.project_root.display()
+                )
+            })?;
+        *root_cache = Some(root.clone());
+        Ok(root)
+    }
+
     /// Validate that a path resolves within the project root and contains no traversal.
     fn ensure_safe_path(&self, joined: &Path, display_path: &str) -> Result<PathBuf> {
         // SECURITY: Check for traversal components before canonicalization to prevent bypasses.
@@ -133,21 +152,7 @@ impl Linker {
             )
         })?;
 
-        let mut root_cache = self.canonical_project_root.borrow_mut();
-        let canonical_project_root = if let Some(ref root) = *root_cache {
-            root.clone()
-        } else {
-            let root = self
-                .canonicalize_uncached(&self.project_root)
-                .with_context(|| {
-                    format!(
-                        "Failed to canonicalize project root: {}",
-                        self.project_root.display()
-                    )
-                })?;
-            *root_cache = Some(root.clone());
-            root
-        };
+        let canonical_project_root = self.get_canonical_project_root()?;
 
         let canonical_ancestor =
             self.canonicalize_uncached(existing_ancestor)
@@ -224,23 +229,7 @@ impl Linker {
                     format!("Failed to canonicalize parent: {}", parent.display())
                 })?;
 
-                let canonical_root = {
-                    let mut root_cache = self.canonical_project_root.borrow_mut();
-                    if let Some(ref root) = *root_cache {
-                        root.clone()
-                    } else {
-                        let root = self
-                            .canonicalize_uncached(&self.project_root)
-                            .with_context(|| {
-                                format!(
-                                    "Failed to canonicalize project root: {}",
-                                    self.project_root.display()
-                                )
-                            })?;
-                        *root_cache = Some(root.clone());
-                        root
-                    }
-                };
+                let canonical_root = self.get_canonical_project_root()?;
 
                 if !canonical_parent.starts_with(&canonical_root) {
                     anyhow::bail!(
@@ -287,23 +276,7 @@ impl Linker {
                             )
                         })?;
 
-                let canonical_root = {
-                    let mut root_cache = self.canonical_project_root.borrow_mut();
-                    if let Some(ref root) = *root_cache {
-                        root.clone()
-                    } else {
-                        let root = self
-                            .canonicalize_uncached(&self.project_root)
-                            .with_context(|| {
-                                format!(
-                                    "Failed to canonicalize project root: {}",
-                                    self.project_root.display()
-                                )
-                            })?;
-                        *root_cache = Some(root.clone());
-                        root
-                    }
-                };
+                let canonical_root = self.get_canonical_project_root()?;
 
                 if !canonical_parent.starts_with(&canonical_root) {
                     anyhow::bail!(

--- a/tests/test_security.rs
+++ b/tests/test_security.rs
@@ -146,16 +146,16 @@ fn test_path_traversal_bypass_attempt() {
     let agents_dir = project_root.join(".agents");
     fs::create_dir_all(&agents_dir).unwrap();
 
-    // Create a dummy dir inside project root
+    // Create a dummy dir and valid source file inside project root
     let dummy_dir = project_root.join("dummy");
     fs::create_dir_all(&dummy_dir).unwrap();
+    fs::write(project_root.join("AGENTS.md"), "safe source").unwrap();
 
     let config_path = agents_dir.join("agentsync.toml");
 
     // Attempt to bypass check using non-existent directory + ParentDir components
-    // "dummy/../../etc/passwd" -> Joined with project_root it used to pass because
-    // "project/dummy" exists and is inside project_root.
-    let bypass_path = "dummy/../../../../../../../../etc/passwd";
+    // Escape to a writable location outside project root so we can assert no mutation.
+    let bypass_path = "../escaped/linked_outside";
 
     let toml = format!(
         r#"
@@ -182,5 +182,12 @@ fn test_path_traversal_bypass_attempt() {
     assert_eq!(
         result.errors, 1,
         "Sync should have errors for bypass path traversal attempt"
+    );
+
+    // Verify that no file or symlink was created outside project root
+    let escaped_path = temp_dir.path().join("escaped").join("linked_outside");
+    assert!(
+        !escaped_path.exists(),
+        "Sync must not create links/files outside project root"
     );
 }

--- a/tests/test_security.rs
+++ b/tests/test_security.rs
@@ -92,3 +92,95 @@ fn test_nested_glob_search_root_traversal() {
         "Clean should not remove anything for an invalid search root"
     );
 }
+
+#[test]
+fn test_symlink_source_traversal() {
+    let temp_dir = TempDir::new().unwrap();
+    let project_root = temp_dir.path().join("project");
+    let agents_dir = project_root.join(".agents");
+    fs::create_dir_all(&agents_dir).unwrap();
+
+    // Create a sensitive file OUTSIDE the project root
+    let root_parent = temp_dir.path();
+    let sensitive_file = root_parent.join("sensitive.txt");
+    fs::write(&sensitive_file, "SENSITIVE CONTENT").unwrap();
+
+    let config_path = agents_dir.join("agentsync.toml");
+
+    // Malicious source pointing outside project root using relative path
+    let malicious_source = "../../sensitive.txt";
+
+    let toml = format!(
+        r#"
+        source_dir = "."
+        [agents.attacker]
+        enabled = true
+        [agents.attacker.targets.malicious]
+        source = "{}"
+        destination = "linked_sensitive"
+        type = "symlink"
+    "#,
+        malicious_source
+    );
+    fs::write(&config_path, toml).unwrap();
+
+    let config = Config::load(&config_path).unwrap();
+    let linker = Linker::new(config, config_path);
+    let options = SyncOptions {
+        verbose: true,
+        ..Default::default()
+    };
+
+    // The target should now fail due to unsafe source path
+    let result = linker.sync(&options).unwrap();
+    assert_eq!(result.errors, 1);
+
+    let linked_file = project_root.join("linked_sensitive");
+    assert!(!linked_file.exists());
+}
+
+#[test]
+fn test_path_traversal_bypass_attempt() {
+    let temp_dir = TempDir::new().unwrap();
+    let project_root = temp_dir.path().join("project");
+    let agents_dir = project_root.join(".agents");
+    fs::create_dir_all(&agents_dir).unwrap();
+
+    // Create a dummy dir inside project root
+    let dummy_dir = project_root.join("dummy");
+    fs::create_dir_all(&dummy_dir).unwrap();
+
+    let config_path = agents_dir.join("agentsync.toml");
+
+    // Attempt to bypass check using non-existent directory + ParentDir components
+    // "dummy/../../etc/passwd" -> Joined with project_root it used to pass because
+    // "project/dummy" exists and is inside project_root.
+    let bypass_path = "dummy/../../../../../../../../etc/passwd";
+
+    let toml = format!(
+        r#"
+        source_dir = "."
+        [agents.attacker]
+        enabled = true
+        [agents.attacker.targets.bypass]
+        source = "AGENTS.md"
+        destination = "{}"
+        type = "symlink"
+    "#,
+        bypass_path
+    );
+    fs::write(&config_path, toml).unwrap();
+
+    let config = Config::load(&config_path).unwrap();
+    let linker = Linker::new(config, config_path);
+    let options = SyncOptions {
+        verbose: true,
+        ..Default::default()
+    };
+
+    let result = linker.sync(&options).unwrap();
+    assert_eq!(
+        result.errors, 1,
+        "Sync should have errors for bypass path traversal attempt"
+    );
+}

--- a/tests/unit/detect_coverage.rs
+++ b/tests/unit/detect_coverage.rs
@@ -1,0 +1,272 @@
+use agentsync::skills::catalog::EmbeddedSkillCatalog;
+use agentsync::skills::detect::{CatalogDrivenDetector, ContentCache, RepoDetector};
+use std::fs;
+use tempfile::TempDir;
+
+fn catalog_detector() -> CatalogDrivenDetector {
+    let catalog = EmbeddedSkillCatalog::default();
+    CatalogDrivenDetector::new(&catalog).expect("embedded catalog should compile detection rules")
+}
+
+#[test]
+fn test_detect_pyproject_toml_with_poetry_groups() {
+    let temp = TempDir::new().unwrap();
+    let project_root = temp.path();
+
+    // Create a pyproject.toml with poetry groups (line 790 coverage)
+    fs::write(
+        project_root.join("pyproject.toml"),
+        r#"
+[tool.poetry]
+name = "test-project"
+
+[tool.poetry.dependencies]
+python = "^3.9"
+requests = "^2.28.0"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.0.0"
+black = "^22.0.0"
+
+[tool.poetry.dev-dependencies]
+mypy = "^0.950"
+"#,
+    )
+    .unwrap();
+
+    let detector = catalog_detector();
+    let mut cache = ContentCache::new();
+    let detections = detector.detect(project_root, &mut cache).unwrap();
+
+    // Should detect Python from pyproject.toml
+    assert!(
+        !detections.is_empty(),
+        "Should detect at least Python from pyproject.toml"
+    );
+}
+
+#[test]
+fn test_detect_pipfile_deps() {
+    let temp = TempDir::new().unwrap();
+    let project_root = temp.path();
+
+    // Create a Pipfile (line 797-809 coverage)
+    fs::write(
+        project_root.join("Pipfile"),
+        r#"
+[packages]
+django = "*"
+requests = ">=2.28.0"
+
+[dev-packages]
+pytest = "*"
+black = "*"
+"#,
+    )
+    .unwrap();
+
+    let detector = catalog_detector();
+    let mut cache = ContentCache::new();
+    let detections = detector.detect(project_root, &mut cache).unwrap();
+
+    // Should detect Python from Pipfile
+    assert!(!detections.is_empty(), "Should detect Python from Pipfile");
+}
+
+#[test]
+fn test_detect_requirements_txt_with_nested_includes() {
+    let temp = TempDir::new().unwrap();
+    let project_root = temp.path();
+
+    // Create requirements.txt with -r include (line 670, 708, 718-721, 725 coverage)
+    fs::write(
+        project_root.join("requirements.txt"),
+        "requests>=2.28.0\n-r dev-requirements.txt\n",
+    )
+    .unwrap();
+
+    fs::write(
+        project_root.join("dev-requirements.txt"),
+        "pytest>=7.0.0\nblack>=22.0.0\n",
+    )
+    .unwrap();
+
+    let detector = catalog_detector();
+    let mut cache = ContentCache::new();
+    let detections = detector.detect(project_root, &mut cache).unwrap();
+
+    // Should detect Python from requirements.txt
+    assert!(
+        !detections.is_empty(),
+        "Should detect Python from requirements.txt"
+    );
+}
+
+#[test]
+fn test_detect_with_gradle_layout() {
+    let temp = TempDir::new().unwrap();
+    let project_root = temp.path();
+
+    // Create Gradle project structure (line 560 coverage)
+    fs::create_dir_all(project_root.join("app")).unwrap();
+    fs::write(
+        project_root.join("build.gradle.kts"),
+        "plugins { id(\"java\") }",
+    )
+    .unwrap();
+    fs::write(
+        project_root.join("settings.gradle.kts"),
+        "rootProject.name = \"test\"",
+    )
+    .unwrap();
+    fs::write(
+        project_root.join("app/build.gradle.kts"),
+        "plugins { id(\"java\") }",
+    )
+    .unwrap();
+
+    let detector = catalog_detector();
+    let mut cache = ContentCache::new();
+    let detections = detector.detect(project_root, &mut cache).unwrap();
+
+    // Should detect Gradle
+    assert!(
+        !detections.is_empty(),
+        "Should detect Gradle from build files"
+    );
+}
+
+#[test]
+fn test_detect_with_explicit_config_files() {
+    let temp = TempDir::new().unwrap();
+    let project_root = temp.path();
+
+    // Create Rust project (line 566-574 coverage)
+    fs::write(
+        project_root.join("Cargo.toml"),
+        "[package]\nname = \"test\"",
+    )
+    .unwrap();
+
+    let detector = catalog_detector();
+    let mut cache = ContentCache::new();
+    let detections = detector.detect(project_root, &mut cache).unwrap();
+
+    // Should detect Rust
+    let tech_ids: Vec<_> = detections
+        .iter()
+        .map(|d| d.technology.as_ref().to_string())
+        .collect();
+    assert!(
+        tech_ids.contains(&"rust".to_string()),
+        "Should detect Rust from Cargo.toml"
+    );
+}
+
+#[test]
+fn test_detect_ignores_node_modules_and_git() {
+    let temp = TempDir::new().unwrap();
+    let project_root = temp.path();
+
+    // Create directories that should be ignored (line 126 coverage)
+    fs::create_dir_all(project_root.join("node_modules")).unwrap();
+    fs::create_dir_all(project_root.join(".git")).unwrap();
+    fs::create_dir_all(project_root.join("target")).unwrap();
+    fs::create_dir_all(project_root.join("src")).unwrap();
+
+    fs::write(project_root.join("src/main.rs"), "fn main() {}").unwrap();
+    fs::write(project_root.join("node_modules/test.js"), "test").unwrap();
+    fs::write(
+        project_root.join("Cargo.toml"),
+        "[package]\nname = \"test\"",
+    )
+    .unwrap();
+
+    let detector = catalog_detector();
+    let mut cache = ContentCache::new();
+    let detections = detector.detect(project_root, &mut cache).unwrap();
+
+    let tech_ids: Vec<_> = detections
+        .iter()
+        .map(|d| d.technology.as_ref().to_string())
+        .collect();
+    assert!(tech_ids.contains(&"rust".to_string()), "Should detect Rust");
+
+    // The detector should not have scanned node_modules or .git
+    // (we can't directly test this, but the test exercises the ignore logic)
+}
+
+#[test]
+fn test_content_cache_reuses_reads() {
+    let temp = TempDir::new().unwrap();
+    let project_root = temp.path();
+
+    fs::write(
+        project_root.join("package.json"),
+        r#"{"dependencies": {"react": "^18.0.0"}}"#,
+    )
+    .unwrap();
+
+    let detector = catalog_detector();
+    let mut cache = ContentCache::new();
+
+    // First detection
+    let detections1 = detector.detect(project_root, &mut cache).unwrap();
+
+    // Cache should now contain package.json
+    assert!(!cache.is_empty(), "Cache should contain read files");
+
+    // Second detection should reuse cache
+    let detections2 = detector.detect(project_root, &mut cache).unwrap();
+
+    assert_eq!(
+        detections1.len(),
+        detections2.len(),
+        "Should get same results from cache"
+    );
+}
+
+#[test]
+fn test_detect_with_empty_project() {
+    let temp = TempDir::new().unwrap();
+    let project_root = temp.path();
+
+    // Empty project - no files
+    let detector = catalog_detector();
+    let mut cache = ContentCache::new();
+    let detections = detector.detect(project_root, &mut cache).unwrap();
+
+    // Should return empty or minimal detections
+    assert!(
+        detections.is_empty() || detections.len() < 3,
+        "Empty project should have few/no detections"
+    );
+}
+
+#[test]
+fn test_cache_stores_failed_reads() {
+    let temp = TempDir::new().unwrap();
+    let project_root = temp.path();
+
+    // Create a project with a reference to a non-existent file
+    fs::write(
+        project_root.join("Cargo.toml"),
+        "[package]\nname = \"test\"",
+    )
+    .unwrap();
+
+    let detector = catalog_detector();
+    let mut cache = ContentCache::new();
+
+    // First detection - will try to read various files
+    let _detections = detector.detect(project_root, &mut cache).unwrap();
+
+    // Cache should contain entries after detection
+    // The detector reads files during detection, so cache will have entries
+    // even if some reads fail (they're cached as None)
+    // We just verify the detection completes without error
+    let _ = cache.is_empty(); // Use the cache to avoid unused warning
+
+    // The important thing is that the detection completes without error
+    // This exercises the cache logic for both successful and failed reads
+}

--- a/tests/unit/detect_coverage.rs
+++ b/tests/unit/detect_coverage.rs
@@ -236,10 +236,13 @@ fn test_detect_with_empty_project() {
     let mut cache = ContentCache::new();
     let detections = detector.detect(project_root, &mut cache).unwrap();
 
-    // Should return empty or minimal detections
+    // An empty project has no files, so no technology should be detected.
+    // Up to 2 detections are tolerated in case future catalog rules add baseline
+    // markers that fire on an empty tree (known noise); zero is the expected case.
     assert!(
-        detections.is_empty() || detections.len() < 3,
-        "Empty project should have few/no detections"
+        detections.len() < 3,
+        "Empty project should have 0 detections (tolerance ≤2 for baseline catalog noise), got {}",
+        detections.len()
     );
 }
 
@@ -248,25 +251,39 @@ fn test_cache_stores_failed_reads() {
     let temp = TempDir::new().unwrap();
     let project_root = temp.path();
 
-    // Create a project with a reference to a non-existent file
-    fs::write(
-        project_root.join("Cargo.toml"),
-        "[package]\nname = \"test\"",
-    )
-    .unwrap();
+    // Write requirements.txt so detect will call get_file_content on it.
+    // get_file_content caches None for any path it cannot read; here the file
+    // exists, so the cache entry will be Some.  A separate missing path is
+    // never even attempted by detect (collect_package_names guards on
+    // metadata.paths first), so we assert its absence from the cache to
+    // confirm detect does not speculatively read non-existent paths.
+    let requirements_path = project_root.join("requirements.txt");
+    fs::write(&requirements_path, "requests\n").unwrap();
 
     let detector = catalog_detector();
     let mut cache = ContentCache::new();
-
-    // First detection - will try to read various files
     let _detections = detector.detect(project_root, &mut cache).unwrap();
 
-    // Cache should contain entries after detection
-    // The detector reads files during detection, so cache will have entries
-    // even if some reads fail (they're cached as None)
-    // We just verify the detection completes without error
-    let _ = cache.is_empty(); // Use the cache to avoid unused warning
+    // The requirements.txt that was read must be present in the cache.
+    // get_file_content stores entries under the canonicalized path, so resolve
+    // it the same way before asserting.
+    let canonical_requirements = requirements_path
+        .canonicalize()
+        .expect("requirements.txt should be canonicalizable");
+    assert!(
+        cache.contains_key(&canonical_requirements),
+        "ContentCache should contain an entry for requirements.txt after detect"
+    );
+    assert!(
+        cache[&canonical_requirements].is_some(),
+        "Cache entry for requirements.txt should be Some (file was readable)"
+    );
 
-    // The important thing is that the detection completes without error
-    // This exercises the cache logic for both successful and failed reads
+    // A path that was never attempted must be absent (detect does not
+    // speculatively populate None entries for files it never reads).
+    let missing_path = project_root.join("nonexistent_dep_file.txt");
+    assert!(
+        !cache.contains_key(&missing_path),
+        "ContentCache must not contain an entry for a path detect never attempted"
+    );
 }

--- a/tests/unit/linker_security.rs
+++ b/tests/unit/linker_security.rs
@@ -1,0 +1,372 @@
+use agentsync::config::{AgentConfig, Config, SyncType, TargetConfig};
+use agentsync::linker::Linker;
+use std::collections::BTreeMap;
+use std::fs;
+use tempfile::TempDir;
+
+/// Helper to create a target config
+fn make_target(source: &str, destination: &str, sync_type: SyncType) -> TargetConfig {
+    TargetConfig {
+        source: source.to_string(),
+        destination: destination.to_string(),
+        sync_type,
+        pattern: None,
+        exclude: vec![],
+        mappings: vec![],
+    }
+}
+
+/// Helper to create a config with one agent and one target
+fn make_config_with_target(target: TargetConfig) -> Config {
+    let mut targets = BTreeMap::new();
+    targets.insert("target".to_string(), target);
+
+    let agent_config = AgentConfig {
+        enabled: true,
+        description: String::new(),
+        targets,
+    };
+
+    let mut agents = BTreeMap::new();
+    agents.insert("test".to_string(), agent_config);
+
+    Config {
+        source_dir: ".agents".to_string(),
+        compress_agents_md: false,
+        default_agents: vec![],
+        agents,
+        gitignore: Default::default(),
+        mcp: Default::default(),
+        mcp_servers: Default::default(),
+    }
+}
+
+#[test]
+fn test_ensure_safe_destination_rejects_absolute_paths() {
+    let temp = TempDir::new().unwrap();
+    let project_root = temp.path();
+
+    // Create source file first
+    let agents_dir = project_root.join(".agents");
+    fs::create_dir_all(&agents_dir).unwrap();
+    fs::write(agents_dir.join("test.md"), "# Test").unwrap();
+
+    let target = make_target("test.md", "/etc/passwd", SyncType::Symlink);
+    let config = make_config_with_target(target);
+
+    let config_path = project_root.join("agentsync.toml");
+    let linker = Linker::new(config, config_path);
+
+    let result = linker.sync(&agentsync::linker::SyncOptions {
+        clean: false,
+        dry_run: false,
+        verbose: false,
+        agents: Some(vec!["test".to_string()]),
+    });
+
+    // Should fail or report error
+    assert!(
+        result.is_err() || result.unwrap().errors > 0,
+        "Should reject absolute paths"
+    );
+}
+
+#[test]
+fn test_ensure_safe_destination_rejects_parent_dir_traversal() {
+    let temp = TempDir::new().unwrap();
+    let project_root = temp.path();
+
+    // Create source file first
+    let agents_dir = project_root.join(".agents");
+    fs::create_dir_all(&agents_dir).unwrap();
+    fs::write(agents_dir.join("test.md"), "# Test").unwrap();
+
+    let target = make_target("test.md", "../../../etc/passwd", SyncType::Symlink);
+    let config = make_config_with_target(target);
+
+    let config_path = project_root.join("agentsync.toml");
+    let linker = Linker::new(config, config_path);
+
+    let result = linker.sync(&agentsync::linker::SyncOptions {
+        clean: false,
+        dry_run: false,
+        verbose: false,
+        agents: Some(vec!["test".to_string()]),
+    });
+
+    // Should fail or report error due to path traversal
+    assert!(
+        result.is_err() || result.unwrap().errors > 0,
+        "Should reject path traversal"
+    );
+}
+
+#[test]
+fn test_ensure_safe_destination_rejects_empty_path() {
+    let temp = TempDir::new().unwrap();
+    let project_root = temp.path();
+
+    // Create source file first
+    let agents_dir = project_root.join(".agents");
+    fs::create_dir_all(&agents_dir).unwrap();
+    fs::write(agents_dir.join("test.md"), "# Test").unwrap();
+
+    let target = make_target("test.md", "", SyncType::Symlink);
+    let config = make_config_with_target(target);
+
+    let config_path = project_root.join("agentsync.toml");
+    let linker = Linker::new(config, config_path);
+
+    let result = linker.sync(&agentsync::linker::SyncOptions {
+        clean: false,
+        dry_run: false,
+        verbose: false,
+        agents: Some(vec!["test".to_string()]),
+    });
+
+    // Should fail or report error due to empty path
+    assert!(
+        result.is_err() || result.unwrap().errors > 0,
+        "Should reject empty path"
+    );
+}
+
+#[test]
+fn test_ensure_safe_destination_accepts_valid_relative_path() {
+    let temp = TempDir::new().unwrap();
+    let project_root = temp.path();
+
+    // Create source file
+    let agents_dir = project_root.join(".agents");
+    fs::create_dir_all(&agents_dir).unwrap();
+    fs::write(agents_dir.join("test.md"), "# Test").unwrap();
+
+    let target = make_target("test.md", "valid/path/test.md", SyncType::Symlink);
+    let config = make_config_with_target(target);
+
+    let config_path = project_root.join("agentsync.toml");
+    let linker = Linker::new(config, config_path);
+
+    let result = linker.sync(&agentsync::linker::SyncOptions {
+        clean: false,
+        dry_run: false,
+        verbose: false,
+        agents: Some(vec!["test".to_string()]),
+    });
+
+    assert!(result.is_ok(), "Expected success, got: {:?}", result);
+}
+
+#[test]
+fn test_canonicalize_cached_returns_cached_value() {
+    let temp = TempDir::new().unwrap();
+    let project_root = temp.path();
+
+    // Create source file
+    let agents_dir = project_root.join(".agents");
+    fs::create_dir_all(&agents_dir).unwrap();
+    fs::write(agents_dir.join("source.md"), "# Source").unwrap();
+
+    let target = make_target("source.md", "dest.md", SyncType::Symlink);
+    let config = make_config_with_target(target);
+
+    let config_path = project_root.join("agentsync.toml");
+    let linker = Linker::new(config, config_path);
+
+    // Run sync twice to test caching
+    let result1 = linker.sync(&agentsync::linker::SyncOptions {
+        clean: false,
+        dry_run: false,
+        verbose: false,
+        agents: Some(vec!["test".to_string()]),
+    });
+
+    let result2 = linker.sync(&agentsync::linker::SyncOptions {
+        clean: false,
+        dry_run: false,
+        verbose: false,
+        agents: Some(vec!["test".to_string()]),
+    });
+
+    assert!(result1.is_ok());
+    assert!(result2.is_ok());
+}
+
+#[test]
+fn test_canonicalize_cached_handles_nonexistent_path() {
+    let temp = TempDir::new().unwrap();
+    let project_root = temp.path();
+
+    let target = make_target("nonexistent.md", "dest.md", SyncType::Symlink);
+    let config = make_config_with_target(target);
+
+    let config_path = project_root.join("agentsync.toml");
+    let linker = Linker::new(config, config_path);
+
+    let result = linker.sync(&agentsync::linker::SyncOptions {
+        clean: false,
+        dry_run: false,
+        verbose: false,
+        agents: Some(vec!["test".to_string()]),
+    });
+
+    // Should report error because source doesn't exist
+    let sync_result = result.unwrap();
+    assert!(
+        sync_result.errors > 0 || sync_result.skipped > 0,
+        "Should skip or error on nonexistent source"
+    );
+}
+
+#[test]
+fn test_revalidate_unlink_path_works_for_valid_symlink() {
+    let temp = TempDir::new().unwrap();
+    let project_root = temp.path();
+
+    // Create source file
+    let agents_dir = project_root.join(".agents");
+    fs::create_dir_all(&agents_dir).unwrap();
+    fs::write(agents_dir.join("source.md"), "# Source").unwrap();
+
+    let target = make_target("source.md", "link.md", SyncType::Symlink);
+    let config = make_config_with_target(target);
+
+    let config_path = project_root.join("agentsync.toml");
+    let linker = Linker::new(config, config_path);
+
+    // Create the symlink
+    let result = linker.sync(&agentsync::linker::SyncOptions {
+        clean: false,
+        dry_run: false,
+        verbose: false,
+        agents: Some(vec!["test".to_string()]),
+    });
+
+    assert!(result.is_ok());
+
+    // Now clean should work
+    let clean_result = linker.clean(&agentsync::linker::SyncOptions {
+        clean: true,
+        dry_run: false,
+        verbose: false,
+        agents: Some(vec!["test".to_string()]),
+    });
+
+    assert!(clean_result.is_ok());
+}
+
+#[test]
+fn test_revalidate_path_with_parent_dir_component() {
+    let temp = TempDir::new().unwrap();
+    let project_root = temp.path();
+
+    // Create source file first
+    let agents_dir = project_root.join(".agents");
+    fs::create_dir_all(&agents_dir).unwrap();
+    fs::write(agents_dir.join("source.md"), "# Source").unwrap();
+
+    // Try to create a symlink with .. in destination
+    let target = make_target("source.md", "subdir/../escape.md", SyncType::Symlink);
+    let config = make_config_with_target(target);
+
+    let config_path = project_root.join("agentsync.toml");
+    let linker = Linker::new(config, config_path);
+
+    let result = linker.sync(&agentsync::linker::SyncOptions {
+        clean: false,
+        dry_run: false,
+        verbose: false,
+        agents: Some(vec!["test".to_string()]),
+    });
+
+    // Should fail or report error due to parent dir component
+    assert!(
+        result.is_err() || result.unwrap().errors > 0,
+        "Should reject parent dir component"
+    );
+}
+
+#[test]
+fn test_nested_glob_error_handling_with_verbose() {
+    let temp = TempDir::new().unwrap();
+    let project_root = temp.path();
+
+    // Create a nested glob target
+    let mut target = make_target(".", "**/test.md", SyncType::NestedGlob);
+    target.pattern = Some("**/test.md".to_string());
+
+    let config = make_config_with_target(target);
+
+    let config_path = project_root.join("agentsync.toml");
+    let linker = Linker::new(config, config_path);
+
+    // Run with verbose to trigger error path logging (lines 1070-1080)
+    let result = linker.sync(&agentsync::linker::SyncOptions {
+        clean: false,
+        dry_run: false,
+        verbose: true,
+        agents: Some(vec!["test".to_string()]),
+    });
+
+    // Should succeed even if no files match
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_relative_path_with_missing_source() {
+    let temp = TempDir::new().unwrap();
+    let project_root = temp.path();
+
+    // Create agents dir but not the source file
+    let agents_dir = project_root.join(".agents");
+    fs::create_dir_all(&agents_dir).unwrap();
+
+    let target = make_target("missing.md", "dest.md", SyncType::Symlink);
+    let config = make_config_with_target(target);
+
+    let config_path = project_root.join("agentsync.toml");
+    let linker = Linker::new(config, config_path);
+
+    let result = linker.sync(&agentsync::linker::SyncOptions {
+        clean: false,
+        dry_run: false,
+        verbose: false,
+        agents: Some(vec!["test".to_string()]),
+    });
+
+    // Should report error with source not found (lines 1238-1247)
+    let sync_result = result.unwrap();
+    assert!(
+        sync_result.errors > 0 || sync_result.skipped > 0,
+        "Should skip or error on missing source"
+    );
+}
+
+#[test]
+fn test_ensure_safe_path_with_nonexistent_ancestor() {
+    let temp = TempDir::new().unwrap();
+    let project_root = temp.path();
+
+    // Try to create a symlink in a deeply nested non-existent path
+    let target = make_target("test.md", "a/b/c/d/e/f/test.md", SyncType::Symlink);
+
+    // Create source
+    let agents_dir = project_root.join(".agents");
+    fs::create_dir_all(&agents_dir).unwrap();
+    fs::write(agents_dir.join("test.md"), "# Test").unwrap();
+
+    let config = make_config_with_target(target);
+
+    let config_path = project_root.join("agentsync.toml");
+    let linker = Linker::new(config, config_path);
+
+    let result = linker.sync(&agentsync::linker::SyncOptions {
+        clean: false,
+        dry_run: false,
+        verbose: false,
+        agents: Some(vec!["test".to_string()]),
+    });
+
+    // Should succeed and create parent directories
+    assert!(result.is_ok(), "Expected success, got: {:?}", result);
+}

--- a/tests/unit/linker_security.rs
+++ b/tests/unit/linker_security.rs
@@ -158,7 +158,7 @@ fn test_ensure_safe_destination_accepts_valid_relative_path() {
 }
 
 #[test]
-fn test_canonicalize_cached_returns_cached_value() {
+fn test_repeated_sync_succeeds() {
     let temp = TempDir::new().unwrap();
     let project_root = temp.path();
 
@@ -300,7 +300,7 @@ fn test_nested_glob_error_handling_with_verbose() {
     let config_path = project_root.join("agentsync.toml");
     let linker = Linker::new(config, config_path);
 
-    // Run with verbose to trigger error path logging (lines 1070-1080)
+    // Run with verbose to trigger the error-path logging section in the implementation
     let result = linker.sync(&agentsync::linker::SyncOptions {
         clean: false,
         dry_run: false,
@@ -334,7 +334,7 @@ fn test_relative_path_with_missing_source() {
         agents: Some(vec!["test".to_string()]),
     });
 
-    // Should report error with source not found (lines 1238-1247)
+    // Should report error with source not found
     let sync_result = result.unwrap();
     assert!(
         sync_result.errors > 0 || sync_result.skipped > 0,

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -9,3 +9,9 @@ mod suggest_detector;
 
 #[cfg(test)]
 mod suggest_install;
+
+#[cfg(test)]
+mod linker_security;
+
+#[cfg(test)]
+mod detect_coverage;


### PR DESCRIPTION
Harden the path traversal validation logic by explicitly rejecting `..` (ParentDir) components before path resolution. This prevents bypasses where non-existent directory segments could be used to escape the project root.

Additionally, extend this security validation to symlink sources for all sync types (Symlink, SymlinkContents, ModuleMap) to ensure they remain within the project root, preventing unauthorized information disclosure of host files.

Changes:
- Refactor `ensure_safe_destination_path` to `ensure_safe_path`
- Implement `ParentDir` check in `ensure_safe_path`
- Call `revalidate_path` on resolved sources in `process_target` and `process_module_map`
- Add regression tests for source traversal and bypass attempts in `tests/test_security.rs`

Severity: HIGH
Vulnerability: Path traversal via unchecked sources and bypassable destination validation.
Impact: Attackers could create symlinks to arbitrary host files or create files outside the project root.
Fix: Explicit component-based validation and consistent application to all sync paths.
Source: src/linker.rs

---
*PR created automatically by Jules for task [2618369295450097405](https://jules.google.com/task/2618369295450097405) started by @yacosta738*