### PR TITLE
docs: correct technology detection confidence explanation

### DIFF
--- a/.agents/journal/scribe-journal.md
+++ b/.agents/journal/scribe-journal.md
@@ -32,3 +32,8 @@
 
 **Learning:** Both the CLI reference and the Skills guide claimed that active evaluation of multi-technology "combo" entries was deferred. However, Phase 2 of `recommend_skills` in `src/skills/suggest.rs` already implements this logic, providing specific recommendations for combinations like `react-hook-form` + `zod`.
 **Action:** Before claiming a feature is "deferred" or "planned," verify the relevant logic phases in the implementation (e.g., Phase 2 evaluation loops).
+
+## 2026-06-12 - Technology Detection Confidence Inaccuracy
+
+**Learning:** The Skills guide documented technology detection confidence as location-based (root vs. nested vs. test paths). However, the implementation in `src/skills/detect.rs` uses rule-based confidence (High for exact packages/configs, Medium for patterns/extensions/content) regardless of file location. "Low" confidence is unused by the detector.
+**Action:** Verify confidence assignment logic in `src/skills/detect.rs:evaluate_rules` when documentation claims it depends on file path depth or location.

--- a/website/docs/src/content/docs/guides/skills.mdx
+++ b/website/docs/src/content/docs/guides/skills.mdx
@@ -172,9 +172,10 @@ A representative set of supported technologies and markers includes:
 Notes:
 
 - Detection uses repository contents only; recommendation metadata does **not** decide what technologies are detected.
-- Root-level canonical markers yield `high` confidence.
-- Nested markers generally yield `medium` confidence.
-- Markers under test/example-style paths yield `low` confidence.
+- Technology detection confidence is rule-based:
+  - **`High` confidence** is assigned to exact package matches (`packages`) and configuration file existence (`config_files`).
+  - **`Medium` confidence** is assigned to package regex patterns (`package_patterns`), file content matches (`config_file_content`), and file extensions (`file_extensions`).
+  - File location (root vs nested) does not influence the assigned confidence level.
 - AgentSync ignores common generated/vendor directories like `.git`, `.agents`, `node_modules`, `target`, `dist`, `build`, `.astro`, `.next`, `.turbo`, and `.pnpm-store` while scanning.
 
 Recommendation metadata now comes from a hybrid catalog model:


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Corrects the documentation for technology detection confidence in the Skills guide.

Previously, the guide inaccurately stated that confidence levels (high, medium, low) were determined by the file's location within the repository (root, nested, or test paths). This update clarifies that technology detection confidence is rule-based:
- **High confidence** is assigned for exact package matches and the presence of specific configuration files.
- **Medium confidence** is assigned for package regex patterns, matches within configuration file content, and specific file extensions.
- The documentation now explicitly states that file location (root vs. nested) does not influence the assigned confidence level.

This change ensures the Skills guide provides accurate information about how AgentSync determines the confidence of detected technologies.
<!-- kody-pr-summary:end -->