### PR TITLE
⚡ Bolt: optimize technology detection path checks and allocations

### DIFF
--- a/.agents/journal/bolt.md
+++ b/.agents/journal/bolt.md
@@ -168,3 +168,9 @@ from the path string (`split('/')`), we eliminated this per-file allocation enti
 
 **Action:** Prefer iterator-based pattern matching over `Vec` collection when processing large numbers
 of items in a loop. Use `Clone` bounds on iterators to support backtracking without re-allocation.
+
+## 2025-05-27 - Depth-Aware Existence Checks and Rule Pre-Compilation
+
+**Learning:** Technology detection involves evaluating 111+ technologies, many of which specify multiple config markers. Even with a single-pass WalkDir, the system was performing redundant `fs::exists` syscalls for markers that were already indexed in `metadata.paths` (depth <= 4). Furthermore, `ConfigFileContentRules` was storing file markers as `String`, forcing a `PathBuf` allocation for every rule evaluation.
+
+**Action:** Leverage the `MAX_DISCOVER_DEPTH` constant to skip `fs::exists` syscalls for any path within the discovery depth that isn't in the `paths` cache. Pre-compile all file markers into `PathBuf` during rule initialization to move allocation costs from the hot evaluation loop to the cold initialization phase.

--- a/src/skills/detect.rs
+++ b/src/skills/detect.rs
@@ -229,7 +229,7 @@ struct CompiledDetectionRules {
 }
 
 struct CompiledConfigFileContentRules {
-    files: Option<Vec<String>>,
+    files: Option<Vec<PathBuf>>,
     patterns: Vec<Regex>,
     scan_gradle_layout: bool,
 }
@@ -303,8 +303,13 @@ impl CatalogDrivenDetector {
                     })
                     .collect::<Result<Vec<_>>>()?;
 
+                let files = content_rules
+                    .files
+                    .as_ref()
+                    .map(|files| files.iter().map(PathBuf::from).collect());
+
                 Ok::<_, anyhow::Error>(CompiledConfigFileContentRules {
-                    files: content_rules.files.clone(),
+                    files,
                     patterns,
                     scan_gradle_layout: content_rules.scan_gradle_layout.unwrap_or(false),
                 })
@@ -459,7 +464,10 @@ fn evaluate_rules(
     if let Some(config_files) = &rules.config_files {
         for path in config_files {
             // Check cache first (hot path for shallow markers), fallback to fs for deeply nested ones
-            if metadata.paths.contains(path) || project_root.join(path).exists() {
+            if metadata.paths.contains(path)
+                || (path.components().count() > MAX_DISCOVER_DEPTH
+                    && project_root.join(path).exists())
+            {
                 let display = path.display().to_string();
                 return Some(make_detection(
                     tech_id,
@@ -545,9 +553,9 @@ fn gather_content_scan_files(
             "settings.gradle",
             "gradle/libs.versions.toml",
         ] {
-            let path = PathBuf::from(name);
-            if metadata.paths.contains(&path) {
-                files.push(path);
+            let path = Path::new(name);
+            if metadata.paths.contains(path) {
+                files.push(path.to_path_buf());
             }
         }
 
@@ -564,12 +572,13 @@ fn gather_content_scan_files(
     }
 
     if let Some(explicit_files) = &rules.files {
-        for file in explicit_files {
-            let path = PathBuf::from(file);
-            if (metadata.paths.contains(&path) || project_root.join(&path).exists())
-                && !files.contains(&path)
+        for path in explicit_files {
+            if (metadata.paths.contains(path)
+                || (path.components().count() > MAX_DISCOVER_DEPTH
+                    && project_root.join(path).exists()))
+                && !files.contains(path)
             {
-                files.push(path);
+                files.push(path.clone());
             }
         }
     }
@@ -937,7 +946,9 @@ fn expand_workspace_patterns(
             for dir_rel in &metadata.dirs {
                 let manifest = dir_rel.join("package.json");
                 if dir_rel.parent() == Some(base_rel)
-                    && (metadata.paths.contains(&manifest) || project_root.join(&manifest).exists())
+                    && (metadata.paths.contains(&manifest)
+                        || (manifest.components().count() > MAX_DISCOVER_DEPTH
+                            && project_root.join(&manifest).exists()))
                 {
                     dirs.push(project_root.join(dir_rel));
                 }
@@ -945,7 +956,10 @@ fn expand_workspace_patterns(
         } else {
             // Exact path: check cache first, then fall back to filesystem existence.
             let manifest = base_rel.join("package.json");
-            if metadata.paths.contains(&manifest) || project_root.join(&manifest).exists() {
+            if metadata.paths.contains(&manifest)
+                || (manifest.components().count() > MAX_DISCOVER_DEPTH
+                    && project_root.join(&manifest).exists())
+            {
                 dirs.push(project_root.join(base_rel));
             }
         }


### PR DESCRIPTION
⚡ Bolt: optimize technology detection path checks and allocations

💡 What:
- Refactored `CompiledConfigFileContentRules` to store pre-compiled `PathBuf`s instead of `String`s.
- Implemented depth-aware existence checks leveraging `MAX_DISCOVER_DEPTH`.
- Minimized allocations in `gather_content_scan_files` using `Path::new`.

🎯 Why:
The technology detection system evaluates over 111 technologies. Many rules specify shallow configuration markers (like `package.json` or `Cargo.toml`). Previously, the system was performing redundant `fs::exists` syscalls for these markers even though they were already present in the `metadata.paths` cache (which covers all files up to depth 4). Additionally, storing markers as `String` forced a new `PathBuf` allocation for every rule evaluation.

📊 Impact:
- Eliminates hundreds of redundant `fs::exists` syscalls per detection run.
- Reduces heap pressure by moving `PathBuf` allocations from the hot loop (evaluation) to the cold path (rule compilation).

🔬 Measurement:
- Verified via full test suite (`cargo test --all-features`).
- Correctness confirmed by manual inspection of `metadata.paths` population logic.

---
*PR created automatically by Jules for task [1553060984072360262](https://jules.google.com/task/1553060984072360262) started by @yacosta738*