### PR TITLE
docs: fix Agent Compatibility Matrix drift and formatting

### DIFF
--- a/.agents/journal/scribe-journal.md
+++ b/.agents/journal/scribe-journal.md
@@ -32,3 +32,8 @@
 
 **Learning:** Both the CLI reference and the Skills guide claimed that active evaluation of multi-technology "combo" entries was deferred. However, Phase 2 of `recommend_skills` in `src/skills/suggest.rs` already implements this logic, providing specific recommendations for combinations like `react-hook-form` + `zod`.
 **Action:** Before claiming a feature is "deferred" or "planned," verify the relevant logic phases in the implementation (e.g., Phase 2 evaluation loops).
+
+## 2026-05-24 - Agent Compatibility Matrix Drift
+
+**Learning:** The `Agent Compatibility Matrix` in the configuration reference had drifted significantly from `src/agent_ids.rs` and `src/mcp.rs`. Several agents had missing or incorrect skill directory mappings, and a Markdown formatting error (a note breaking the table) had made the table disjointed and hard to maintain.
+**Action:** Treat the Compatibility Matrix as a living map of `src/agent_ids.rs`. Periodically verify that every agent canonicalized in Rust is present in the table, alphabetized for maintainability, and that skill paths are correctly categorized in "Skills Support" rather than "Notes".

--- a/website/docs/src/content/docs/reference/configuration.mdx
+++ b/website/docs/src/content/docs/reference/configuration.mdx
@@ -197,40 +197,40 @@ The matrix below documents common agent locations and whether AgentSync can hand
 | Agent | Rules File(s) | MCP Configuration / Notes | Skills Support / Location |
 | :--- | :--- | :--- | :--- |
 | AGENTS.md | `AGENTS.md` | Pseudo-agent pattern via `[agents.root]` target | - |
-| GitHub Copilot | `.github/copilot-instructions.md` | `.vscode/mcp.json` (native MCP) | Configurable |
+| Aider | - | No native MCP formatter; `.aider.conf.yml`, `.aiderignore` ignores | Configurable |
+| Amazon Q CLI | - | No native MCP formatter; `.amazonq/rules/`, `.amazonq/mcp.json` ignores | Configurable |
+| Amp | `AMPCODE.md` | No native MCP formatter | Configurable |
+| Antigravity | - | No native MCP formatter; `.agent/rules/` ignore | Configurable; `.agent/skills/` |
+| AugmentCode | - | No native MCP formatter; `.augment/rules/` ignore | Configurable |
 | Claude Code | `CLAUDE.md` | `.mcp.json` (native MCP) | Configurable; `.claude/skills/` |
-| OpenAI Codex CLI | `AGENTS.md` | `.codex/config.toml` (native MCP) | Configurable; `.codex/skills/` |
-| VS Code | - | `.vscode/mcp.json` (native MCP) | Configurable |
-| Pi Coding Agent | - | No native MCP formatter | Configurable |
-| Jules | - | No native MCP formatter | Configurable |
-| Cursor | `.cursor/rules/agentsync.mdc` | `.cursor/mcp.json` (native MCP) | Configurable; `.cursor/skills/` |
-| Windsurf | `.windsurfrules` | No native MCP formatter; `.windsurf/mcp_config.json` ignore | Configurable |
 | Cline | `.clinerules` | No native MCP formatter | Configurable |
 | Crush | `CRUSH.md` | No native MCP formatter; `.crush.json` ignore | Configurable |
-| Amp | `AMPCODE.md` | No native MCP formatter | Configurable |
-| Antigravity | - | No native MCP formatter; `.agent/rules/`, `.agent/skills/` ignores | Configurable |
-| Amazon Q CLI | - | No native MCP formatter; `.amazonq/rules/`, `.amazonq/mcp.json` ignores | Configurable |
-| Aider | - | No native MCP formatter; `.aider.conf.yml`, `.aiderignore` ignores | Configurable |
+| Cursor | `.cursor/rules/agentsync.mdc` | `.cursor/mcp.json` (native MCP) | Configurable; `.cursor/skills/` |
+| Factory Droid | - | No native MCP formatter; `.factory/mcp.json` ignore | Configurable; `.factory/skills/` |
 | Firebase Studio | - | No native MCP formatter; `.idx/airules.md`, `.idx/mcp.json` ignores | Configurable |
+| Firebender | - | No native MCP formatter; `firebender.json` ignore | Configurable |
+| Gemini CLI | `GEMINI.md` | `.gemini/settings.json` (native MCP, adds `"trust": true`) | Configurable; `.gemini/skills/` |
+| GitHub Copilot | `.github/copilot-instructions.md` | `.vscode/mcp.json` (native MCP) | Configurable |
+| Goose | - | No native MCP formatter; `.goosehints` ignore | Configurable |
+| JetBrains AI Assistant | - | No native MCP formatter; `.aiassistant/rules/` ignore | Configurable |
+| Jules | - | No native MCP formatter | Configurable |
+| Junie | - | No native MCP formatter; `.junie/` ignore | Configurable |
+| Kilo Code | - | No native MCP formatter; `.kilocode/mcp.json` ignore | Configurable |
+| Kiro | - | No native MCP formatter; `.kiro/steering/`, `.kiro/settings/mcp.json` ignores | Configurable |
+| Mistral Vibe | - | No native MCP formatter; `.vibe/config.toml` ignore | Configurable; `.vibe/skills/` |
 | Open Hands | - | No native MCP formatter; `.openhands/microagents/` ignore | Configurable |
