### PR TITLE
docs: correct technology detection confidence and validation logic

### DIFF
--- a/.agents/journal/scribe-journal.md
+++ b/.agents/journal/scribe-journal.md
@@ -32,3 +32,8 @@
 
 **Learning:** Both the CLI reference and the Skills guide claimed that active evaluation of multi-technology "combo" entries was deferred. However, Phase 2 of `recommend_skills` in `src/skills/suggest.rs` already implements this logic, providing specific recommendations for combinations like `react-hook-form` + `zod`.
 **Action:** Before claiming a feature is "deferred" or "planned," verify the relevant logic phases in the implementation (e.g., Phase 2 evaluation loops).
+
+## 2025-05-22 - Technology Detection Confidence and Validation Drift
+
+**Learning:** The Skills guide inaccurately described technology detection confidence as being location-based (attributing "low" confidence to markers in test/fixture directories). In reality, `src/skills/detect.rs` implements rule-based confidence (High for exact matches, Medium for patterns) and ignores test/generated directories entirely. Additionally, skill ID validation logic is implemented in `src/commands/skill.rs`, not `src/skills/catalog.rs` as previously documented.
+**Action:** Always cross-reference heuristic descriptions against the specific implementation file (e.g., `detect.rs` for detection logic) and verify the exact location of shared validation functions before documenting them as reference points.

--- a/website/docs/src/content/docs/guides/skills.mdx
+++ b/website/docs/src/content/docs/guides/skills.mdx
@@ -172,9 +172,8 @@ A representative set of supported technologies and markers includes:
 Notes:
 
 - Detection uses repository contents only; recommendation metadata does **not** decide what technologies are detected.
-- Root-level canonical markers yield `high` confidence.
-- Nested markers generally yield `medium` confidence.
-- Markers under test/example-style paths yield `low` confidence.
+- Confidence is rule-based: **high** for exact package matches and configuration file existence; **medium** for package name patterns, file content matches, and file extensions.
+- Location (root vs. nested) does not influence confidence, though common generated and test directories are ignored entirely.
 - AgentSync ignores common generated/vendor directories like `.git`, `.agents`, `node_modules`, `target`, `dist`, `build`, `.astro`, `.next`, `.turbo`, and `.pnpm-store` while scanning.
 
 Recommendation metadata now comes from a hybrid catalog model:
@@ -391,7 +390,7 @@ When an install/update fails, re-run with higher verbosity or use `--json` to ge
 
 ## Security & safe usage
 
-- The CLI validates skill identifiers and rejects path traversal (no `/` or `\` and no absolute paths). This protects projects from accidental overwrites. The validation logic lives in `src/skills/catalog.rs` (function `validate_local_skill_id`), which is invoked by the CLI.
+- The CLI validates skill identifiers and rejects path traversal (no `/` or `\` and no absolute paths). This protects projects from accidental overwrites. The validation logic lives in `src/commands/skill.rs` (function `validate_skill_id`), which is invoked by the CLI.
 - Treat third-party skill archives as untrusted input. Review the contents before installing in sensitive environments.
 
 ## Links & further reading


### PR DESCRIPTION
This PR addresses inaccuracies in the Skills guide that were discovered during a source code audit.

### Changes:
- **Technology Detection Confidence:** The documentation previously claimed confidence was location-based (root vs nested vs test). The implementation in `src/skills/detect.rs` uses rule-based confidence (High for exact matches/config files, Medium for patterns/extensions).
- **Ignored Directories:** Clarified that AgentSync ignores common test and generated directories (e.g., `node_modules`, `target`, `dist`) entirely during technology scanning, rather than assigning them "low" confidence.
- **Validation Logic Location:** Updated the reference for skill ID validation from `src/skills/catalog.rs` to the correct location in `src/commands/skill.rs`.

### Verification:
- Read `src/skills/detect.rs` and `src/commands/skill.rs` to confirm logic.
- Ran `pnpm run docs:build` to ensure the site builds without errors.
- Ran `cargo test skills::detect` and `cargo test validate_skill_id` to verify behavior consistency.
- Captured screenshots of the updated documentation sections.

---
*PR created automatically by Jules for task [9534925558213391635](https://jules.google.com/task/9534925558213391635) started by @yacosta738*