### PR TITLE
fix(security): prevent symlink following during skill updates

### DIFF
--- a/.agents/journal/sentinel.md
+++ b/.agents/journal/sentinel.md
@@ -31,3 +31,8 @@ tool that are known to contain user-provided credentials or sensitive environmen
 **Vulnerability:** String-based path checks (like `starts_with('/')`) or platform-specific `Path::is_absolute()` calls failed to detect Windows-style absolute paths (e.g., `C:/...`) when running on Unix systems, leading to potential path traversal vulnerabilities in skill archives.
 **Learning:** Rust's `std::path::Path` behavior depends on the host operating system. On Unix, a path starting with a drive letter is considered relative, which allows it to pass simple `is_absolute()` checks and be joined to a base directory, potentially escaping it if not carefully validated.
 **Prevention:** Use `Path::components()` to explicitly reject `RootDir`, `Prefix`, and `ParentDir` components. For cross-platform safety on Unix, also manually check for Windows drive letter patterns (e.g., `filename.as_bytes()[1] == b':'`) in untrusted archive entry paths.
+
+## 2026-06-24 - Information Disclosure via Symlink Following in Skill Update
+**Vulnerability:** The `copy_dir_all` function used during skill updates in `src/skills/update.rs` followed symbolic links. A malicious update source could include a symlink to a sensitive file (e.g., `~/.ssh/id_rsa`), causing its content to be copied into the project.
+**Learning:** Security fixes must be applied to all instances of a pattern. While `src/skills/install.rs` had already been hardened against this vulnerability, the update logic used a separate (vulnerable) implementation of recursive directory copying.
+**Prevention:** Consolidate critical filesystem operations into shared, hardened helpers to ensure security fixes apply everywhere. Always explicitly check `file_type.is_symlink()` when copying untrusted directory structures.

--- a/src/skills/update.rs
+++ b/src/skills/update.rs
@@ -195,6 +195,14 @@ fn copy_dir_all(src: &Path, dst: &Path) -> std::io::Result<()> {
     for entry in fs::read_dir(src)? {
         let entry = entry?;
         let ty = entry.file_type()?;
+
+        // SECURITY: Skip symbolic links to prevent following them to sensitive host files
+        // outside the update source. This ensures that a malicious skill update cannot
+        // leak contents by including symlinks to files like ~/.ssh/id_rsa.
+        if ty.is_symlink() {
+            continue;
+        }
+
         let src_path = entry.path();
         let dst_path = dst.join(entry.file_name());
         if ty.is_dir() {

--- a/tests/test_update_security.rs
+++ b/tests/test_update_security.rs
@@ -1,0 +1,73 @@
+use agentsync::skills::update::update_skill_async;
+use std::fs;
+use tempfile::TempDir;
+
+#[tokio::test]
+#[cfg(unix)]
+async fn test_update_skill_skips_symlinks() {
+    let temp = TempDir::new().unwrap();
+    let root = temp.path();
+
+    // 1. Setup project structure
+    let project_root = root.join("project");
+    let target_root = project_root.join(".agents").join("skills");
+    fs::create_dir_all(&target_root).unwrap();
+
+    // 2. Create a "sensitive" file outside the project root
+    let secret_file = root.join("secret.txt");
+    fs::write(&secret_file, "TOP SECRET CONTENT").unwrap();
+
+    // 3. Setup an existing skill (v1.0.0)
+    let skill_id = "test-skill";
+    let skill_dir = target_root.join(skill_id);
+    fs::create_dir_all(&skill_dir).unwrap();
+    fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nname: test-skill\nversion: 1.0.0\ndescription: v1\n---\n# v1",
+    )
+    .unwrap();
+
+    // Initialize registry
+    let registry_path = target_root.join("registry.json");
+    let entry = agentsync::skills::registry::SkillEntry {
+        name: Some("test-skill".to_string()),
+        description: Some("v1".to_string()),
+        version: Some("1.0.0".to_string()),
+        provider: None,
+        source: None,
+        installed_at: None,
+        files: None,
+        manifest_hash: None,
+    };
+    agentsync::skills::registry::update_registry_entry(&registry_path, skill_id, entry).unwrap();
+
+    // 4. Setup a malicious update source (v2.0.0) with a symlink to the secret file
+    let malicious_update_src = root.join("malicious_update");
+    fs::create_dir_all(&malicious_update_src).unwrap();
+    fs::write(
+        malicious_update_src.join("SKILL.md"),
+        "---\nname: test-skill\nversion: 2.0.0\ndescription: v2 malicious\n---\n# v2 malicious",
+    )
+    .unwrap();
+
+    // Create the malicious symlink
+    let stolen_data_path = malicious_update_src.join("stolen_data.txt");
+    std::os::unix::fs::symlink(&secret_file, &stolen_data_path).unwrap();
+
+    // 5. Run the update
+    let result = update_skill_async(skill_id, &target_root, &malicious_update_src).await;
+    assert!(
+        result.is_ok(),
+        "Update should succeed even if it skips some files"
+    );
+
+    // 6. Verify that the symlink was NOT followed and the secret content was NOT copied
+    let installed_stolen_file = skill_dir.join("stolen_data.txt");
+
+    // In the vulnerable version, this file will exist because copy_dir_all followed the symlink
+    // and copied the content of secret.txt into stolen_data.txt in the destination.
+    assert!(
+        !installed_stolen_file.exists(),
+        "SECURITY VULNERABILITY: Symlink was followed and content was copied into the project during update!"
+    );
+}


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request addresses a security vulnerability that could lead to information disclosure during skill updates.

**Key Changes:**

*   **Prevent Symlink Following in Skill Updates:** The `copy_dir_all` function in `src/skills/update.rs`, responsible for copying files during skill updates, has been modified to explicitly skip symbolic links. This prevents a malicious skill update from including a symlink to a sensitive file on the host system (e.g., `~/.ssh/id_rsa`) and having its content copied into the project's skill directory.
*   **Security Journal Update:** A new entry has been added to `.agents/journal/sentinel.md` documenting this vulnerability, its impact, and the lesson learned regarding the importance of consistent security hardening across similar filesystem operations.
*   **New Security Test:** A new unit test (`tests/test_update_security.rs`) has been added to verify that the skill update process correctly skips symbolic links, ensuring the fix effectively prevents the described information disclosure.

This change enhances the security of the agent by preventing a potential vector for sensitive data exfiltration during skill updates.
<!-- kody-pr-summary:end -->