+| OpenAI Codex CLI | `AGENTS.md` | `.codex/config.toml` (native MCP) | Configurable |
+| OpenCode | `AGENTS.md` | `opencode.json` (native MCP) | Configurable; `.opencode/skills/` |
+| Pi Coding Agent | - | No native MCP formatter | Configurable |
+| Qwen Code | - | No native MCP formatter; `.qwen/settings.json` ignore | Configurable |
+| RooCode | - | No native MCP formatter; `.roo/mcp.json`, `.roo/rules/` ignores | Configurable; `.roo/skills/` |
+| Trae AI | - | No native MCP formatter; `.trae/rules/` ignore | Configurable |
+| VS Code | - | `.vscode/mcp.json` (native MCP) | Configurable |
+| Warp | `WARP.md` | No native MCP formatter | Configurable |
+| Windsurf | `.windsurfrules` | No native MCP formatter; `.windsurf/mcp_config.json` ignore | Configurable |
+| Zed | - | No native MCP formatter; `.zed/settings.json` ignore | Configurable |
 
 **Note (Cursor rules filename):** `.cursor/rules/agentsync.mdc` is the documented example path used by AgentSync for Cursor rules. You may use a different `.mdc` filename/path if you configure it explicitly under your `[agents.<name>.targets.*]` entries.
-| Gemini CLI | `GEMINI.md` | `.gemini/settings.json` (native MCP, adds `"trust": true`) | Configurable; `.gemini/skills/` |
-| Junie | - | No native MCP formatter; `.junie/` ignore | Configurable |
-| AugmentCode | - | No native MCP formatter; `.augment/rules/` ignore | Configurable |
-| Kilo Code | - | No native MCP formatter; `.kilocode/mcp.json` ignore | Configurable |
-| OpenCode | `AGENTS.md` | `opencode.json` (native MCP) | Configurable; `.opencode/skills/` |
-| Goose | - | No native MCP formatter; `.goosehints` ignore | Configurable |
-| Qwen Code | - | No native MCP formatter; `.qwen/settings.json` ignore | Configurable |
-| RooCode | - | No native MCP formatter; `.roo/mcp.json`, `.roo/rules/`, `.roo/skills/` ignores | Configurable |
-| Zed | - | No native MCP formatter; `.zed/settings.json` ignore | Configurable |
-| Trae AI | - | No native MCP formatter; `.trae/rules/` ignore | Configurable |
-| Warp | `WARP.md` | No native MCP formatter | Configurable |
-| Kiro | - | No native MCP formatter; `.kiro/steering/`, `.kiro/settings/mcp.json` ignores | Configurable |
-| Firebender | - | No native MCP formatter; `firebender.json` ignore | Configurable |
-| Factory Droid | - | No native MCP formatter; `.factory/mcp.json`, `.factory/skills/` ignores | Configurable |
-| Mistral Vibe | - | No native MCP formatter; `.vibe/config.toml`, `.vibe/skills/` ignores | Configurable |
-| JetBrains AI Assistant | - | No native MCP formatter; `.aiassistant/rules/` ignore | Configurable |
 
 ### What "configurable" means in practice
 


### PR DESCRIPTION
This PR fixes several inaccuracies and formatting issues in the `Agent Compatibility Matrix` within the configuration reference documentation.

### Changes
- **Accuracy:** Updated skill directory locations for Antigravity (`.agent/skills/`), Factory Droid (`.factory/skills/`), Mistral Vibe (`.vibe/skills/`), and RooCode (`.roo/skills/`) to match their definitions in `src/agent_ids.rs`.
- **Cleanup:** Removed a non-existent skills entry for OpenAI Codex CLI.
- **Formatting:** Fixed a Markdown error where a Cursor-specific note was breaking the table into disjointed pieces. Unified the table and moved the note to the bottom.
- **Consistency:** Ensured all file paths and patterns in the table use backticks (code formatting) and corrected pluralization of "ignores" based on the number of items.
- **Maintainability:** Alphabetized the agent list in the matrix.

### Source of Truth
Verified against:
- `src/agent_ids.rs`: `known_ignore_patterns` and `canonical_configurable_agent_id`
- `src/mcp.rs`: Native MCP configuration paths

### Verification
- Ran `pnpm run docs:build` (Successful)
- Visual inspection of the rendered table via local dev server.

---
*PR created automatically by Jules for task [18000121763584278041](https://jules.google.com/task/18000121763584278041) started by @yacosta738*