### PR TITLE
docs: clarify gitignore management and backup handling

### DIFF
--- a/.agents/journal/scribe-journal.md
+++ b/.agents/journal/scribe-journal.md
@@ -32,3 +32,8 @@
 
 **Learning:** Both the CLI reference and the Skills guide claimed that active evaluation of multi-technology "combo" entries was deferred. However, Phase 2 of `recommend_skills` in `src/skills/suggest.rs` already implements this logic, providing specific recommendations for combinations like `react-hook-form` + `zod`.
 **Action:** Before claiming a feature is "deferred" or "planned," verify the relevant logic phases in the implementation (e.g., Phase 2 evaluation loops).
+
+## 2026-05-21 - Gitignore Management Drift
+
+**Learning:** The configuration reference claimed that "all symlink destination paths" are added to .gitignore. In reality, the logic in `src/config.rs` is more nuanced: it includes `.bak` versions for all literal destinations, expands `module-map` entries into individual patterns, always adds a defensive `.agents/skills/*.bak` pattern, and explicitly *skips* `nested-glob` destinations because they are templates.
+**Action:** Document the specific behavior for different sync types and the automatic inclusion of backup patterns to avoid user confusion about why certain files are or aren't ignored.

--- a/website/docs/src/content/docs/reference/configuration.mdx
+++ b/website/docs/src/content/docs/reference/configuration.mdx
@@ -126,9 +126,13 @@ AgentSync automatically adds the following patterns to `.gitignore` based on whi
 | **jetbrains** | `.aiassistant/rules/` |
 
 **Notes:**
-- The `entries` field in your config is only needed for additional files not covered by the patterns above
-- All symlink destination paths are also automatically added to `.gitignore`
-- Duplicate entries are automatically deduplicated
+- The `entries` field in your config is only needed for additional files not covered by the patterns above.
+- All literal symlink destination paths (e.g., from `type = "symlink"` or `type = "symlink-contents"`) are automatically added to `.gitignore`.
+- For every managed destination, AgentSync also adds a corresponding `.bak` pattern (e.g., `/CLAUDE.md.bak`) to ignore temporary backup files created during sync.
+- `module-map` targets expand each individual mapping into its own `.gitignore` entries (including `.bak` versions).
+- `nested-glob` destinations are **not** automatically added to `.gitignore` because they are template strings, not literal paths.
+- AgentSync always adds `.agents/skills/*.bak` as a defensive pattern to ignore skill backup files.
+- Duplicate entries are automatically deduplicated.
 
 ## Agent Definitions
 


### PR DESCRIPTION
Updated `website/docs/src/content/docs/reference/configuration.mdx` to accurately reflect the `.gitignore` management logic implemented in `src/config.rs:351-395`.

Changes:
- Documented that `.bak` versions of literal destinations are automatically ignored.
- Clarified that `module-map` targets are expanded into individual entries.
- Explicitly stated that `nested-glob` destinations are skipped (due to being templates).
- Added documentation for the defensive `.agents/skills/*.bak` pattern.
- Updated the Scribe journal.

---
*PR created automatically by Jules for task [14330922111662938599](https://jules.google.com/task/14330922111662938599) started by @yacosta738*