### PR TITLE
docs: unify and correct agent compatibility matrix

### DIFF
--- a/.agents/journal/scribe-journal.md
+++ b/.agents/journal/scribe-journal.md
@@ -32,3 +32,8 @@
 
 **Learning:** Both the CLI reference and the Skills guide claimed that active evaluation of multi-technology "combo" entries was deferred. However, Phase 2 of `recommend_skills` in `src/skills/suggest.rs` already implements this logic, providing specific recommendations for combinations like `react-hook-form` + `zod`.
 **Action:** Before claiming a feature is "deferred" or "planned," verify the relevant logic phases in the implementation (e.g., Phase 2 evaluation loops).
+
+## 2026-07-05 - Fragmented and Inaccurate Agent Matrix
+
+**Learning:** The Agent Compatibility Matrix was split into two separate tables and lacked technical details for specific agent mappings (e.g., OpenAI Codex CLI's `headers` to `http_headers` conversion). This fragmentation made it harder for users to find their agent and obscured important MCP generation behavior.
+**Action:** Keep agent-related technical details in a unified, alphabetized matrix. When documenting MCP generation for a specific agent, cross-reference both `src/agent_ids.rs` and `src/mcp.rs` to capture any agent-specific field renames or merge strategies.

--- a/website/docs/src/content/docs/reference/configuration.mdx
+++ b/website/docs/src/content/docs/reference/configuration.mdx
@@ -197,40 +197,40 @@ The matrix below documents common agent locations and whether AgentSync can hand
 | Agent | Rules File(s) | MCP Configuration / Notes | Skills Support / Location |
 | :--- | :--- | :--- | :--- |
 | AGENTS.md | `AGENTS.md` | Pseudo-agent pattern via `[agents.root]` target | - |
-| GitHub Copilot | `.github/copilot-instructions.md` | `.vscode/mcp.json` (native MCP) | Configurable |
-| Claude Code | `CLAUDE.md` | `.mcp.json` (native MCP) | Configurable; `.claude/skills/` |
-| OpenAI Codex CLI | `AGENTS.md` | `.codex/config.toml` (native MCP) | Configurable; `.codex/skills/` |
-| VS Code | - | `.vscode/mcp.json` (native MCP) | Configurable |
-| Pi Coding Agent | - | No native MCP formatter | Configurable |
-| Jules | - | No native MCP formatter | Configurable |
-| Cursor | `.cursor/rules/agentsync.mdc` | `.cursor/mcp.json` (native MCP) | Configurable; `.cursor/skills/` |
-| Windsurf | `.windsurfrules` | No native MCP formatter; `.windsurf/mcp_config.json` ignore | Configurable |
-| Cline | `.clinerules` | No native MCP formatter | Configurable |
-| Crush | `CRUSH.md` | No native MCP formatter; `.crush.json` ignore | Configurable |
+| Aider | - | No native MCP formatter; `.aider.conf.yml`, `.aiderignore` ignores | Configurable |
+| Amazon Q CLI | - | No native MCP formatter; `.amazonq/rules/`, `.amazonq/mcp.json` ignores | Configurable |
 | Amp | `AMPCODE.md` | No native MCP formatter | Configurable |
 | Antigravity | - | No native MCP formatter; `.agent/rules/`, `.agent/skills/` ignores | Configurable |
-| Amazon Q CLI | - | No native MCP formatter; `.amazonq/rules/`, `.amazonq/mcp.json` ignores | Configurable |
-| Aider | - | No native MCP formatter; `.aider.conf.yml`, `.aiderignore` ignores | Configurable |
-| Firebase Studio | - | No native MCP formatter; `.idx/airules.md`, `.idx/mcp.json` ignores | Configurable |
-| Open Hands | - | No native MCP formatter; `.openhands/microagents/` ignore | Configurable |
-
-**Note (Cursor rules filename):** `.cursor/rules/agentsync.mdc` is the documented example path used by AgentSync for Cursor rules. You may use a different `.mdc` filename/path if you configure it explicitly under your `[agents.<name>.targets.*]` entries.
-| Gemini CLI | `GEMINI.md` | `.gemini/settings.json` (native MCP, adds `"trust": true`) | Configurable; `.gemini/skills/` |
-| Junie | - | No native MCP formatter; `.junie/` ignore | Configurable |
 | AugmentCode | - | No native MCP formatter; `.augment/rules/` ignore | Configurable |
-| Kilo Code | - | No native MCP formatter; `.kilocode/mcp.json` ignore | Configurable |
-| OpenCode | `AGENTS.md` | `opencode.json` (native MCP) | Configurable; `.opencode/skills/` |
+| Claude Code | `CLAUDE.md` | `.mcp.json` (native MCP) | Configurable; `.claude/skills/` |
+| Cline | `.clinerules` | No native MCP formatter | Configurable |
+| Crush | `CRUSH.md` | No native MCP formatter; `.crush.json` ignore | Configurable |
+| Cursor | `.cursor/rules/agentsync.mdc` | `.cursor/mcp.json` (native MCP) | Configurable; `.cursor/skills/` |
+| Factory Droid | - | No native MCP formatter; `.factory/mcp.json`, `.factory/skills/` ignores | Configurable |
+| Firebase Studio | - | No native MCP formatter; `.idx/airules.md`, `.idx/mcp.json` ignores | Configurable |
+| Firebender | - | No native MCP formatter; `firebender.json` ignore | Configurable |
+| Gemini CLI | `GEMINI.md` | `.gemini/settings.json` (native MCP, adds `"trust": true`) | Configurable; `.gemini/skills/` |
+| GitHub Copilot | `.github/copilot-instructions.md` | `.vscode/mcp.json` (native MCP) | Configurable |
 | Goose | - | No native MCP formatter; `.goosehints` ignore | Configurable |
+| JetBrains AI Assistant | - | No native MCP formatter; `.aiassistant/rules/` ignore | Configurable |
+| Jules | - | No native MCP formatter | Configurable |
+| Junie | - | No native MCP formatter; `.junie/` ignore | Configurable |
+| Kilo Code | - | No native MCP formatter; `.kilocode/mcp.json` ignore | Configurable |
+| Kiro | - | No native MCP formatter; `.kiro/steering/`, `.kiro/settings/mcp.json` ignores | Configurable |
+| Mistral Vibe | - | No native MCP formatter; `.vibe/config.toml`, `.vibe/skills/` ignores | Configurable |
+| Open Hands | - | No native MCP formatter; `.openhands/microagents/` ignore | Configurable |
+| OpenAI Codex CLI | `AGENTS.md` | `.codex/config.toml` (native MCP); AgentSync maps `headers` to `http_headers` | Configurable; `.codex/skills/` |
+| OpenCode | `AGENTS.md` | `opencode.json` (native MCP) | Configurable; `.opencode/skills/` |
+| Pi Coding Agent | - | No native MCP formatter | Configurable |
 | Qwen Code | - | No native MCP formatter; `.qwen/settings.json` ignore | Configurable |
 | RooCode | - | No native MCP formatter; `.roo/mcp.json`, `.roo/rules/`, `.roo/skills/` ignores | Configurable |
-| Zed | - | No native MCP formatter; `.zed/settings.json` ignore | Configurable |
 | Trae AI | - | No native MCP formatter; `.trae/rules/` ignore | Configurable |
+| VS Code | - | `.vscode/mcp.json` (native MCP) | Configurable |
 | Warp | `WARP.md` | No native MCP formatter | Configurable |
-| Kiro | - | No native MCP formatter; `.kiro/steering/`, `.kiro/settings/mcp.json` ignores | Configurable |
-| Firebender | - | No native MCP formatter; `firebender.json` ignore | Configurable |
-| Factory Droid | - | No native MCP formatter; `.factory/mcp.json`, `.factory/skills/` ignores | Configurable |
-| Mistral Vibe | - | No native MCP formatter; `.vibe/config.toml`, `.vibe/skills/` ignores | Configurable |
-| JetBrains AI Assistant | - | No native MCP formatter; `.aiassistant/rules/` ignore | Configurable |
+| Windsurf | `.windsurfrules` | No native MCP formatter; `.windsurf/mcp_config.json` ignore | Configurable |
+| Zed | - | No native MCP formatter; `.zed/settings.json` ignore | Configurable |
+
+**Note (Cursor rules filename):** `.cursor/rules/agentsync.mdc` is the documented example path used by AgentSync for Cursor rules. You may use a different `.mdc` filename/path if you configure it explicitly under your `[agents.<name>.targets.*]` entries.
 
 ### What "configurable" means in practice
 


### PR DESCRIPTION
This PR synchronizes the Agent Compatibility Matrix with the actual codebase implementation. Previously, the matrix was split into two separate, non-alphabetized tables, making it difficult for users to find their specific agent. Additionally, technical nuances like the field renaming for OpenAI Codex CLI were missing.

Key changes:
- Merged all 33 supported agents into a single unified table.
- Alphabetized entries for easier navigation.
- Documented the `headers` to `http_headers` mapping for OpenAI Codex CLI, as verified in `src/mcp.rs`.
- Extracted Cursor's specialized "rules" file instructions into a standalone paragraph.
- Added a journal entry documenting the drift and the importance of cross-referencing `src/mcp.rs` for field renames.

Verified by running `pnpm run docs:build` and visual inspection of the generated site.

---
*PR created automatically by Jules for task [16344474590821296838](https://jules.google.com/task/16344474590821296838) started by @yacosta738*