### PR TITLE
fix(security): prevent sensitive file disclosure during skill updates

### DIFF
--- a/src/skills/update.rs
+++ b/src/skills/update.rs
@@ -186,6 +186,39 @@ pub async fn update_skill_async(
     Ok(())
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[tokio::test]
+    async fn test_update_skill_skips_symlinks() {
+        let temp = tempfile::tempdir().unwrap();
+        let target_root = temp.path().join("skills");
+        fs::create_dir_all(&target_root).unwrap();
+        let skill_path = target_root.join("test-skill");
+        fs::create_dir_all(&skill_path).unwrap();
+        fs::write(
+            skill_path.join("SKILL.md"),
+            "---\nname: test-skill\nversion: 1.0.0\n---",
+        )
+        .unwrap();
+        let update_source = temp.path().join("update");
+        fs::create_dir_all(&update_source).unwrap();
+        fs::write(
+            update_source.join("SKILL.md"),
+            "---\nname: test-skill\nversion: 1.1.0\n---",
+        )
+        .unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(temp.path().join("root"), update_source.join("leaked")).unwrap();
+        update_skill_async("test-skill", &target_root, &update_source)
+            .await
+            .unwrap();
+        assert!(!skill_path.join("leaked").exists());
+    }
+}
+
 /// Recursively copies a directory (src) to dst.
 fn copy_dir_all(src: &Path, dst: &Path) -> std::io::Result<()> {
     use std::fs;
@@ -195,6 +228,13 @@ fn copy_dir_all(src: &Path, dst: &Path) -> std::io::Result<()> {
     for entry in fs::read_dir(src)? {
         let entry = entry?;
         let ty = entry.file_type()?;
+
+        // SECURITY: Skip symbolic links to prevent following them and disclosing
+        // sensitive information from outside the update source.
+        if ty.is_symlink() {
+            continue;
+        }
+
         let src_path = entry.path();
         let dst_path = dst.join(entry.file_name());
         if ty.is_dir() {


### PR DESCRIPTION
**Severity:** HIGH
**Vulnerability:** Information Disclosure via Symlink Following. The `copy_dir_all` function in `src/skills/update.rs` followed symbolic links during recursive directory copies, allowing a malicious skill update source to copy sensitive files from outside the project into the skill directory.
**Impact:** Attackers providing a malicious skill update source (e.g., via a compromised local directory or a maliciously crafted archive if processed through this path) could read arbitrary files accessible to the user running `agentsync`.
**Fix:** Hardened `copy_dir_all` in `src/skills/update.rs` to explicitly skip symbolic links.
**Source:** `src/skills/update.rs`, `copy_dir_all` function.
**Verification:** Added a regression test `test_update_skill_skips_symlinks` that confirms symbolic links are ignored during updates.

---
*PR created automatically by Jules for task [8029699396642992343](https://jules.google.com/task/8029699396642992343) started by @yacosta738*