### PR TITLE
docs: fix technology marker inaccuracies and update agent matrix

### DIFF
--- a/website/docs/src/content/docs/guides/skills.mdx
+++ b/website/docs/src/content/docs/guides/skills.mdx
@@ -154,19 +154,19 @@ A representative set of supported technologies and markers includes:
 |---|---|---|
 | `rust` | Rust | `Cargo.toml` |
 | `node_typescript` | Node/TypeScript | `package.json`, `tsconfig.json` |
-| `astro` | Astro | `astro.config.*`, `package.json` (astro) |
+| `astro` | Astro | `astro.config.mjs`, `astro.config.js`, `astro.config.ts`, `package.json` |
 | `react` | React | `package.json` (react, react-dom) |
-| `nextjs` | Next.js | `next.config.*`, `package.json` (next) |
+| `nextjs` | Next.js | `next.config.js`, `next.config.mjs`, `next.config.ts`, `package.json` |
 | `vue` | Vue | `package.json` (vue) |
 | `svelte` | Svelte | `svelte.config.js`, `package.json` (svelte) |
-| `python` | Python | `pyproject.toml`, `uv.lock`, `poetry.lock`, `requirements*.txt` |
-| `github_actions` | GitHub Actions | `.github/workflows/*.yml`, `.github/workflows/*.yaml` |
-| `docker` | Docker | `Dockerfile*`, `compose.yml`, `docker-compose*.yml` |
+| `python` | Python | `pyproject.toml`, `uv.lock`, `poetry.lock`, `requirements.txt`, `Pipfile`, `setup.py` |
+| `github_actions` | GitHub Actions | `.github/workflows/` directory |
+| `docker` | Docker | `Dockerfile`, `compose.yml`, `compose.yaml`, `docker-compose.yml` |
 | `postgresql` | PostgreSQL | `package.json` (pg, postgres, @vercel/postgres) |
-| `eslint` | ESLint | `eslint.config.*`, `.eslintrc.*` |
-| `prettier` | Prettier | `.prettierrc.*`, `prettier.config.*` |
-| `vitest` | Vitest | `vitest.config.*`, `package.json` (vitest) |
-| `playwright` | Playwright | `playwright.config.*`, `package.json` (playwright) |
+| `eslint` | ESLint | `eslint.config.js`, `.eslintrc.json`, `.eslintrc.js`, `.eslintrc.yml` |
+| `prettier` | Prettier | `.prettierrc`, `.prettierrc.json`, `.prettierrc.js`, `prettier.config.js` |
+| `vitest` | Vitest | `vitest.config.ts`, `vitest.config.js`, `vitest.config.mts` |
+| `playwright` | Playwright | `playwright.config.ts`, `playwright.config.js`, `playwright.config.mjs` |
 | `make` | Make | `Makefile`, `GNUmakefile` |
 
 Notes:

--- a/website/docs/src/content/docs/reference/configuration.mdx
+++ b/website/docs/src/content/docs/reference/configuration.mdx
@@ -200,6 +200,7 @@ The matrix below documents common agent locations and whether AgentSync can hand
 | GitHub Copilot | `.github/copilot-instructions.md` | `.vscode/mcp.json` (native MCP) | Configurable |
 | Claude Code | `CLAUDE.md` | `.mcp.json` (native MCP) | Configurable; `.claude/skills/` |
 | OpenAI Codex CLI | `AGENTS.md` | `.codex/config.toml` (native MCP) | Configurable; `.codex/skills/` |
+| VS Code | - | `.vscode/mcp.json` (native MCP) | Configurable |
 | Pi Coding Agent | - | No native MCP formatter | Configurable |
 | Jules | - | No native MCP formatter | Configurable |
 | Cursor | `.cursor/rules/agentsync.mdc` | `.cursor/mcp.json` (native MCP) | Configurable; `.cursor/skills/` |


### PR DESCRIPTION
This PR fixes several documentation inaccuracies identified during a source code audit:

1. **Hallucinated Wildcards**: The Skills guide documented technology markers using wildcards (e.g., `requirements*.txt`), but the implementation in `src/skills/detect.rs` performs literal path existence checks against the catalog. I've replaced these with the actual literal filenames.
2. **Missing Markers**: Added representative markers for several technologies (e.g., `Pipfile`, `setup.py`, `compose.yaml`, `.eslintrc.json`) that were present in `src/skills/catalog.v1.toml` but missing from the docs.
3. **Agent Matrix Gap**: Added VS Code to the Agent Compatibility Matrix. VS Code is a native MCP agent using `.vscode/mcp.json`, but was missing from the summary table.

Verified by reading `src/skills/catalog.v1.toml`, `src/mcp.rs`, and running a successful `pnpm run build` in `website/docs`.

---
*PR created automatically by Jules for task [14230874607552907928](https://jules.google.com/task/14230874607552907928) started by @yacosta738*