### PR TITLE
fix(security): prevent symlink following in skill updates

### DIFF
--- a/src/skills/update.rs
+++ b/src/skills/update.rs
@@ -195,6 +195,13 @@ fn copy_dir_all(src: &Path, dst: &Path) -> std::io::Result<()> {
     for entry in fs::read_dir(src)? {
         let entry = entry?;
         let ty = entry.file_type()?;
+
+        // SECURITY: Skip symbolic links to prevent information disclosure if the source
+        // contains a link pointing to a sensitive file outside the update source.
+        if ty.is_symlink() {
+            continue;
+        }
+
         let src_path = entry.path();
         let dst_path = dst.join(entry.file_name());
         if ty.is_dir() {

--- a/tests/test_update_security.rs
+++ b/tests/test_update_security.rs
@@ -1,0 +1,59 @@
+use agentsync::skills::update::update_skill_async;
+use std::fs;
+use tempfile::TempDir;
+
+#[cfg(unix)]
+#[tokio::test]
+async fn test_update_skill_skips_symlinks() {
+    use std::os::unix::fs::symlink;
+
+    let temp_dir = TempDir::new().unwrap();
+    let project_root = temp_dir.path().join("project");
+    let target_root = project_root.join(".agents").join("skills");
+    fs::create_dir_all(&target_root).unwrap();
+
+    // 1. Create a sensitive file OUTSIDE the update source
+    let sensitive_file = temp_dir.path().join("sensitive.txt");
+    fs::write(&sensitive_file, "SECRET CONTENT").unwrap();
+
+    // 2. Create an update source directory
+    let update_source = temp_dir.path().join("update_source");
+    fs::create_dir_all(&update_source).unwrap();
+
+    // Create a valid SKILL.md in update source with frontmatter
+    let manifest_content =
+        "---\nname: test-skill\nversion: 1.0.0\ndescription: test\n---\n# Test Skill";
+    fs::write(update_source.join("SKILL.md"), manifest_content).unwrap();
+
+    // 3. Create a malicious symlink inside update source pointing to sensitive file
+    let malicious_link = update_source.join("malicious_link");
+    symlink(&sensitive_file, &malicious_link).unwrap();
+
+    // 4. Run update_skill_async
+    // We need an "installed" version to trigger update, or just update into empty
+    // update_skill_async checks if new version > installed.
+    // If not installed, it treats as 0.0.0.
+
+    update_skill_async("test-skill", &target_root, &update_source)
+        .await
+        .unwrap();
+
+    // 5. Verify results
+    let installed_skill_dir = target_root.join("test-skill");
+    assert!(installed_skill_dir.exists());
+    assert!(installed_skill_dir.join("SKILL.md").exists());
+
+    // SECURITY: The malicious_link should NOT have been copied
+    let copied_link = installed_skill_dir.join("malicious_link");
+    assert!(
+        !copied_link.exists(),
+        "Malicious symlink should NOT have been copied"
+    );
+
+    // Verify it didn't copy the content either (in case it followed it)
+    // If it followed it, it might have created a regular file with the same name.
+    assert!(
+        !copied_link.is_file(),
+        "Malicious symlink content should NOT have been copied as a file"
+    );
+}


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request implements a security enhancement to prevent potential information disclosure during skill updates.

The `copy_dir_all` function, responsible for copying skill files, has been modified to explicitly skip symbolic links. This prevents the application from following symlinks that might be present in a skill's update source, which could otherwise lead to unintended copying of files from outside the skill's intended directory structure if a malicious symlink pointed to sensitive data.

A new test case has been added to validate this security measure. The test confirms that when a symbolic link pointing to a sensitive file (outside the update source) is present in the update package, the link and its target content are not copied into the installed skill directory.
<!-- kody-pr-summary:end -->