### PR TITLE
fix(security): prevent symlink following in skill updates

### DIFF
--- a/.agents/journal/sentinel.md
+++ b/.agents/journal/sentinel.md
@@ -33,6 +33,7 @@ tool that are known to contain user-provided credentials or sensitive environmen
 **Prevention:** Use `Path::components()` to explicitly reject `RootDir`, `Prefix`, and `ParentDir` components. For cross-platform safety on Unix, also manually check for Windows drive letter patterns (e.g., `filename.as_bytes()[1] == b':'`) in untrusted archive entry paths.
 
 ## 2025-05-19 - Information Disclosure via Symlink Following in Skill Update
+
 **Vulnerability:** The `copy_dir_all` function used during local skill updates followed symbolic links. A malicious update source could include a symlink to a sensitive file (e.g., `~/.ssh/id_rsa`), causing its content to be copied into the project.
 **Learning:** This was a regression of the pattern fixed in `install.rs` (2025-05-17), but in the `update.rs` module which used its own `copy_dir_all` implementation. Recursive copy logic must always be hardened against symlinks in this codebase.
 **Prevention:** Always check `entry.file_type()?.is_symlink()` and skip symlinks in any recursive directory copy operation used for untrusted content.

--- a/.agents/journal/sentinel.md
+++ b/.agents/journal/sentinel.md
@@ -31,3 +31,8 @@ tool that are known to contain user-provided credentials or sensitive environmen
 **Vulnerability:** String-based path checks (like `starts_with('/')`) or platform-specific `Path::is_absolute()` calls failed to detect Windows-style absolute paths (e.g., `C:/...`) when running on Unix systems, leading to potential path traversal vulnerabilities in skill archives.
 **Learning:** Rust's `std::path::Path` behavior depends on the host operating system. On Unix, a path starting with a drive letter is considered relative, which allows it to pass simple `is_absolute()` checks and be joined to a base directory, potentially escaping it if not carefully validated.
 **Prevention:** Use `Path::components()` to explicitly reject `RootDir`, `Prefix`, and `ParentDir` components. For cross-platform safety on Unix, also manually check for Windows drive letter patterns (e.g., `filename.as_bytes()[1] == b':'`) in untrusted archive entry paths.
+
+## 2025-05-19 - Information Disclosure via Symlink Following in Skill Update
+**Vulnerability:** The `copy_dir_all` function used during local skill updates followed symbolic links. A malicious update source could include a symlink to a sensitive file (e.g., `~/.ssh/id_rsa`), causing its content to be copied into the project.
+**Learning:** This was a regression of the pattern fixed in `install.rs` (2025-05-17), but in the `update.rs` module which used its own `copy_dir_all` implementation. Recursive copy logic must always be hardened against symlinks in this codebase.
+**Prevention:** Always check `entry.file_type()?.is_symlink()` and skip symlinks in any recursive directory copy operation used for untrusted content.

