### PR TITLE
fix(security): prevent symlink following in skill updates

### DIFF
--- a/src/skills/update.rs
+++ b/src/skills/update.rs
@@ -195,6 +195,13 @@ fn copy_dir_all(src: &Path, dst: &Path) -> std::io::Result<()> {
     for entry in fs::read_dir(src)? {
         let entry = entry?;
         let ty = entry.file_type()?;
+
+        // SECURITY: Skip symbolic links to prevent following them to sensitive host files
+        // outside the update source. This matches the security pattern in install.rs.
+        if ty.is_symlink() {
+            continue;
+        }
+
         let src_path = entry.path();
         let dst_path = dst.join(entry.file_name());
         if ty.is_dir() {

--- a/tests/test_update_security.rs
+++ b/tests/test_update_security.rs
@@ -1,0 +1,60 @@
+#[cfg(unix)]
+use agentsync::skills::update::update_skill_async;
+#[cfg(unix)]
+use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::symlink;
+#[cfg(unix)]
+use tempfile::TempDir;
+
+#[tokio::test]
+#[cfg(unix)]
+async fn test_update_skill_skips_symlinks() {
+    let td = TempDir::new().unwrap();
+    let project_root = td.path().join("project");
+    let target_root = project_root.join(".agents").join("skills");
+    fs::create_dir_all(&target_root).unwrap();
+
+    let skill_id = "test-skill";
+    let skill_dir = target_root.join(skill_id);
+    fs::create_dir_all(&skill_dir).unwrap();
+
+    // Create v1 manifest in the current skill dir
+    let v1_manifest = "---\nname: test-skill\ndescription: Test\nversion: 1.0.0\n---\n";
+    fs::write(skill_dir.join("SKILL.md"), v1_manifest).unwrap();
+
+    // Create a sensitive file OUTSIDE the update source
+    let sensitive_file = td.path().join("sensitive.txt");
+    fs::write(&sensitive_file, "SENSITIVE CONTENT").unwrap();
+
+    // Create update source (v1.1.0) with a malicious symlink
+    let update_src = td.path().join("update-src");
+    fs::create_dir_all(&update_src).unwrap();
+    let v2_manifest = "---\nname: test-skill\ndescription: Test\nversion: 1.1.0\n---\n";
+    fs::write(update_src.join("SKILL.md"), v2_manifest).unwrap();
+
+    // Malicious symlink pointing to sensitive.txt
+    symlink(&sensitive_file, update_src.join("leaked.txt")).unwrap();
+
+    // Perform update
+    update_skill_async(skill_id, &target_root, &update_src)
+        .await
+        .expect("Update failed");
+
+    // Verify if leaked.txt exists in the installed skill dir
+    let installed_leaked = skill_dir.join("leaked.txt");
+
+    if installed_leaked.exists() {
+        let metadata = fs::symlink_metadata(&installed_leaked).unwrap();
+        if !metadata.file_type().is_symlink() {
+            panic!("SECURITY VULNERABILITY: Symlink was followed and content was copied!");
+        }
+    }
+
+    // In a secure implementation, symlinks should be skipped entirely,
+    // so installed_leaked should not exist.
+    assert!(
+        !installed_leaked.exists(),
+        "SECURITY: Symlinks should be skipped during update"
+    );
+}


### PR DESCRIPTION
Identified and fixed a security vulnerability in `src/skills/update.rs` where the `copy_dir_all` function followed symbolic links during skill updates. A malicious skill update source could have used this to leak sensitive host files into the project directory.

The fix explicitly checks `file_type.is_symlink()` and skips symlinks during recursive directory copies. A new regression test `tests/test_update_security.rs` verifies that symlinks are ignored and their targets are not copied.

Verified with `cargo test --all-features`, `cargo fmt`, and `cargo clippy`.

---
*PR created automatically by Jules for task [13695676142155576676](https://jules.google.com/task/13695676142155576676) started by @yacosta738*