### PR TITLE
perf: optimize package.json dependency parsing

### DIFF
--- a/src/skills/detect.rs
+++ b/src/skills/detect.rs
@@ -634,14 +634,16 @@ fn collect_package_names(
 
 fn parse_package_json_deps(path: &Path, cache: &mut ContentCache) -> Option<BTreeSet<String>> {
     let content = get_file_content(path, cache)?;
-    let json: serde_json::Value = serde_json::from_str(&content).ok()?;
-    let obj = json.as_object()?;
+    let mut json: serde_json::Value = serde_json::from_str(&content).ok()?;
+    let obj = json.as_object_mut()?;
 
     let mut deps = BTreeSet::new();
     for key in &["dependencies", "devDependencies", "peerDependencies"] {
-        if let Some(section) = obj.get(*key).and_then(|v| v.as_object()) {
-            for dep_name in section.keys() {
-                deps.insert(dep_name.clone());
+        // Optimization: Use remove() to take ownership of the section and its keys,
+        // eliminating redundant String clones for every dependency name.
+        if let Some(serde_json::Value::Object(section)) = obj.remove(*key) {
+            for (dep_name, _) in section {
+                deps.insert(dep_name);
             }
         }
     }


### PR DESCRIPTION
💡 What: Optimized `parse_package_json_deps` in `src/skills/detect.rs` to use ownership-based extraction of dependency names.
🎯 Why: The previous implementation performed a `clone()` on every dependency name (String) when inserting into the `BTreeSet`.
📊 Impact: Eliminates $O(N)$ heap allocations and string copies per `package.json` file scanned.
🔬 Measurement: Verified with existing test suite (`cargo test`) to ensure detection logic remains correct.

---
*PR created automatically by Jules for task [14757056003143017734](https://jules.google.com/task/14757056003143017734) started by @yacosta738*