--- a/src/skills/update.rs
+++ b/src/skills/update.rs
@@ -195,6 +195,14 @@ fn copy_dir_all(src: &Path, dst: &Path) -> std::io::Result<()> {
     for entry in fs::read_dir(src)? {
         let entry = entry?;
         let ty = entry.file_type()?;
+
+        // SECURITY: Skip symbolic links to prevent following them outside the update source.
+        // This prevents information disclosure if a malicious update source contains
+        // symlinks to sensitive host files (e.g., ~/.ssh/id_rsa).
+        if ty.is_symlink() {
+            continue;
+        }
+
         let src_path = entry.path();
         let dst_path = dst.join(entry.file_name());
         if ty.is_dir() {

--- a/tests/test_update_security.rs
+++ b/tests/test_update_security.rs
@@ -41,18 +41,18 @@ async fn test_update_skill_skips_symlinks() {
             .await
             .expect("Update should succeed");
 
-        // 5. Verify if the sensitive content was copied (VULNERABILITY)
+        // 5. Verify the symlink was NOT followed — the leaked file must not exist
         let leaked_path = skill_dir.join("leaked.txt");
+        assert!(
+            !leaked_path.exists(),
+            "SECURITY VULNERABILITY: Symlink target was copied into the skill directory!"
+        );
 
-        if leaked_path.exists() {
-            let metadata = fs::symlink_metadata(&leaked_path).expect("Failed to get metadata");
-            // If the vulnerability exists, copy_dir_all will follow the symlink and create a regular file.
-            // We want it to either NOT exist or still be a (non-followed) symlink if we chose to copy links.
-            // But the hardening goal is to skip them entirely.
-            assert!(
-                metadata.file_type().is_symlink(),
-                "SECURITY VULNERABILITY: Symlink was followed and content was copied into the project!"
-            );
-        }
+        // Also verify the skill itself was updated (SKILL.md content changed)
+        let skill_content = fs::read_to_string(skill_dir.join("SKILL.md")).unwrap();
+        assert!(
+            skill_content.contains("2.0.0"),
+            "Skill should have been updated to v2.0.0"
+        );
     }
 }

--- a/tests/test_update_security.rs
+++ b/tests/test_update_security.rs
@@ -1,0 +1,58 @@
+use agentsync::skills::update::update_skill_async;
+use std::fs;
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn test_update_skill_skips_symlinks() {
+    #[cfg(unix)]
+    {
+        let temp_dir = TempDir::new().unwrap();
+        let project_root = temp_dir.path().join("project");
+        let target_root = project_root.join(".agents").join("skills");
+        fs::create_dir_all(&target_root).unwrap();
+
+        // 1. Create a sensitive file OUTSIDE the update source
+        let sensitive_file = temp_dir.path().join("sensitive.txt");
+        fs::write(&sensitive_file, "SENSITIVE CONTENT").unwrap();
+
+        // 2. Pre-install a skill (v1.0.0)
+        let skill_id = "test-skill";
+        let skill_dir = target_root.join(skill_id);
+        fs::create_dir_all(&skill_dir).unwrap();
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: test-skill\nversion: 1.0.0\n---",
+        )
+        .unwrap();
+
+        // 3. Create a malicious update source (v2.0.0) with a symlink to the sensitive file
+        let update_source = temp_dir.path().join("malicious-update");
+        fs::create_dir_all(&update_source).unwrap();
+        fs::write(
+            update_source.join("SKILL.md"),
+            "---\nname: test-skill\nversion: 2.0.0\n---",
+        )
+        .unwrap();
+
+        std::os::unix::fs::symlink(&sensitive_file, update_source.join("leaked.txt")).unwrap();
+
+        // 4. Run the update
+        update_skill_async(skill_id, &target_root, &update_source)
+            .await
+            .expect("Update should succeed");
+
+        // 5. Verify if the sensitive content was copied (VULNERABILITY)
+        let leaked_path = skill_dir.join("leaked.txt");
+
+        if leaked_path.exists() {
+            let metadata = fs::symlink_metadata(&leaked_path).expect("Failed to get metadata");
+            // If the vulnerability exists, copy_dir_all will follow the symlink and create a regular file.
+            // We want it to either NOT exist or still be a (non-followed) symlink if we chose to copy links.
+            // But the hardening goal is to skip them entirely.
+            assert!(
+                metadata.file_type().is_symlink(),
+                "SECURITY VULNERABILITY: Symlink was followed and content was copied into the project!"
+            );
+        }
+    }
+}


### PR DESCRIPTION
### Severity: HIGH

### Vulnerability
The `copy_dir_all` function used during local skill updates followed symbolic links. A malicious update source could include a symlink to a sensitive file (e.g., `~/.ssh/id_rsa`), causing its content to be copied into the project directory when the update was applied.

### Impact
Information disclosure of arbitrary sensitive files on the user's system that are reachable by the process.

### Fix
Modified `src/skills/update.rs:copy_dir_all` to explicitly check for symbolic links via `DirEntry::file_type()` and skip them if found. Added `// SECURITY:` comments explaining the mitigation.

### Source
`src/skills/update.rs` - `copy_dir_all` function.

### Verification
Added a new integration test `tests/test_update_security.rs` that simulates a malicious update containing a symlink to a sensitive file and verifies that the content is NOT copied into the project. All existing tests pass.

---
*PR created automatically by Jules for task [14963143575840251585](https://jules.google.com/task/14963143575840251585) started by @yacosta738*