### PR TITLE
ci: allow cargo cache to fail on Windows runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
 
       - name: Cache cargo registry
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        continue-on-error: true
         with:
           path: |
             ~/.cargo/registry
@@ -84,6 +85,7 @@ jobs:
 
       - name: Cache cargo registry
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        continue-on-error: true
         with:
           path: |
             ~/.cargo/registry
@@ -117,6 +119,7 @@ jobs:
 
       - name: Cache cargo registry
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        continue-on-error: true
         with:
           path: |
             ~/.cargo/registry
@@ -150,6 +153,7 @@ jobs:
 
       - name: Cache cargo registry
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        continue-on-error: true
         with:
           path: |
             ~/.cargo/registry


### PR DESCRIPTION
This change adds `continue-on-error: true` to the cargo cache steps in the CI workflow. This prevents the build from failing on Windows runners due to compatibility issues with the cache action in the new environment, while still providing speed benefits when it works.

Key changes:
- Modified `.github/workflows/ci.yml` to include `continue-on-error: true` for all `Cache cargo registry` steps.
- Ensured that unrelated files (like lockfiles and unrelated JSON formatting) were not affected by the change.

Fixes #427

---
*PR created automatically by Jules for task [9772318573722699889](https://jules.google.com/task/9772318573722699889) started by @yacosta738*