### PR TITLE
fix(security): harden skill ID validation and installation paths

### DIFF
--- a/src/commands/skill.rs
+++ b/src/commands/skill.rs
@@ -1359,44 +1359,29 @@ fn validate_skill_id(skill_id: &str) -> Result<()> {
         return Err(anyhow::anyhow!("skill id must not be empty"));
     }
 
-    // Quick reject any obvious separators
-    if skill_id.contains('/') || skill_id.contains('\\') {
+    // SECURITY: Use a strict whitelist for skill IDs to prevent path traversal
+    // or other filesystem-related attacks. Only alphanumeric, hyphens, and underscores are allowed.
+    // This is more restrictive than standard filesystem rules but safe for our use case.
+    if !skill_id
+        .chars()
+        .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+    {
         return Err(anyhow::anyhow!(
-            "invalid skill id: must be a single path segment without '/' or '\\'"
+            "invalid skill id: only alphanumeric characters, hyphens, and underscores are allowed: {}",
+            skill_id
         ));
     }
 
+    // Double check with component analysis for defense-in-depth
     let p = Path::new(skill_id);
-
-    // Reject absolute paths or paths that start with a prefix/root (drive letter on Windows)
-    if p.is_absolute() {
-        return Err(anyhow::anyhow!(
-            "invalid skill id: must not be an absolute path"
-        ));
+    let mut components = p.components();
+    match (components.next(), components.next()) {
+        (Some(Component::Normal(_)), None) => Ok(()),
+        _ => Err(anyhow::anyhow!(
+            "invalid skill id: must be a single safe path segment: {}",
+            skill_id
+        )),
     }
-
-    // Ensure components() yields exactly one Component::Normal
-    let mut count_normal = 0usize;
-    for comp in p.components() {
-        match comp {
-            Component::Normal(_) => count_normal += 1,
-            // Any other component is invalid (RootDir, Prefix, CurDir, ParentDir)
-            other => {
-                return Err(anyhow::anyhow!(
-                    "invalid skill id: contains invalid path component: {:?}",
-                    other
-                ));
-            }
-        }
-    }
-
-    if count_normal != 1 {
-        return Err(anyhow::anyhow!(
-            "invalid skill id: must be a single path segment"
-        ));
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]
@@ -1972,6 +1957,19 @@ mod tests {
     fn validate_skill_id_rejects_dot() {
         let result = validate_skill_id(".");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn validate_skill_id_rejects_triple_dot() {
+        let result = validate_skill_id("...");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn validate_skill_id_rejects_special_chars() {
+        assert!(validate_skill_id("skill@123").is_err());
+        assert!(validate_skill_id("skill!").is_err());
+        assert!(validate_skill_id("skill ").is_err());
     }
 
     // Tests for remediation_for_error

--- a/src/skills/install.rs
+++ b/src/skills/install.rs
@@ -77,6 +77,19 @@ pub fn install_from_dir(
     src_dir: &std::path::Path,
     target_root: &std::path::Path,
 ) -> Result<(), SkillInstallError> {
+    // SECURITY: Validate skill_id is a single safe component to prevent path traversal
+    // if it were to escape the target_root via malicious input like "../escape".
+    let mut components = Path::new(skill_id).components();
+    match (components.next(), components.next()) {
+        (Some(std::path::Component::Normal(_)), None) => {}
+        _ => {
+            return Err(SkillInstallError::Validation(format!(
+                "invalid skill id: {}",
+                skill_id
+            )));
+        }
+    }
+
     let skill_dir = target_root.join(skill_id);
 
     // Create a temporary directory for rollback if anything fails

--- a/tests/test_security.rs
+++ b/tests/test_security.rs
@@ -191,3 +191,29 @@ fn test_path_traversal_bypass_attempt() {
         "Sync must not create links/files outside project root"
     );
 }
+
+#[test]
+fn test_skill_install_id_traversal() {
+    let temp_dir = TempDir::new().unwrap();
+    let project_root = temp_dir.path().join("project");
+    let agents_dir = project_root.join(".agents");
+    let skills_dir = agents_dir.join("skills");
+    fs::create_dir_all(&skills_dir).unwrap();
+
+    let source_dir = temp_dir.path().join("source_skill");
+    fs::create_dir_all(&source_dir).unwrap();
+    fs::write(source_dir.join("SKILL.md"), "---\nname: test-skill\n---").unwrap();
+
+    // Malicious skill ID attempting traversal
+    let malicious_id = "../outside_skill";
+
+    let result =
+        agentsync::skills::install::install_from_dir(malicious_id, &source_dir, &skills_dir);
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.to_string().contains("invalid skill id"));
+
+    let outside_path = agents_dir.join("outside_skill");
+    assert!(!outside_path.exists());
+}


### PR DESCRIPTION
### User's Goal
Harden AgentSync against path traversal vulnerabilities by strictly validating skill IDs during installation and updates.

### Severity
**CRITICAL**

### Vulnerability
Path traversal during skill installation. Malicious configurations could provide skill IDs like `../escape`, allowing the tool to create directories or files outside the intended `.agents/skills/` directory.

### Impact
An attacker with control over `agentsync.toml` or providing malicious skill IDs to the CLI could potentially overwrite sensitive files or create unauthorized directories on the user's filesystem.

### Fix
Implemented a two-layered defense:
1.  **Strict Whitelisting:** At the CLI entry point (`src/commands/skill.rs`), skill IDs are now restricted to a safe set of characters (alphanumeric, hyphens, and underscores).
2.  **Defense-in-Depth Validation:** At the core installation layer (`src/skills/install.rs`), the `install_from_dir` function now validates that the provided `skill_id` resolves to exactly one "Normal" path component, preventing any traversal attempts even if the CLI whitelist were bypassed.

### Source
- `src/commands/skill.rs`: `validate_skill_id`
- `src/skills/install.rs`: `install_from_dir`

### Verification
- New unit tests in `src/commands/skill.rs` verify the hardened `validate_skill_id` logic.
- A new regression test `test_skill_install_id_traversal` in `tests/test_security.rs` confirms that traversal attempts in skill IDs are correctly rejected during installation.
- All existing tests pass.
- Verified code quality with `cargo clippy` and `cargo fmt`.

---
*PR created automatically by Jules for task [10869251960065621527](https://jules.google.com/task/10869251960065621527) started by @yacosta738*