### PR TITLE
feat(init): add --template flag and XDG user config template support

### DIFF
--- a/.agents/skills/registry.json
+++ b/.agents/skills/registry.json
@@ -1,136 +1,136 @@
 {
-  "schemaVersion": 1,
-  "last_updated": "2026-05-02T14:08:56.336437+00:00",
-  "skills": {
-    "accessibility": {
-      "name": "accessibility",
-      "version": null,
-      "description": "Audit and improve web accessibility following WCAG 2.1 guidelines. Use when the task involves `improve accessibility`, `a11y audit`, `WCAG compliance`, `screen reader support`, `keyboard navigation`, or `make accessible`.",
-      "provider": null,
-      "source": "/var/folders/zz/d4kl1hfj1j15nxm43d24px300000gn/T/.tmpQE0kcA",
-      "installedAt": "2026-05-02T14:08:49.360329+00:00",
-      "files": null,
-      "manifestHash": null
-    },
-    "astrolicious-astro": {
-      "name": "astro",
-      "version": null,
-      "description": "Skill for building with the Astro web framework. Helps create Astro components and pages, configure SSR adapters, set up content collections, deploy static sites, and manage project structure and CLI commands. Use when the user needs to work with Astro, mentions .astro files, asks about static site generation (SSG), islands architecture, content collections, or deploying an Astro project.",
-      "provider": null,
-      "source": "/var/folders/zz/d4kl1hfj1j15nxm43d24px300000gn/T/.tmpZOYGvB",
-      "installedAt": "2026-05-02T14:08:49.755568+00:00",
-      "files": null,
-      "manifestHash": null
-    },
-    "best-practices": {
-      "name": "best-practices",
-      "version": null,
-      "description": "Apply modern web development best practices for security, compatibility, and code quality. Use when the task involves `apply best practices`, `security audit`, `modernize code`, `code quality review`, or `check for vulnerabilities`.",
-      "provider": null,
-      "source": "/var/folders/zz/d4kl1hfj1j15nxm43d24px300000gn/T/.tmpUnT0K7",
-      "installedAt": "2026-05-02T14:08:50.339585+00:00",
-      "files": null,
-      "manifestHash": null
-    },
-    "core-web-vitals": {
-      "name": "core-web-vitals",
-      "version": null,
-      "description": "Optimize Core Web Vitals (LCP, INP, CLS) for better page experience and search ranking. Use when the task involves `improve Core Web Vitals`, `fix LCP`, `reduce CLS`, `optimize INP`, `page experience optimization`, or `fix layout shifts`.",
-      "provider": null,
-      "source": "/var/folders/zz/d4kl1hfj1j15nxm43d24px300000gn/T/.tmpMNxMDI",
-      "installedAt": "2026-05-02T14:08:50.850324+00:00",
-      "files": null,
-      "manifestHash": null
-    },
-    "docker-expert": {
-      "name": "docker-expert",
-      "version": null,
-      "description": "Advanced Docker containerization expert for multi-stage builds, image optimization, security hardening, and Compose orchestration. Use when the task involves `working with Dockerfile`, `docker-compose.yml`, `containerization`, `multi-stage builds`, or `optimizing Docker images`.",
-      "provider": null,
-      "source": "/var/folders/zz/d4kl1hfj1j15nxm43d24px300000gn/T/.tmpNvxOCL",
-      "installedAt": "2026-05-02T14:08:51.395934+00:00",
-      "files": null,
-      "manifestHash": null
-    },
-    "frontend-design": {
-      "name": "frontend-design",
-      "version": null,
-      "description": "Create distinctive, production-grade frontend interfaces with high design quality that avoids generic AI aesthetics. Use when the task involves `build web components`, `create frontend interface`, `build web page`, `build web application`, `frontend design`, `create UI component`, or `design web interface`.",
-      "provider": null,
-      "source": "/var/folders/zz/d4kl1hfj1j15nxm43d24px300000gn/T/.tmpMxcFaI",
-      "installedAt": "2026-05-02T14:08:51.884864+00:00",
-      "files": null,
-      "manifestHash": null
-    },
-    "github-actions": {
-      "name": "github-actions",
-      "version": null,
-      "description": "Comprehensive guide for building robust, secure, and efficient CI/CD pipelines using GitHub Actions. Use when the task involves `creating or editing GitHub Actions workflows`, `.github/workflows/*.yml`, `CI/CD pipelines`, `GitHub Actions best practices`, or `workflow optimization`.",
-      "provider": null,
-      "source": "/var/folders/zz/d4kl1hfj1j15nxm43d24px300000gn/T/.tmpmk0mnc",
-      "installedAt": "2026-05-02T14:08:52.440865+00:00",
-      "files": null,
-      "manifestHash": null
-    },
-    "makefile": {
-      "name": "makefile",
-      "version": null,
-      "description": "Best practices for authoring clean, maintainable, and portable GNU Make Makefiles. Use when the task involves `creating or editing Makefiles`, `Makefile`, `makefile`, `*.mk`, `GNUmakefile`, `GNU Make patterns`, `build automation`, or `makefile troubleshooting`.",
-      "provider": null,
-      "source": "/var/folders/zz/d4kl1hfj1j15nxm43d24px300000gn/T/.tmpyt1b7L",
-      "installedAt": "2026-05-02T14:08:53.165751+00:00",
-      "files": null,
-      "manifestHash": null
-    },
-    "nothing-design": {
-      "name": "nothing-design",
-      "version": null,
-      "description": "Guides intentional Nothing-inspired UI and design-system work with typography, spacing, hierarchy, components, and platform-specific execution. Use when the user explicitly asks for Nothing style, Nothing design, or `/nothing-design`, not for generic UI or design tasks.",
-      "provider": null,
-      "source": "/var/folders/zz/d4kl1hfj1j15nxm43d24px300000gn/T/.tmppkYF9D",
-      "installedAt": "2026-05-02T14:08:53.701563+00:00",
-      "files": null,
-      "manifestHash": null
-    },
-    "performance": {
-      "name": "performance",
-      "version": null,
-      "description": "Optimize web performance for faster loading and better user experience. Use when the task involves `speed up my site`, `optimize performance`, `reduce load time`, `fix slow loading`, `improve page speed`, or `performance audit`.",
-      "provider": null,
-      "source": "/var/folders/zz/d4kl1hfj1j15nxm43d24px300000gn/T/.tmpFuu2y8",
-      "installedAt": "2026-05-02T14:08:54.353560+00:00",
-      "files": null,
-      "manifestHash": null
-    },
-    "pinned-tag": {
-      "name": "pinned-tag",
-      "version": null,
-      "description": "Manage pinned tags and commit SHAs for GitHub Actions security, resolving mutable tags to immutable commit references. Use when the task involves `Unpinned tag for a non-immutable Action`, `pin GitHub Action to commit SHA`, `resolve git tag to SHA`, or `GitHub Actions security hardening`.",
-      "provider": null,
-      "source": "/var/folders/zz/d4kl1hfj1j15nxm43d24px300000gn/T/.tmpLcTUJU",
-      "installedAt": "2026-05-02T14:08:54.995680+00:00",
-      "files": null,
-      "manifestHash": null
-    },
-    "rust-async-patterns": {
-      "name": "rust-async-patterns",
-      "version": null,
-      "description": "Master Rust async programming with Tokio, async traits, error handling, and concurrent patterns. Use when the task involves `async Rust`, `Tokio patterns`, `Rust concurrent programming`, `async traits`, or `Rust futures and streams`.",
-      "provider": null,
-      "source": "/var/folders/zz/d4kl1hfj1j15nxm43d24px300000gn/T/.tmpseJ3ib",
-      "installedAt": "2026-05-02T14:08:55.596130+00:00",
-      "files": null,
-      "manifestHash": null
-    },
-    "seo": {
-      "name": "seo",
-      "version": null,
-      "description": "Optimize for search engine visibility and ranking. Use when the task involves `improve SEO`, `optimize for search`, `fix meta tags`, `add structured data`, `sitemap optimization`, or `search engine optimization`.",
-      "provider": null,
-      "source": "/var/folders/zz/d4kl1hfj1j15nxm43d24px300000gn/T/.tmp89W6f3",
-      "installedAt": "2026-05-02T14:08:56.336226+00:00",
-      "files": null,
-      "manifestHash": null
-    }
-  }
+	"schemaVersion": 1,
+	"last_updated": "2026-05-02T14:08:56.336437+00:00",
+	"skills": {
+		"accessibility": {
+			"name": "accessibility",
+			"version": null,
+			"description": "Audit and improve web accessibility following WCAG 2.1 guidelines. Use when the task involves `improve accessibility`, `a11y audit`, `WCAG compliance`, `screen reader support`, `keyboard navigation`, or `make accessible`.",
+			"provider": null,
+			"source": "/var/folders/zz/d4kl1hfj1j15nxm43d24px300000gn/T/.tmpQE0kcA",
+			"installedAt": "2026-05-02T14:08:49.360329+00:00",
+			"files": null,
+			"manifestHash": null
+		},
+		"astrolicious-astro": {
+			"name": "astro",
+			"version": null,
+			"description": "Skill for building with the Astro web framework. Helps create Astro components and pages, configure SSR adapters, set up content collections, deploy static sites, and manage project structure and CLI commands. Use when the user needs to work with Astro, mentions .astro files, asks about static site generation (SSG), islands architecture, content collections, or deploying an Astro project.",
+			"provider": null,
+			"source": "/var/folders/zz/d4kl1hfj1j15nxm43d24px300000gn/T/.tmpZOYGvB",
+			"installedAt": "2026-05-02T14:08:49.755568+00:00",
+			"files": null,
+			"manifestHash": null
+		},
+		"best-practices": {
+			"name": "best-practices",
+			"version": null,
+			"description": "Apply modern web development best practices for security, compatibility, and code quality. Use when the task involves `apply best practices`, `security audit`, `modernize code`, `code quality review`, or `check for vulnerabilities`.",
+			"provider": null,
+			"source": "/var/folders/zz/d4kl1hfj1j15nxm43d24px300000gn/T/.tmpUnT0K7",
+			"installedAt": "2026-05-02T14:08:50.339585+00:00",
+			"files": null,
+			"manifestHash": null
+		},
+		"core-web-vitals": {
+			"name": "core-web-vitals",
+			"version": null,
+			"description": "Optimize Core Web Vitals (LCP, INP, CLS) for better page experience and search ranking. Use when the task involves `improve Core Web Vitals`, `fix LCP`, `reduce CLS`, `optimize INP`, `page experience optimization`, or `fix layout shifts`.",
+			"provider": null,
+			"source": "/var/folders/zz/d4kl1hfj1j15nxm43d24px300000gn/T/.tmpMNxMDI",
+			"installedAt": "2026-05-02T14:08:50.850324+00:00",
+			"files": null,
+			"manifestHash": null
+		},
+		"docker-expert": {
+			"name": "docker-expert",
+			"version": null,
+			"description": "Advanced Docker containerization expert for multi-stage builds, image optimization, security hardening, and Compose orchestration. Use when the task involves `working with Dockerfile`, `docker-compose.yml`, `containerization`, `multi-stage builds`, or `optimizing Docker images`.",
+			"provider": null,
+			"source": "/var/folders/zz/d4kl1hfj1j15nxm43d24px300000gn/T/.tmpNvxOCL",
+			"installedAt": "2026-05-02T14:08:51.395934+00:00",
+			"files": null,
+			"manifestHash": null
+		},
+		"frontend-design": {
+			"name": "frontend-design",
+			"version": null,
+			"description": "Create distinctive, production-grade frontend interfaces with high design quality that avoids generic AI aesthetics. Use when the task involves `build web components`, `create frontend interface`, `build web page`, `build web application`, `frontend design`, `create UI component`, or `design web interface`.",
+			"provider": null,
+			"source": "/var/folders/zz/d4kl1hfj1j15nxm43d24px300000gn/T/.tmpMxcFaI",
+			"installedAt": "2026-05-02T14:08:51.884864+00:00",
+			"files": null,
+			"manifestHash": null
+		},
+		"github-actions": {
+			"name": "github-actions",
+			"version": null,
+			"description": "Comprehensive guide for building robust, secure, and efficient CI/CD pipelines using GitHub Actions. Use when the task involves `creating or editing GitHub Actions workflows`, `.github/workflows/*.yml`, `CI/CD pipelines`, `GitHub Actions best practices`, or `workflow optimization`.",
+			"provider": null,
+			"source": "/var/folders/zz/d4kl1hfj1j15nxm43d24px300000gn/T/.tmpmk0mnc",
+			"installedAt": "2026-05-02T14:08:52.440865+00:00",
+			"files": null,
+			"manifestHash": null
+		},
+		"makefile": {
+			"name": "makefile",
+			"version": null,
+			"description": "Best practices for authoring clean, maintainable, and portable GNU Make Makefiles. Use when the task involves `creating or editing Makefiles`, `Makefile`, `makefile`, `*.mk`, `GNUmakefile`, `GNU Make patterns`, `build automation`, or `makefile troubleshooting`.",
+			"provider": null,
+			"source": "/var/folders/zz/d4kl1hfj1j15nxm43d24px300000gn/T/.tmpyt1b7L",
+			"installedAt": "2026-05-02T14:08:53.165751+00:00",
+			"files": null,
+			"manifestHash": null
+		},
+		"nothing-design": {
+			"name": "nothing-design",
+			"version": null,
+			"description": "Guides intentional Nothing-inspired UI and design-system work with typography, spacing, hierarchy, components, and platform-specific execution. Use when the user explicitly asks for Nothing style, Nothing design, or `/nothing-design`, not for generic UI or design tasks.",
+			"provider": null,
+			"source": "/var/folders/zz/d4kl1hfj1j15nxm43d24px300000gn/T/.tmppkYF9D",
+			"installedAt": "2026-05-02T14:08:53.701563+00:00",
+			"files": null,
+			"manifestHash": null
+		},
+		"performance": {
+			"name": "performance",
+			"version": null,
+			"description": "Optimize web performance for faster loading and better user experience. Use when the task involves `speed up my site`, `optimize performance`, `reduce load time`, `fix slow loading`, `improve page speed`, or `performance audit`.",
+			"provider": null,
+			"source": "/var/folders/zz/d4kl1hfj1j15nxm43d24px300000gn/T/.tmpFuu2y8",
+			"installedAt": "2026-05-02T14:08:54.353560+00:00",
+			"files": null,
+			"manifestHash": null
+		},
+		"pinned-tag": {
+			"name": "pinned-tag",
+			"version": null,
+			"description": "Manage pinned tags and commit SHAs for GitHub Actions security, resolving mutable tags to immutable commit references. Use when the task involves `Unpinned tag for a non-immutable Action`, `pin GitHub Action to commit SHA`, `resolve git tag to SHA`, or `GitHub Actions security hardening`.",
+			"provider": null,
+			"source": "/var/folders/zz/d4kl1hfj1j15nxm43d24px300000gn/T/.tmpLcTUJU",
+			"installedAt": "2026-05-02T14:08:54.995680+00:00",
+			"files": null,
+			"manifestHash": null
+		},
+		"rust-async-patterns": {
+			"name": "rust-async-patterns",
+			"version": null,
+			"description": "Master Rust async programming with Tokio, async traits, error handling, and concurrent patterns. Use when the task involves `async Rust`, `Tokio patterns`, `Rust concurrent programming`, `async traits`, or `Rust futures and streams`.",
+			"provider": null,
+			"source": "/var/folders/zz/d4kl1hfj1j15nxm43d24px300000gn/T/.tmpseJ3ib",
+			"installedAt": "2026-05-02T14:08:55.596130+00:00",
+			"files": null,
+			"manifestHash": null
+		},
+		"seo": {
+			"name": "seo",
+			"version": null,
+			"description": "Optimize for search engine visibility and ranking. Use when the task involves `improve SEO`, `optimize for search`, `fix meta tags`, `add structured data`, `sitemap optimization`, or `search engine optimization`.",
+			"provider": null,
+			"source": "/var/folders/zz/d4kl1hfj1j15nxm43d24px300000gn/T/.tmp89W6f3",
+			"installedAt": "2026-05-02T14:08:56.336226+00:00",
+			"files": null,
+			"manifestHash": null
+		}
+	}
 }

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -1,139 +1,133 @@
 {
-  "id": 11864609,
-  "name": "main",
-  "target": "branch",
-  "source_type": "Repository",
-  "source": "dallay/agentsync",
-  "enforcement": "active",
-  "conditions": {
-    "ref_name": {
-      "exclude": [],
-      "include": [
-        "~DEFAULT_BRANCH"
-      ]
-    }
-  },
-  "rules": [
-    {
-      "type": "deletion"
-    },
-    {
-      "type": "non_fast_forward"
-    },
-    {
-      "type": "creation"
-    },
-    {
-      "type": "required_linear_history"
-    },
-    {
-      "type": "required_signatures"
-    },
-    {
-      "type": "pull_request",
-      "parameters": {
-        "required_approving_review_count": 1,
-        "dismiss_stale_reviews_on_push": true,
-        "required_reviewers": [],
-        "require_code_owner_review": true,
-        "require_last_push_approval": true,
-        "required_review_thread_resolution": true,
-        "allowed_merge_methods": [
-          "merge",
-          "squash",
-          "rebase"
-        ]
-      }
-    },
-    {
-      "type": "required_status_checks",
-      "parameters": {
-        "strict_required_status_checks_policy": true,
-        "do_not_enforce_on_create": false,
-        "required_status_checks": [
-          {
-            "context": "Check",
-            "integration_id": 15368
-          },
-          {
-            "context": "Rustfmt",
-            "integration_id": 15368
-          },
-          {
-            "context": "Clippy",
-            "integration_id": 15368
-          },
-          {
-            "context": "Build (macos-latest)",
-            "integration_id": 15368
-          },
-          {
-            "context": "Build (ubuntu-latest)",
-            "integration_id": 15368
-          },
-          {
-            "context": "Build (windows-latest)",
-            "integration_id": 15368
-          },
-          {
-            "context": "Test (macos-latest)",
-            "integration_id": 15368
-          },
-          {
-            "context": "Test (ubuntu-latest)",
-            "integration_id": 15368
-          },
-          {
-            "context": "Test (windows-latest)",
-            "integration_id": 15368
-          },
-          {
-            "context": "Security Audit",
-            "integration_id": 15368
-          },
-          {
-            "context": "E2E Tests (alpine)",
-            "integration_id": 15368
-          },
-          {
-            "context": "E2E Tests (arch)",
-            "integration_id": 15368
-          },
-          {
-            "context": "E2E Tests (ubuntu)",
-            "integration_id": 15368
-          }
-        ]
-      }
-    },
-    {
-      "type": "merge_queue",
-      "parameters": {
-        "merge_method": "MERGE",
-        "max_entries_to_build": 5,
-        "min_entries_to_merge": 1,
-        "max_entries_to_merge": 5,
-        "min_entries_to_merge_wait_minutes": 5,
-        "grouping_strategy": "ALLGREEN",
-        "check_response_timeout_minutes": 60
-      }
-    }
-  ],
-  "bypass_actors": [
-    {
-      "actor_id": 5,
-      "actor_type": "RepositoryRole",
-      "bypass_mode": "always"
-    },
-    {
-      "actor_id": 915548,
-      "actor_type": "Integration",
-      "bypass_mode": "always"
-    },
-    {
-      "actor_id": 2502251,
-      "actor_type": "Integration",
-      "bypass_mode": "always"
-    }
-  ]
+	"id": 11864609,
+	"name": "main",
+	"target": "branch",
+	"source_type": "Repository",
+	"source": "dallay/agentsync",
+	"enforcement": "active",
+	"conditions": {
+		"ref_name": {
+			"exclude": [],
+			"include": ["~DEFAULT_BRANCH"]
+		}
+	},
+	"rules": [
+		{
+			"type": "deletion"
+		},
+		{
+			"type": "non_fast_forward"
+		},
+		{
+			"type": "creation"
+		},
+		{
+			"type": "required_linear_history"
+		},
+		{
+			"type": "required_signatures"
+		},
+		{
+			"type": "pull_request",
+			"parameters": {
+				"required_approving_review_count": 1,
+				"dismiss_stale_reviews_on_push": true,
+				"required_reviewers": [],
+				"require_code_owner_review": true,
+				"require_last_push_approval": true,
+				"required_review_thread_resolution": true,
+				"allowed_merge_methods": ["merge", "squash", "rebase"]
+			}
+		},
+		{
+			"type": "required_status_checks",
+			"parameters": {
+				"strict_required_status_checks_policy": true,
+				"do_not_enforce_on_create": false,
+				"required_status_checks": [
+					{
+						"context": "Check",
+						"integration_id": 15368
+					},
+					{
+						"context": "Rustfmt",
+						"integration_id": 15368
+					},
+					{
+						"context": "Clippy",
+						"integration_id": 15368
+					},
+					{
+						"context": "Build (macos-latest)",
+						"integration_id": 15368
+					},
+					{
+						"context": "Build (ubuntu-latest)",
+						"integration_id": 15368
+					},
+					{
+						"context": "Build (windows-latest)",
+						"integration_id": 15368
+					},
+					{
+						"context": "Test (macos-latest)",
+						"integration_id": 15368
+					},
+					{
+						"context": "Test (ubuntu-latest)",
+						"integration_id": 15368
+					},
+					{
+						"context": "Test (windows-latest)",
+						"integration_id": 15368
+					},
+					{
+						"context": "Security Audit",
+						"integration_id": 15368
+					},
+					{
+						"context": "E2E Tests (alpine)",
+						"integration_id": 15368
+					},
+					{
+						"context": "E2E Tests (arch)",
+						"integration_id": 15368
+					},
+					{
+						"context": "E2E Tests (ubuntu)",
+						"integration_id": 15368
+					}
+				]
+			}
+		},
+		{
+			"type": "merge_queue",
+			"parameters": {
+				"merge_method": "MERGE",
+				"max_entries_to_build": 5,
+				"min_entries_to_merge": 1,
+				"max_entries_to_merge": 5,
+				"min_entries_to_merge_wait_minutes": 5,
+				"grouping_strategy": "ALLGREEN",
+				"check_response_timeout_minutes": 60
+			}
+		}
+	],
+	"bypass_actors": [
+		{
+			"actor_id": 5,
+			"actor_type": "RepositoryRole",
+			"bypass_mode": "always"
+		},
+		{
+			"actor_id": 915548,
+			"actor_type": "Integration",
+			"bypass_mode": "always"
+		},
+		{
+			"actor_id": 2502251,
+			"actor_type": "Integration",
+			"bypass_mode": "always"
+		}
+	]
 }

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: ${{ env.CODECOV_TOKEN != '' }}
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
         with:
           files: target/coverage/rust.lcov.info
           fail_ci_if_error: true
@@ -67,7 +67,7 @@ jobs:
 
       - name: Upload coverage to Codecov (tokenless)
         if: ${{ env.CODECOV_TOKEN == '' }}
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
         with:
           files: target/coverage/rust.lcov.info
           fail_ci_if_error: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
  "is-terminal",
  "lazy_static",
  "pathdiff",
- "rand 0.10.1",
+ "rand",
  "ratatui",
  "regex",
  "reqwest",
@@ -133,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "async-compression"
@@ -276,7 +276,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -889,11 +889,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -906,7 +904,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.1",
+ "rand_core",
  "wasip2",
  "wasip3",
  "wasm-bindgen",
@@ -1678,15 +1676,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efca4c95a19a79d1c98f791f10aebd5c1363b473244630bb7dbde1dc98455a24"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1727,15 +1716,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.4",
+ "rand",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1784,42 +1774,13 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
-dependencies = [
- "rand_chacha",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1827,6 +1788,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "ratatui"
@@ -3432,26 +3402,6 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",

--- a/src/init.rs
+++ b/src/init.rs
@@ -22,6 +22,18 @@ pub enum TemplateSource {
     Default,
 }
 
+impl TemplateSource {
+    /// Returns a human-readable provenance notice for the template source,
+    /// or `None` for the built-in default (which needs no announcement).
+    pub fn notice(&self) -> Option<String> {
+        match self {
+            Self::Flag(p) => Some(format!("Using template: {}", p.display())),
+            Self::UserConfig(p) => Some(format!("Using user config template: {}", p.display())),
+            Self::Default => None,
+        }
+    }
+}
+
 /// Check XDG paths for a user-level config template.
 ///
 /// Resolution order:
@@ -72,24 +84,47 @@ pub fn resolve_user_config_path_from(
 /// 2. XDG user config → read file, validate, warn + fallback on failure
 /// 3. `DEFAULT_CONFIG`
 pub fn resolve_config_template(template_path: Option<&Path>) -> Result<(String, TemplateSource)> {
+    resolve_config_template_with(template_path, resolve_user_config_path())
+}
+
+/// Testable inner function that accepts the user config path explicitly so tests
+/// don't race on `std::env`.
+pub(crate) fn resolve_config_template_with(
+    template_path: Option<&Path>,
+    user_config_path: Option<PathBuf>,
+) -> Result<(String, TemplateSource)> {
     // 1. Explicit --template flag
     if let Some(path) = template_path {
         let content = fs::read_to_string(path)
             .with_context(|| format!("Failed to read template file: {}", path.display()))?;
 
         // Validate as Config (full deserialization)
-        toml::from_str::<Config>(&content)
+        let config: Config = toml::from_str(&content)
             .with_context(|| format!("Invalid template file: {}", path.display()))?;
+
+        if config.agents.is_empty() {
+            anyhow::bail!(
+                "Template file defines no agents: {}. \
+                 Add at least one [agents.<name>] section.",
+                path.display()
+            );
+        }
 
         return Ok((content, TemplateSource::Flag(path.to_path_buf())));
     }
 
     // 2. XDG auto-discovery
-    if let Some(user_path) = resolve_user_config_path() {
+    if let Some(user_path) = user_config_path {
         match fs::read_to_string(&user_path) {
             Ok(content) => match toml::from_str::<Config>(&content) {
-                Ok(_) => {
+                Ok(config) if !config.agents.is_empty() => {
                     return Ok((content, TemplateSource::UserConfig(user_path)));
+                }
+                Ok(_) => {
+                    tracing::warn!(
+                        path = %user_path.display(),
+                        "User config template defines no agents; falling back to default"
+                    );
                 }
                 Err(e) => {
                     tracing::warn!(
@@ -1765,18 +1800,8 @@ pub fn init_wizard(project_root: &Path, force: bool, template_path: Option<&Path
 
     // Resolve template content once for all code paths
     let (resolved_content, resolved_source) = resolve_config_template(template_path)?;
-    match &resolved_source {
-        TemplateSource::Flag(p) => {
-            println!("  {} Using template: {}", "✔".green(), p.display());
-        }
-        TemplateSource::UserConfig(p) => {
-            println!(
-                "  {} Using user config template: {}",
-                "✔".green(),
-                p.display()
-            );
-        }
-        TemplateSource::Default => {}
+    if let Some(notice) = resolved_source.notice() {
+        println!("  {} {notice}", "✔".green());
     }
 
     // Scan for existing agent files
@@ -4503,6 +4528,29 @@ type = "symlink"
     }
 
     #[test]
+    fn test_resolve_config_template_explicit_no_agents_errors() {
+        let temp_dir = TempDir::new().unwrap();
+        let template_path = temp_dir.path().join("empty.toml");
+        fs::write(&template_path, "source_dir = \".agents\"\n").unwrap();
+
+        let result = resolve_config_template(Some(&template_path));
+        assert!(result.is_err());
+        let err_msg = format!("{:#}", result.unwrap_err());
+        assert!(err_msg.contains("defines no agents"));
+    }
+
+    #[test]
+    fn test_resolve_config_template_user_config_no_agents_falls_back() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("config.toml");
+        fs::write(&config_path, "source_dir = \".agents\"\n").unwrap();
+
+        let (content, source) = resolve_config_template_with(None, Some(config_path)).unwrap();
+        assert_eq!(content, DEFAULT_CONFIG);
+        assert_eq!(source, TemplateSource::Default);
+    }
+
+    #[test]
     fn test_resolve_config_template_explicit_invalid_toml() {
         let temp_dir = TempDir::new().unwrap();
         let template_path = temp_dir.path().join("bad.toml");
@@ -4516,25 +4564,8 @@ type = "symlink"
 
     #[test]
     fn test_resolve_config_template_no_flag_no_xdg_returns_default() {
-        // Temporarily override env to ensure no XDG/HOME discovery
-        let orig_xdg = std::env::var("XDG_CONFIG_HOME").ok();
-        let orig_home = std::env::var("HOME").ok();
-        unsafe {
-            std::env::set_var("XDG_CONFIG_HOME", "/nonexistent-xdg-test-path");
-            std::env::set_var("HOME", "/nonexistent-home-test-path");
-        }
-
-        let (content, source) = resolve_config_template(None).unwrap();
-
-        // Restore
-        match orig_xdg {
-            Some(v) => unsafe { std::env::set_var("XDG_CONFIG_HOME", v) },
-            None => unsafe { std::env::remove_var("XDG_CONFIG_HOME") },
-        }
-        match orig_home {
-            Some(v) => unsafe { std::env::set_var("HOME", v) },
-            None => unsafe { std::env::remove_var("HOME") },
-        }
+        // No flag, no user config → built-in default
+        let (content, source) = resolve_config_template_with(None, None).unwrap();
 
         assert_eq!(content, DEFAULT_CONFIG);
         assert_eq!(source, TemplateSource::Default);
@@ -4559,17 +4590,9 @@ type = "symlink"
 "#;
         fs::write(&config_path, template_content).unwrap();
 
-        let orig_xdg = std::env::var("XDG_CONFIG_HOME").ok();
-        unsafe {
-            std::env::set_var("XDG_CONFIG_HOME", temp_dir.path());
-        }
-
-        let (content, source) = resolve_config_template(None).unwrap();
-
-        match orig_xdg {
-            Some(v) => unsafe { std::env::set_var("XDG_CONFIG_HOME", v) },
-            None => unsafe { std::env::remove_var("XDG_CONFIG_HOME") },
-        }
+        // Pure DI — pass the discovered path directly, no env mutation.
+        let (content, source) =
+            resolve_config_template_with(None, Some(config_path.clone())).unwrap();
 
         assert_eq!(content, template_content);
         assert_eq!(source, TemplateSource::UserConfig(config_path));
@@ -4583,23 +4606,8 @@ type = "symlink"
         let config_path = xdg_dir.join("config.toml");
         fs::write(&config_path, "this is not { valid toml").unwrap();
 
-        let orig_xdg = std::env::var("XDG_CONFIG_HOME").ok();
-        let orig_home = std::env::var("HOME").ok();
-        unsafe {
-            std::env::set_var("XDG_CONFIG_HOME", temp_dir.path());
-            std::env::set_var("HOME", "/nonexistent-home-test-path");
-        }
-
-        let (content, source) = resolve_config_template(None).unwrap();
-
-        match orig_xdg {
-            Some(v) => unsafe { std::env::set_var("XDG_CONFIG_HOME", v) },
-            None => unsafe { std::env::remove_var("XDG_CONFIG_HOME") },
-        }
-        match orig_home {
-            Some(v) => unsafe { std::env::set_var("HOME", v) },
-            None => unsafe { std::env::remove_var("HOME") },
-        }
+        // Pass invalid file directly — no env mutation needed.
+        let (content, source) = resolve_config_template_with(None, Some(config_path)).unwrap();
 
         assert_eq!(content, DEFAULT_CONFIG);
         assert_eq!(source, TemplateSource::Default);

--- a/src/init.rs
+++ b/src/init.rs
@@ -6,10 +6,94 @@ use anyhow::{Context, Result};
 use std::collections::BTreeMap;
 use std::fs;
 use std::io::{self, IsTerminal};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::config::{Config, SyncType, TargetConfig};
 use crate::skills_layout::{detect_skills_layout_match, detect_skills_mode_mismatch};
+
+/// Indicates where the config template content was resolved from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TemplateSource {
+    /// Explicit `--template <path>` flag.
+    Flag(PathBuf),
+    /// Auto-discovered from XDG config path.
+    UserConfig(PathBuf),
+    /// Built-in `DEFAULT_CONFIG` constant.
+    Default,
+}
+
+/// Check XDG paths for a user-level config template.
+///
+/// Resolution order:
+/// 1. `$XDG_CONFIG_HOME/agentsync/config.toml`
+/// 2. `$HOME/.config/agentsync/config.toml`
+///
+/// Returns `None` if neither path exists.
+pub fn resolve_user_config_path() -> Option<PathBuf> {
+    if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
+        let p = PathBuf::from(xdg).join("agentsync").join("config.toml");
+        if p.exists() {
+            return Some(p);
+        }
+    }
+    if let Ok(home) = std::env::var("HOME") {
+        let p = PathBuf::from(home)
+            .join(".config")
+            .join("agentsync")
+            .join("config.toml");
+        if p.exists() {
+            return Some(p);
+        }
+    }
+    None
+}
+
+/// Resolve config template content by precedence:
+///
+/// 1. Explicit `--template` path → read file, validate as Config, hard-error on failure
+/// 2. XDG user config → read file, validate, warn + fallback on failure
+/// 3. `DEFAULT_CONFIG`
+pub fn resolve_config_template(template_path: Option<&Path>) -> Result<(String, TemplateSource)> {
+    // 1. Explicit --template flag
+    if let Some(path) = template_path {
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("Failed to read template file: {}", path.display()))?;
+
+        // Validate as Config (full deserialization)
+        toml::from_str::<Config>(&content)
+            .with_context(|| format!("Invalid template file: {}", path.display()))?;
+
+        return Ok((content, TemplateSource::Flag(path.to_path_buf())));
+    }
+
+    // 2. XDG auto-discovery
+    if let Some(user_path) = resolve_user_config_path() {
+        match fs::read_to_string(&user_path) {
+            Ok(content) => match toml::from_str::<Config>(&content) {
+                Ok(_) => {
+                    return Ok((content, TemplateSource::UserConfig(user_path)));
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        path = %user_path.display(),
+                        error = %e,
+                        "User config template is invalid TOML; falling back to default"
+                    );
+                }
+            },
+            Err(e) => {
+                tracing::warn!(
+                    path = %user_path.display(),
+                    error = %e,
+                    "Could not read user config template; falling back to default"
+                );
+            }
+        }
+    }
+
+    // 3. Default
+    Ok((DEFAULT_CONFIG.to_string(), TemplateSource::Default))
+}
 
 /// Default configuration template
 pub const DEFAULT_CONFIG: &str = r#"# AgentSync Configuration
@@ -194,7 +278,7 @@ pub const DEFAULT_AGENTS_MD: &str = r#"# AI Agent Instructions
 "#;
 
 /// Initialize a new configuration in the given directory
-pub fn init(project_root: &Path, force: bool) -> Result<()> {
+pub fn init(project_root: &Path, force: bool, config_content: &str) -> Result<()> {
     use colored::Colorize;
 
     let agents_dir = project_root.join(".agents");
@@ -241,7 +325,7 @@ pub fn init(project_root: &Path, force: bool) -> Result<()> {
             config_path.display()
         );
     } else {
-        fs::write(&config_path, DEFAULT_CONFIG)?;
+        fs::write(&config_path, config_content)?;
         println!("  {} Created: {}", "✔".green(), config_path.display());
     }
 
@@ -1072,11 +1156,14 @@ fn select_wizard_skills_modes<R: InitWizardRenderer>(
     Ok(skills_modes)
 }
 
-fn build_default_config_with_skills_modes(modes: &BTreeMap<String, SyncType>) -> String {
+fn build_default_config_with_skills_modes(
+    base_config: &str,
+    modes: &BTreeMap<String, SyncType>,
+) -> String {
     let mut rendered = Vec::new();
     let mut current_skills_agent: Option<String> = None;
 
-    for line in DEFAULT_CONFIG.lines() {
+    for line in base_config.lines() {
         if let Some(agent_name) = parse_skills_section_agent(line) {
             current_skills_agent = Some(agent_name.to_string());
             rendered.push(line.to_string());
@@ -1100,7 +1187,7 @@ fn build_default_config_with_skills_modes(modes: &BTreeMap<String, SyncType>) ->
     }
 
     let mut output = rendered.join("\n");
-    if DEFAULT_CONFIG.ends_with('\n') {
+    if base_config.ends_with('\n') {
         output.push('\n');
     }
     output
@@ -1460,7 +1547,11 @@ fn missing_terminal_tui_error(reason: &str) -> Option<String> {
     }
 }
 
-pub fn init_wizard_experimental_tui(project_root: &Path, force: bool) -> Result<()> {
+pub fn init_wizard_experimental_tui(
+    project_root: &Path,
+    force: bool,
+    template_path: Option<&Path>,
+) -> Result<()> {
     use colored::Colorize;
 
     match experimental_tui_context_from_env() {
@@ -1493,7 +1584,7 @@ pub fn init_wizard_experimental_tui(project_root: &Path, force: bool) -> Result<
         }
     }
 
-    init_wizard(project_root, force)
+    init_wizard(project_root, force, template_path)
 }
 
 fn render_experimental_tui_intro_frame(frame: &mut ratatui::Frame<'_>) {
@@ -1580,7 +1671,7 @@ fn run_experimental_tui_intro() -> Result<ExperimentalTuiIntroOutcome> {
 }
 
 /// Interactive wizard for initializing agentsync with file migration
-pub fn init_wizard(project_root: &Path, force: bool) -> Result<()> {
+pub fn init_wizard(project_root: &Path, force: bool, template_path: Option<&Path>) -> Result<()> {
     use colored::Colorize;
     use dialoguer::{Confirm, MultiSelect, Select, theme::ColorfulTheme};
 
@@ -1654,6 +1745,22 @@ pub fn init_wizard(project_root: &Path, force: bool) -> Result<()> {
         }
     }
 
+    // Resolve template content once for all code paths
+    let (resolved_content, resolved_source) = resolve_config_template(template_path)?;
+    match &resolved_source {
+        TemplateSource::Flag(p) => {
+            println!("  {} Using template: {}", "✔".green(), p.display());
+        }
+        TemplateSource::UserConfig(p) => {
+            println!(
+                "  {} Using user config template: {}",
+                "✔".green(),
+                p.display()
+            );
+        }
+        TemplateSource::Default => {}
+    }
+
     // Scan for existing agent files
     println!("{}", "🔍 Scanning for existing agent files...".cyan());
     let discovered_files = scan_agent_files(project_root)?;
@@ -1664,7 +1771,7 @@ pub fn init_wizard(project_root: &Path, force: bool) -> Result<()> {
             "{}",
             "  Proceeding with standard initialization...".dimmed()
         );
-        return init(project_root, force);
+        return init(project_root, force, &resolved_content);
     }
 
     println!("  {} Found {} file(s)", "✔".green(), discovered_files.len());
@@ -1683,7 +1790,7 @@ pub fn init_wizard(project_root: &Path, force: bool) -> Result<()> {
             "{}",
             "  Skipping migration. Creating standard configuration...".dimmed()
         );
-        return init(project_root, force);
+        return init(project_root, force, &resolved_content);
     };
 
     if files_to_migrate.is_empty() {
@@ -1692,7 +1799,7 @@ pub fn init_wizard(project_root: &Path, force: bool) -> Result<()> {
             "{}",
             "  Proceeding with standard initialization...".dimmed()
         );
-        return init(project_root, force);
+        return init(project_root, force, &resolved_content);
     }
 
     // Create .agents directory structure
@@ -1735,7 +1842,7 @@ pub fn init_wizard(project_root: &Path, force: bool) -> Result<()> {
     let skills_modes =
         select_wizard_skills_modes(&mut renderer, &skills_choices, can_write_config)?;
 
-    let rendered_config = build_default_config_with_skills_modes(&skills_modes);
+    let rendered_config = build_default_config_with_skills_modes(&resolved_content, &skills_modes);
     let layout_facts = build_wizard_layout_facts(&rendered_config)?;
     let layout_block = render_agent_config_layout_section(&layout_facts);
 
@@ -2250,7 +2357,7 @@ mod tests {
     fn test_init_creates_agents_directory() {
         let temp_dir = TempDir::new().unwrap();
 
-        init(temp_dir.path(), false).unwrap();
+        init(temp_dir.path(), false, DEFAULT_CONFIG).unwrap();
 
         let agents_dir = temp_dir.path().join(".agents");
         assert!(agents_dir.exists());
@@ -2261,7 +2368,7 @@ mod tests {
     fn test_init_creates_skills_directory() {
         let temp_dir = TempDir::new().unwrap();
 
-        init(temp_dir.path(), false).unwrap();
+        init(temp_dir.path(), false, DEFAULT_CONFIG).unwrap();
 
         let skills_dir = temp_dir.path().join(".agents").join("skills");
         assert!(skills_dir.exists());
@@ -2272,7 +2379,7 @@ mod tests {
     fn test_init_creates_config_file() {
         let temp_dir = TempDir::new().unwrap();
 
-        init(temp_dir.path(), false).unwrap();
+        init(temp_dir.path(), false, DEFAULT_CONFIG).unwrap();
 
         let config_path = temp_dir.path().join(".agents").join("agentsync.toml");
         assert!(config_path.exists());
@@ -2288,7 +2395,7 @@ mod tests {
     fn test_init_creates_agents_md() {
         let temp_dir = TempDir::new().unwrap();
 
-        init(temp_dir.path(), false).unwrap();
+        init(temp_dir.path(), false, DEFAULT_CONFIG).unwrap();
 
         let agents_md_path = temp_dir.path().join(".agents").join("AGENTS.md");
         assert!(agents_md_path.exists());
@@ -2314,7 +2421,7 @@ mod tests {
         fs::write(&agents_md_path, original_agents).unwrap();
 
         // Init without force
-        init(temp_dir.path(), false).unwrap();
+        init(temp_dir.path(), false, DEFAULT_CONFIG).unwrap();
 
         // Files should NOT be overwritten
         assert_eq!(fs::read_to_string(&config_path).unwrap(), original_config);
@@ -2338,7 +2445,7 @@ mod tests {
         fs::write(&agents_md_path, "# Old agents").unwrap();
 
         // Init WITH force
-        init(temp_dir.path(), true).unwrap();
+        init(temp_dir.path(), true, DEFAULT_CONFIG).unwrap();
 
         // Files SHOULD be overwritten with default content
         let config_content = fs::read_to_string(&config_path).unwrap();
@@ -2357,7 +2464,7 @@ mod tests {
         fs::create_dir_all(&agents_dir).unwrap();
 
         // Init should work even if .agents exists
-        let result = init(temp_dir.path(), false);
+        let result = init(temp_dir.path(), false, DEFAULT_CONFIG);
         assert!(result.is_ok());
 
         // Should still create files
@@ -2371,7 +2478,7 @@ mod tests {
         let nested_project = temp_dir.path().join("deep").join("nested").join("project");
         fs::create_dir_all(&nested_project).unwrap();
 
-        init(&nested_project, false).unwrap();
+        init(&nested_project, false, DEFAULT_CONFIG).unwrap();
 
         let agents_dir = nested_project.join(".agents");
         assert!(agents_dir.exists());
@@ -3954,7 +4061,7 @@ mod tests {
         let mut modes = BTreeMap::new();
         modes.insert("claude".to_string(), SyncType::SymlinkContents);
 
-        let rendered = build_default_config_with_skills_modes(&modes);
+        let rendered = build_default_config_with_skills_modes(DEFAULT_CONFIG, &modes);
         let config: crate::config::Config = toml::from_str(&rendered).unwrap();
 
         assert_eq!(
@@ -3976,7 +4083,7 @@ mod tests {
         let mut modes = BTreeMap::new();
         modes.insert("gemini".to_string(), SyncType::SymlinkContents);
 
-        let rendered = build_default_config_with_skills_modes(&modes);
+        let rendered = build_default_config_with_skills_modes(DEFAULT_CONFIG, &modes);
         let facts = build_wizard_layout_facts(&rendered).unwrap();
 
         assert_eq!(facts.instructions.len(), 5);
@@ -4086,7 +4193,7 @@ mod tests {
 
     #[test]
     fn test_agent_config_layout_omits_targets_not_present_in_generated_config() {
-        let rendered = build_default_config_with_skills_modes(&BTreeMap::new())
+        let rendered = build_default_config_with_skills_modes(DEFAULT_CONFIG, &BTreeMap::new())
             .replace(
                 r#"
 [agents.copilot.targets.instructions]
@@ -4151,8 +4258,11 @@ type = "symlink-contents"
     #[test]
     fn test_upsert_agent_config_layout_block_places_block_after_default_intro() {
         let layout_block = render_agent_config_layout_section(
-            &build_wizard_layout_facts(&build_default_config_with_skills_modes(&BTreeMap::new()))
-                .unwrap(),
+            &build_wizard_layout_facts(&build_default_config_with_skills_modes(
+                DEFAULT_CONFIG,
+                &BTreeMap::new(),
+            ))
+            .unwrap(),
         );
 
         let rendered = upsert_agent_config_layout_block(DEFAULT_AGENTS_MD, &layout_block);
@@ -4170,8 +4280,11 @@ type = "symlink-contents"
     fn test_upsert_agent_config_layout_block_places_block_after_migrated_header() {
         let base_content = "# Instructions from CLAUDE.md\n\nThis content was migrated.\n\n## Existing Section\n\nBody\n";
         let layout_block = render_agent_config_layout_section(
-            &build_wizard_layout_facts(&build_default_config_with_skills_modes(&BTreeMap::new()))
-                .unwrap(),
+            &build_wizard_layout_facts(&build_default_config_with_skills_modes(
+                DEFAULT_CONFIG,
+                &BTreeMap::new(),
+            ))
+            .unwrap(),
         );
 
         let rendered = upsert_agent_config_layout_block(base_content, &layout_block);
@@ -4191,8 +4304,11 @@ type = "symlink-contents"
         let base_content =
             format!("# AI Agent Instructions\n\n> Intro\n\n{old_layout}\n\n## Project Overview\n");
         let layout_block = render_agent_config_layout_section(
-            &build_wizard_layout_facts(&build_default_config_with_skills_modes(&BTreeMap::new()))
-                .unwrap(),
+            &build_wizard_layout_facts(&build_default_config_with_skills_modes(
+                DEFAULT_CONFIG,
+                &BTreeMap::new(),
+            ))
+            .unwrap(),
         );
 
         let rendered_once = upsert_agent_config_layout_block(&base_content, &layout_block);
@@ -4230,6 +4346,7 @@ type = "symlink-contents"
         } else {
             let layout_block = render_agent_config_layout_section(
                 &build_wizard_layout_facts(&build_default_config_with_skills_modes(
+                    DEFAULT_CONFIG,
                     &BTreeMap::new(),
                 ))
                 .unwrap(),
@@ -4247,14 +4364,18 @@ type = "symlink-contents"
         use std::os::unix::fs as unix_fs;
 
         let temp_dir = TempDir::new().unwrap();
-        init(temp_dir.path(), false).unwrap();
+        init(temp_dir.path(), false, DEFAULT_CONFIG).unwrap();
         fs::create_dir_all(temp_dir.path().join(".claude")).unwrap();
         unix_fs::symlink("../.agents/skills", temp_dir.path().join(".claude/skills")).unwrap();
 
         let mut modes = BTreeMap::new();
         modes.insert("claude".to_string(), SyncType::SymlinkContents);
         let config_path = temp_dir.path().join(".agents/agentsync.toml");
-        fs::write(&config_path, build_default_config_with_skills_modes(&modes)).unwrap();
+        fs::write(
+            &config_path,
+            build_default_config_with_skills_modes(DEFAULT_CONFIG, &modes),
+        )
+        .unwrap();
 
         let warnings = collect_post_init_skills_warnings(
             temp_dir.path(),
@@ -4274,14 +4395,14 @@ type = "symlink-contents"
         use std::os::unix::fs as unix_fs;
 
         let temp_dir = TempDir::new().unwrap();
-        init(temp_dir.path(), false).unwrap();
+        init(temp_dir.path(), false, DEFAULT_CONFIG).unwrap();
         fs::create_dir_all(temp_dir.path().join(".claude")).unwrap();
         unix_fs::symlink("../.agents/skills", temp_dir.path().join(".claude/skills")).unwrap();
 
         let config_path = temp_dir.path().join(".agents/agentsync.toml");
         fs::write(
             &config_path,
-            build_default_config_with_skills_modes(&BTreeMap::new()),
+            build_default_config_with_skills_modes(DEFAULT_CONFIG, &BTreeMap::new()),
         )
         .unwrap();
 
@@ -4299,7 +4420,7 @@ type = "symlink-contents"
     fn test_init_creates_commands_directory() {
         let temp_dir = TempDir::new().unwrap();
 
-        init(temp_dir.path(), false).unwrap();
+        init(temp_dir.path(), false, DEFAULT_CONFIG).unwrap();
 
         let commands_dir = temp_dir.path().join(".agents").join("commands");
         assert!(commands_dir.exists());
@@ -4327,5 +4448,367 @@ type = "symlink-contents"
             .any(|f| f.file_type == AgentFileType::CursorSkills);
         assert!(has_dir);
         assert!(has_skills);
+    }
+
+    // ==========================================================================
+    // TEMPLATE RESOLUTION TESTS
+    // ==========================================================================
+
+    #[test]
+    fn test_resolve_config_template_explicit_valid_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let template_path = temp_dir.path().join("custom.toml");
+        let template_content = r#"
+source_dir = ".agents"
+
+[agents.claude]
+enabled = true
+
+[agents.claude.targets.instructions]
+source = "AGENTS.md"
+destination = "CLAUDE.md"
+type = "symlink"
+"#;
+        fs::write(&template_path, template_content).unwrap();
+
+        let (content, source) = resolve_config_template(Some(&template_path)).unwrap();
+        assert_eq!(content, template_content);
+        assert_eq!(source, TemplateSource::Flag(template_path));
+    }
+
+    #[test]
+    fn test_resolve_config_template_explicit_missing_file() {
+        let result = resolve_config_template(Some(Path::new("/nonexistent/missing.toml")));
+        assert!(result.is_err());
+        let err_msg = format!("{:#}", result.unwrap_err());
+        assert!(err_msg.contains("/nonexistent/missing.toml"));
+    }
+
+    #[test]
+    fn test_resolve_config_template_explicit_invalid_toml() {
+        let temp_dir = TempDir::new().unwrap();
+        let template_path = temp_dir.path().join("bad.toml");
+        fs::write(&template_path, "this is not { valid toml").unwrap();
+
+        let result = resolve_config_template(Some(&template_path));
+        assert!(result.is_err());
+        let err_msg = format!("{:#}", result.unwrap_err());
+        assert!(err_msg.contains("bad.toml"));
+    }
+
+    #[test]
+    fn test_resolve_config_template_no_flag_no_xdg_returns_default() {
+        // Temporarily override env to ensure no XDG/HOME discovery
+        let orig_xdg = std::env::var("XDG_CONFIG_HOME").ok();
+        let orig_home = std::env::var("HOME").ok();
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", "/nonexistent-xdg-test-path");
+            std::env::set_var("HOME", "/nonexistent-home-test-path");
+        }
+
+        let (content, source) = resolve_config_template(None).unwrap();
+
+        // Restore
+        match orig_xdg {
+            Some(v) => unsafe { std::env::set_var("XDG_CONFIG_HOME", v) },
+            None => unsafe { std::env::remove_var("XDG_CONFIG_HOME") },
+        }
+        match orig_home {
+            Some(v) => unsafe { std::env::set_var("HOME", v) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+
+        assert_eq!(content, DEFAULT_CONFIG);
+        assert_eq!(source, TemplateSource::Default);
+    }
+
+    #[test]
+    fn test_resolve_config_template_xdg_config_home_valid() {
+        let temp_dir = TempDir::new().unwrap();
+        let xdg_dir = temp_dir.path().join("agentsync");
+        fs::create_dir_all(&xdg_dir).unwrap();
+        let config_path = xdg_dir.join("config.toml");
+        let template_content = r#"
+source_dir = ".agents"
+
+[agents.claude]
+enabled = true
+
+[agents.claude.targets.instructions]
+source = "AGENTS.md"
+destination = "CLAUDE.md"
+type = "symlink"
+"#;
+        fs::write(&config_path, template_content).unwrap();
+
+        let orig_xdg = std::env::var("XDG_CONFIG_HOME").ok();
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", temp_dir.path());
+        }
+
+        let (content, source) = resolve_config_template(None).unwrap();
+
+        match orig_xdg {
+            Some(v) => unsafe { std::env::set_var("XDG_CONFIG_HOME", v) },
+            None => unsafe { std::env::remove_var("XDG_CONFIG_HOME") },
+        }
+
+        assert_eq!(content, template_content);
+        assert_eq!(source, TemplateSource::UserConfig(config_path));
+    }
+
+    #[test]
+    fn test_resolve_config_template_xdg_invalid_warns_and_falls_back() {
+        let temp_dir = TempDir::new().unwrap();
+        let xdg_dir = temp_dir.path().join("agentsync");
+        fs::create_dir_all(&xdg_dir).unwrap();
+        let config_path = xdg_dir.join("config.toml");
+        fs::write(&config_path, "this is not { valid toml").unwrap();
+
+        let orig_xdg = std::env::var("XDG_CONFIG_HOME").ok();
+        let orig_home = std::env::var("HOME").ok();
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", temp_dir.path());
+            std::env::set_var("HOME", "/nonexistent-home-test-path");
+        }
+
+        let (content, source) = resolve_config_template(None).unwrap();
+
+        match orig_xdg {
+            Some(v) => unsafe { std::env::set_var("XDG_CONFIG_HOME", v) },
+            None => unsafe { std::env::remove_var("XDG_CONFIG_HOME") },
+        }
+        match orig_home {
+            Some(v) => unsafe { std::env::set_var("HOME", v) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+
+        assert_eq!(content, DEFAULT_CONFIG);
+        assert_eq!(source, TemplateSource::Default);
+    }
+
+    #[test]
+    fn test_resolve_config_template_flag_overrides_xdg() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // Set up XDG config
+        let xdg_dir = temp_dir.path().join("xdg").join("agentsync");
+        fs::create_dir_all(&xdg_dir).unwrap();
+        let xdg_config = xdg_dir.join("config.toml");
+        fs::write(
+            &xdg_config,
+            r#"
+source_dir = ".agents"
+[agents.xdg_agent]
+enabled = true
+[agents.xdg_agent.targets.instructions]
+source = "AGENTS.md"
+destination = "XDG.md"
+type = "symlink"
+"#,
+        )
+        .unwrap();
+
+        // Set up explicit template
+        let flag_template = temp_dir.path().join("flag.toml");
+        let flag_content = r#"
+source_dir = ".agents"
+[agents.flag_agent]
+enabled = true
+[agents.flag_agent.targets.instructions]
+source = "AGENTS.md"
+destination = "FLAG.md"
+type = "symlink"
+"#;
+        fs::write(&flag_template, flag_content).unwrap();
+
+        let orig_xdg = std::env::var("XDG_CONFIG_HOME").ok();
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", temp_dir.path().join("xdg"));
+        }
+
+        let (content, source) = resolve_config_template(Some(&flag_template)).unwrap();
+
+        match orig_xdg {
+            Some(v) => unsafe { std::env::set_var("XDG_CONFIG_HOME", v) },
+            None => unsafe { std::env::remove_var("XDG_CONFIG_HOME") },
+        }
+
+        assert_eq!(content, flag_content);
+        assert_eq!(source, TemplateSource::Flag(flag_template));
+    }
+
+    #[test]
+    fn test_resolve_user_config_path_xdg_config_home() {
+        let temp_dir = TempDir::new().unwrap();
+        let xdg_dir = temp_dir.path().join("agentsync");
+        fs::create_dir_all(&xdg_dir).unwrap();
+        let config_path = xdg_dir.join("config.toml");
+        fs::write(&config_path, "placeholder").unwrap();
+
+        let orig = std::env::var("XDG_CONFIG_HOME").ok();
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", temp_dir.path());
+        }
+
+        let result = resolve_user_config_path();
+
+        match orig {
+            Some(v) => unsafe { std::env::set_var("XDG_CONFIG_HOME", v) },
+            None => unsafe { std::env::remove_var("XDG_CONFIG_HOME") },
+        }
+
+        assert_eq!(result, Some(config_path));
+    }
+
+    #[test]
+    fn test_resolve_user_config_path_home_fallback() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_dir = temp_dir.path().join(".config").join("agentsync");
+        fs::create_dir_all(&config_dir).unwrap();
+        let config_path = config_dir.join("config.toml");
+        fs::write(&config_path, "placeholder").unwrap();
+
+        let orig_xdg = std::env::var("XDG_CONFIG_HOME").ok();
+        let orig_home = std::env::var("HOME").ok();
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", "/nonexistent-xdg-path-for-test");
+            std::env::set_var("HOME", temp_dir.path());
+        }
+
+        let result = resolve_user_config_path();
+
+        match orig_xdg {
+            Some(v) => unsafe { std::env::set_var("XDG_CONFIG_HOME", v) },
+            None => unsafe { std::env::remove_var("XDG_CONFIG_HOME") },
+        }
+        match orig_home {
+            Some(v) => unsafe { std::env::set_var("HOME", v) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+
+        assert_eq!(result, Some(config_path));
+    }
+
+    #[test]
+    fn test_resolve_user_config_path_none_when_no_env() {
+        let orig_xdg = std::env::var("XDG_CONFIG_HOME").ok();
+        let orig_home = std::env::var("HOME").ok();
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", "/nonexistent-xdg-path-for-test");
+            std::env::set_var("HOME", "/nonexistent-home-path-for-test");
+        }
+
+        let result = resolve_user_config_path();
+
+        match orig_xdg {
+            Some(v) => unsafe { std::env::set_var("XDG_CONFIG_HOME", v) },
+            None => unsafe { std::env::remove_var("XDG_CONFIG_HOME") },
+        }
+        match orig_home {
+            Some(v) => unsafe { std::env::set_var("HOME", v) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_build_default_config_with_skills_modes_custom_base() {
+        let base = r#"source_dir = ".agents"
+
+[agents.claude]
+enabled = true
+
+[agents.claude.targets.skills]
+source = "skills"
+destination = ".claude/skills"
+type = "symlink"
+"#;
+        let mut modes = BTreeMap::new();
+        modes.insert("claude".to_string(), SyncType::SymlinkContents);
+
+        let rendered = build_default_config_with_skills_modes(base, &modes);
+        assert!(rendered.contains("type = \"symlink-contents\""));
+        assert!(rendered.contains("[agents.claude]"));
+    }
+
+    #[test]
+    fn test_wizard_template_flow_end_to_end() {
+        // Integration: template resolution → wizard processing → init write
+        let temp_dir = TempDir::new().unwrap();
+        let project_root = temp_dir.path().join("project");
+        fs::create_dir_all(&project_root).unwrap();
+
+        // 1. Create a custom template with only claude agent and default_agents
+        let template_path = temp_dir.path().join("template.toml");
+        let template_content = r#"source_dir = ".agents"
+default_agents = ["claude"]
+
+[agents.claude]
+enabled = true
+
+[agents.claude.targets.instructions]
+source = "AGENTS.md"
+destination = "CLAUDE.md"
+type = "symlink"
+"#;
+        fs::write(&template_path, template_content).unwrap();
+
+        // 2. Resolve the template
+        let (resolved_content, source) = resolve_config_template(Some(&template_path)).unwrap();
+        assert_eq!(source, TemplateSource::Flag(template_path.clone()));
+
+        // 3. Simulate wizard processing (skills modes from wizard choices)
+        let skills_modes = BTreeMap::new();
+        let rendered = build_default_config_with_skills_modes(&resolved_content, &skills_modes);
+
+        // 4. Write via init()
+        init(&project_root, false, &rendered).unwrap();
+
+        // 5. Verify written config contains ONLY template agents
+        let config_path = project_root.join(".agents").join("agentsync.toml");
+        let written = fs::read_to_string(&config_path).unwrap();
+        assert!(
+            written.contains("[agents.claude]"),
+            "written config must contain claude agent"
+        );
+        assert!(
+            !written.contains("[agents.copilot]"),
+            "written config must NOT contain default copilot agent"
+        );
+        assert!(
+            !written.contains("[agents.cursor]"),
+            "written config must NOT contain default cursor agent"
+        );
+
+        // 6. Verify default_agents is preserved
+        assert!(
+            written.contains("default_agents"),
+            "default_agents key must be preserved from template"
+        );
+    }
+
+    #[test]
+    fn test_init_with_config_content() {
+        let temp_dir = TempDir::new().unwrap();
+        let custom_content = r#"source_dir = ".agents"
+
+[agents.claude]
+enabled = true
+
+[agents.claude.targets.instructions]
+source = "AGENTS.md"
+destination = "CLAUDE.md"
+type = "symlink"
+"#;
+
+        init(temp_dir.path(), false, custom_content).unwrap();
+
+        let config_path = temp_dir.path().join(".agents").join("agentsync.toml");
+        let written = fs::read_to_string(&config_path).unwrap();
+        assert_eq!(written, custom_content);
+        // Should NOT contain default agents like copilot
+        assert!(!written.contains("[agents.copilot]"));
     }
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -29,18 +29,36 @@ pub enum TemplateSource {
 /// 2. `$HOME/.config/agentsync/config.toml`
 ///
 /// Returns `None` if neither path exists.
+///
+/// This wrapper reads the process environment and delegates to
+/// [`resolve_user_config_path_from`], which is the pure, testable logic.
 pub fn resolve_user_config_path() -> Option<PathBuf> {
-    if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
-        let p = PathBuf::from(xdg).join("agentsync").join("config.toml");
+    resolve_user_config_path_from(
+        std::env::var("XDG_CONFIG_HOME")
+            .ok()
+            .map(PathBuf::from)
+            .as_deref(),
+        std::env::var("HOME").ok().map(PathBuf::from).as_deref(),
+    )
+}
+
+/// Pure resolution of the user-level config template path.
+///
+/// Takes the XDG config home and the home directory as explicit parameters so
+/// tests can exercise the logic without mutating the process environment
+/// (parallel tests must never race on `std::env`).
+pub fn resolve_user_config_path_from(
+    xdg_config_home: Option<&Path>,
+    home: Option<&Path>,
+) -> Option<PathBuf> {
+    if let Some(xdg) = xdg_config_home {
+        let p = xdg.join("agentsync").join("config.toml");
         if p.exists() {
             return Some(p);
         }
     }
-    if let Ok(home) = std::env::var("HOME") {
-        let p = PathBuf::from(home)
-            .join(".config")
-            .join("agentsync")
-            .join("config.toml");
+    if let Some(home) = home {
+        let p = home.join(".config").join("agentsync").join("config.toml");
         if p.exists() {
             return Some(p);
         }
@@ -4622,17 +4640,12 @@ type = "symlink"
 "#;
         fs::write(&flag_template, flag_content).unwrap();
 
-        let orig_xdg = std::env::var("XDG_CONFIG_HOME").ok();
-        unsafe {
-            std::env::set_var("XDG_CONFIG_HOME", temp_dir.path().join("xdg"));
-        }
+        // NOTE: no XDG/HOME env mutation here — `resolve_config_template` with
+        // an explicit flag returns before consulting user config, so the flag
+        // wins regardless of the environment. Mutating process env in parallel
+        // tests causes data races (see test_resolve_user_config_path_* below).
 
         let (content, source) = resolve_config_template(Some(&flag_template)).unwrap();
-
-        match orig_xdg {
-            Some(v) => unsafe { std::env::set_var("XDG_CONFIG_HOME", v) },
-            None => unsafe { std::env::remove_var("XDG_CONFIG_HOME") },
-        }
 
         assert_eq!(content, flag_content);
         assert_eq!(source, TemplateSource::Flag(flag_template));
@@ -4646,17 +4659,8 @@ type = "symlink"
         let config_path = xdg_dir.join("config.toml");
         fs::write(&config_path, "placeholder").unwrap();
 
-        let orig = std::env::var("XDG_CONFIG_HOME").ok();
-        unsafe {
-            std::env::set_var("XDG_CONFIG_HOME", temp_dir.path());
-        }
-
-        let result = resolve_user_config_path();
-
-        match orig {
-            Some(v) => unsafe { std::env::set_var("XDG_CONFIG_HOME", v) },
-            None => unsafe { std::env::remove_var("XDG_CONFIG_HOME") },
-        }
+        // Pure function — no process env mutation, no cross-test races.
+        let result = resolve_user_config_path_from(Some(temp_dir.path()), None);
 
         assert_eq!(result, Some(config_path));
     }
@@ -4669,48 +4673,27 @@ type = "symlink"
         let config_path = config_dir.join("config.toml");
         fs::write(&config_path, "placeholder").unwrap();
 
-        let orig_xdg = std::env::var("XDG_CONFIG_HOME").ok();
-        let orig_home = std::env::var("HOME").ok();
-        unsafe {
-            std::env::set_var("XDG_CONFIG_HOME", "/nonexistent-xdg-path-for-test");
-            std::env::set_var("HOME", temp_dir.path());
-        }
-
-        let result = resolve_user_config_path();
-
-        match orig_xdg {
-            Some(v) => unsafe { std::env::set_var("XDG_CONFIG_HOME", v) },
-            None => unsafe { std::env::remove_var("XDG_CONFIG_HOME") },
-        }
-        match orig_home {
-            Some(v) => unsafe { std::env::set_var("HOME", v) },
-            None => unsafe { std::env::remove_var("HOME") },
-        }
+        // XDG path does not exist → falls back to HOME.
+        let result = resolve_user_config_path_from(
+            Some(Path::new("/nonexistent-xdg-path-for-test")),
+            Some(temp_dir.path()),
+        );
 
         assert_eq!(result, Some(config_path));
     }
 
     #[test]
-    fn test_resolve_user_config_path_none_when_no_env() {
-        let orig_xdg = std::env::var("XDG_CONFIG_HOME").ok();
-        let orig_home = std::env::var("HOME").ok();
-        unsafe {
-            std::env::set_var("XDG_CONFIG_HOME", "/nonexistent-xdg-path-for-test");
-            std::env::set_var("HOME", "/nonexistent-home-path-for-test");
-        }
-
-        let result = resolve_user_config_path();
-
-        match orig_xdg {
-            Some(v) => unsafe { std::env::set_var("XDG_CONFIG_HOME", v) },
-            None => unsafe { std::env::remove_var("XDG_CONFIG_HOME") },
-        }
-        match orig_home {
-            Some(v) => unsafe { std::env::set_var("HOME", v) },
-            None => unsafe { std::env::remove_var("HOME") },
-        }
+    fn test_resolve_user_config_path_none_when_no_paths_exist() {
+        // Neither XDG nor HOME contain a config file → None.
+        let result = resolve_user_config_path_from(
+            Some(Path::new("/nonexistent-xdg-path-for-test")),
+            Some(Path::new("/nonexistent-home-path-for-test")),
+        );
 
         assert_eq!(result, None);
+
+        // No paths at all → None.
+        assert_eq!(resolve_user_config_path_from(None, None), None);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -338,6 +338,7 @@ enum Commands {
         )]
         experimental_tui: bool,
         #[arg(
+            short = 't',
             long,
             help = "Path to a TOML config template to use instead of the built-in default"
         )]
@@ -422,20 +423,9 @@ fn main() -> Result<()> {
             } else {
                 println!("{}", "Initializing agentsync configuration...\n".cyan());
                 let (config_content, source) = init::resolve_config_template(template.as_deref())?;
-                match &source {
-                    init::TemplateSource::Flag(p) => {
-                        use colored::Colorize;
-                        println!("  {} Using template: {}", "✔".green(), p.display());
-                    }
-                    init::TemplateSource::UserConfig(p) => {
-                        use colored::Colorize;
-                        println!(
-                            "  {} Using user config template: {}",
-                            "✔".green(),
-                            p.display()
-                        );
-                    }
-                    init::TemplateSource::Default => {}
+                if let Some(notice) = source.notice() {
+                    use colored::Colorize;
+                    println!("  {} {notice}", "✔".green());
                 }
                 init::init(&project_root, force, &config_content)?;
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -337,6 +337,11 @@ enum Commands {
             help = "Run the init wizard with an experimental full-screen TUI intro"
         )]
         experimental_tui: bool,
+        #[arg(
+            long,
+            help = "Path to a TOML config template to use instead of the built-in default"
+        )]
+        template: Option<PathBuf>,
     },
     /// Apply the configuration from agentsync.toml
     Apply {
@@ -400,6 +405,7 @@ fn main() -> Result<()> {
             force,
             wizard,
             experimental_tui,
+            template,
         } => {
             let project_root = path.unwrap_or_else(|| env::current_dir().unwrap());
             print_header();
@@ -409,13 +415,29 @@ fn main() -> Result<()> {
                     "Starting interactive configuration wizard...\n".cyan()
                 );
                 if experimental_tui {
-                    init::init_wizard_experimental_tui(&project_root, force)?;
+                    init::init_wizard_experimental_tui(&project_root, force, template.as_deref())?;
                 } else {
-                    init::init_wizard(&project_root, force)?;
+                    init::init_wizard(&project_root, force, template.as_deref())?;
                 }
             } else {
                 println!("{}", "Initializing agentsync configuration...\n".cyan());
-                init::init(&project_root, force)?;
+                let (config_content, source) = init::resolve_config_template(template.as_deref())?;
+                match &source {
+                    init::TemplateSource::Flag(p) => {
+                        use colored::Colorize;
+                        println!("  {} Using template: {}", "✔".green(), p.display());
+                    }
+                    init::TemplateSource::UserConfig(p) => {
+                        use colored::Colorize;
+                        println!(
+                            "  {} Using user config template: {}",
+                            "✔".green(),
+                            p.display()
+                        );
+                    }
+                    init::TemplateSource::Default => {}
+                }
+                init::init(&project_root, force, &config_content)?;
             }
             println!("\n{}", "✨ Initialization complete!".green().bold());
             if let Some(lines) = init_next_steps_lines(wizard) {

--- a/tests/test_agent_adoption.rs
+++ b/tests/test_agent_adoption.rs
@@ -86,7 +86,7 @@ fn test_adoption_claude_with_skills_and_instructions() -> Result<()> {
     );
 
     // 2. Run init (creates .agents/ structure)
-    agentsync::init::init(root, false)?;
+    agentsync::init::init(root, false, agentsync::init::DEFAULT_CONFIG)?;
 
     // 3. Simulate wizard migration: copy skills and commands into .agents/
     let agents_skills = root.join(".agents/skills");
@@ -182,7 +182,7 @@ fn test_adoption_gemini_with_skills_and_commands() -> Result<()> {
     create_file(root, ".gemini/commands/analyze.md", "# Analyze command");
 
     // 2. Init
-    agentsync::init::init(root, false)?;
+    agentsync::init::init(root, false, agentsync::init::DEFAULT_CONFIG)?;
 
     // 3. Simulate wizard migration
     let agents_skills = root.join(".agents/skills");
@@ -257,7 +257,7 @@ fn test_adoption_codex_with_skills() -> Result<()> {
     );
 
     // 2. Init
-    agentsync::init::init(root, false)?;
+    agentsync::init::init(root, false, agentsync::init::DEFAULT_CONFIG)?;
 
     // 3. Simulate wizard migration
     let agents_skills = root.join(".agents/skills");
@@ -325,7 +325,7 @@ fn test_adoption_multi_agent_claude_gemini_codex() -> Result<()> {
     );
 
     // 2. Init
-    agentsync::init::init(root, false)?;
+    agentsync::init::init(root, false, agentsync::init::DEFAULT_CONFIG)?;
 
     // 3. Simulate wizard migration — merge all skills into .agents/skills/
     let agents_skills = root.join(".agents/skills");
@@ -455,7 +455,7 @@ fn test_adoption_dry_run_no_side_effects() -> Result<()> {
     let root = tmp.path();
 
     // 1. Init and set up skills
-    agentsync::init::init(root, false)?;
+    agentsync::init::init(root, false, agentsync::init::DEFAULT_CONFIG)?;
     create_file(
         root,
         ".agents/skills/my-skill/SKILL.md",
@@ -502,7 +502,7 @@ fn test_adoption_preserves_existing_claude_skills_symlink_default() -> Result<()
     let tmp = TempDir::new()?;
     let root = tmp.path();
 
-    agentsync::init::init(root, false)?;
+    agentsync::init::init(root, false, agentsync::init::DEFAULT_CONFIG)?;
     create_file(
         root,
         ".agents/skills/debugging/SKILL.md",

--- a/website/docs/src/components/CommandTabs.astro
+++ b/website/docs/src/components/CommandTabs.astro
@@ -9,7 +9,7 @@
  *   <CommandTabs command="apply" />
  *   <CommandTabs command="skill suggest --json" />
  */
-import { Tabs, TabItem, Code } from "@astrojs/starlight/components";
+import { Code, TabItem, Tabs } from "@astrojs/starlight/components";
 
 interface Props {
 	command: string;

--- a/website/docs/src/content/docs/guides/getting-started.mdx
+++ b/website/docs/src/content/docs/guides/getting-started.mdx
@@ -108,10 +108,10 @@ This creates a `.agents/` directory with an initial `agentsync.toml` and an `AGE
 If you regularly use only a subset of agents, create a user-level template so `init` generates a leaner config every time:
 
 ```bash
-mkdir -p ~/.config/agentsync
+mkdir -p "${XDG_CONFIG_HOME:-$HOME/.config}/agentsync"
 # Copy and edit the default config, keeping only the agents you need
-agentsync init && cp .agents/agentsync.toml ~/.config/agentsync/config.toml
-# Edit ~/.config/agentsync/config.toml to keep only your preferred agents
+agentsync init && cp .agents/agentsync.toml "${XDG_CONFIG_HOME:-$HOME/.config}/agentsync/config.toml"
+# Edit the config to keep only your preferred agents
 ```
 
 Or use `--template` to point to any TOML file:

--- a/website/docs/src/content/docs/guides/getting-started.mdx
+++ b/website/docs/src/content/docs/guides/getting-started.mdx
@@ -103,6 +103,23 @@ Run `init` in your project root to create the default structure:
 
 This creates a `.agents/` directory with an initial `agentsync.toml` and an `AGENTS.md` file.
 
+**Tip: Personal defaults**
+
+If you regularly use only a subset of agents, create a user-level template so `init` generates a leaner config every time:
+
+```bash
+mkdir -p ~/.config/agentsync
+# Copy and edit the default config, keeping only the agents you need
+agentsync init && cp .agents/agentsync.toml ~/.config/agentsync/config.toml
+# Edit ~/.config/agentsync/config.toml to keep only your preferred agents
+```
+
+Or use `--template` to point to any TOML file:
+
+<CommandTabs command="init --template ~/my-template.toml" />
+
+See <BaseLink href="/reference/cli/">CLI Reference</BaseLink> for details.
+
 #### Existing Projects with Agent Files
 
 If you already have agent configuration files (like `CLAUDE.md`, `.cursor/`, or `.github/copilot-instructions.md`), use the interactive wizard:

--- a/website/docs/src/content/docs/reference/cli.mdx
+++ b/website/docs/src/content/docs/reference/cli.mdx
@@ -24,11 +24,50 @@ agentsync init [OPTIONS]
 - `-f, --force`: Overwrite existing configuration without prompting.
 - `-w, --wizard`: Run interactive configuration wizard to migrate existing files.
 - `--experimental-tui`: Run the init wizard with an experimental full-screen TUI intro. Requires `--wizard`.
+- `-t, --template <PATH>`: Use a custom configuration template file instead of the built-in default. The file must be valid TOML matching the `agentsync.toml` schema. Overrides XDG user config discovery.
 
 **Actions**:
 - Creates the `.agents/` directory if it doesn't exist.
 - Creates a default `.agents/agentsync.toml` file.
 - Creates a template `.agents/AGENTS.md` file.
+
+**User Config Template**:
+AgentSync supports a user-level configuration template that serves as the default for all new projects. When no `--template` flag is provided, `agentsync init` checks these locations in order:
+
+1. `$XDG_CONFIG_HOME/agentsync/config.toml` (if `XDG_CONFIG_HOME` is set)
+2. `~/.config/agentsync/config.toml` (default XDG path)
+3. Built-in default configuration (7 agents, all enabled)
+
+To set up a personal template:
+
+```bash
+mkdir -p ~/.config/agentsync
+# Create your template with only the agents you use
+cat > ~/.config/agentsync/config.toml << 'EOF'
+source_dir = "."
+default_agents = ["claude", "copilot"]
+
+[agents.claude]
+enabled = true
+description = "Claude Code"
+
+[agents.claude.targets.instructions]
+source = "AGENTS.md"
+destination = "CLAUDE.md"
+type = "symlink"
+
+[agents.copilot]
+enabled = true
+description = "GitHub Copilot"
+
+[agents.copilot.targets.instructions]
+source = "AGENTS.md"
+destination = ".github/copilot-instructions.md"
+type = "symlink"
+EOF
+```
+
+After this setup, `agentsync init` will use your template automatically — no flags needed.
 
 **Wizard Mode**:
 When using the `--wizard` flag, AgentSync will guide you through the same initialization flow described in the Getting Started guide, and this section provides the detailed, step‑by‑step reference for that wizard:

--- a/website/docs/src/content/docs/reference/cli.mdx
+++ b/website/docs/src/content/docs/reference/cli.mdx
@@ -28,7 +28,7 @@ agentsync init [OPTIONS]
 
 **Actions**:
 - Creates the `.agents/` directory if it doesn't exist.
-- Creates a default `.agents/agentsync.toml` file.
+- Creates `.agents/agentsync.toml` with the selected template content, or the built-in default when no template is found.
 - Creates a template `.agents/AGENTS.md` file.
 
 **User Config Template**:

--- a/website/docs/src/content/docs/reference/configuration.mdx
+++ b/website/docs/src/content/docs/reference/configuration.mdx
@@ -52,6 +52,20 @@ enabled = true  # Enabled, but won't run unless explicitly specified with --agen
 - If `--agents` flag is provided → uses CLI filter (overrides `default_agents`)
 - If `default_agents` is empty → runs all enabled agents (backward compatible)
 
+### User-level Config Template
+
+You can define a personal configuration template that `agentsync init` uses instead of the built-in default. This avoids editing the generated config every time you start a new project.
+
+**Discovery order:**
+1. `--template <path>` flag (explicit, always wins)
+2. `$XDG_CONFIG_HOME/agentsync/config.toml`
+3. `~/.config/agentsync/config.toml`
+4. Built-in default (all agents enabled)
+
+The template file is a **complete replacement** — it uses the same `agentsync.toml` schema but only needs to include the agents and settings you want. There is no merging with the built-in default.
+
+If a user-level config file exists but contains invalid TOML, AgentSync prints a warning and falls back to the built-in default. If `--template` points to an invalid file, initialization fails with a clear error.
+
 ## Gitignore Management
 
 AgentSync can automatically manage your `.gitignore` file to ensure that generated symbolic links and agent-specific files are not accidentally committed to version control.


### PR DESCRIPTION
## Summary

Adds user-level config template support to `agentsync init` so users can define personal defaults instead of always getting the hardcoded 7-agent template.

Closes #478

## Features

- **`--template <path>` flag** — explicit template file override for `agentsync init`
- **XDG auto-discovery** — when no `--template` flag is provided, checks `$XDG_CONFIG_HOME/agentsync/config.toml` then `~/.config/agentsync/config.toml` automatically
- **Precedence**: `--template` flag > XDG user config > built-in default
- **Full file replacement** — template replaces the built-in default entirely (no partial merge)
- **Works with both `init` and `init --wizard` paths**
- **Provenance output** — shows which template source was used

## Error Handling

- `--template` with missing file → hard error with clear message
- `--template` with invalid TOML → hard error with parse error details
- XDG file with invalid TOML → warn and fallback to built-in default (graceful)
- No `HOME` env var → graceful skip, use built-in default

## Example Usage

```bash
# One-time setup: create a personal template
mkdir -p ~/.config/agentsync
cat > ~/.config/agentsync/config.toml << 'EOF'
source_dir = "."
default_agents = ["claude", "copilot"]

[agents.claude]
enabled = true
description = "Claude Code"

[agents.claude.targets.instructions]
source = "AGENTS.md"
destination = "CLAUDE.md"
type = "symlink"

[agents.copilot]
enabled = true
description = "GitHub Copilot"

[agents.copilot.targets.instructions]
source = "AGENTS.md"
destination = ".github/copilot-instructions.md"
type = "symlink"
EOF

# From now on, init uses your template automatically:
agentsync init

# Or use an explicit template:
agentsync init --template ~/my-team-template.toml
```

## Changes

| File | What Changed |
|------|-------------|
| `src/init.rs` | Added `TemplateSource` enum, `resolve_user_config_path()`, `resolve_config_template()`. Updated signatures for `init()`, `init_wizard()`, `init_wizard_experimental_tui()`, and `build_default_config_with_skills_modes()`. Added 13 unit tests. |
| `src/main.rs` | Added `--template` (`-t`) flag to Init command. Wired template resolution and provenance output. |
| `tests/test_agent_adoption.rs` | Updated 6 `init()` calls to pass config content parameter. |
| `website/docs/.../cli.mdx` | Documented `--template` flag and XDG discovery. |
| `website/docs/.../getting-started.mdx` | Added personal defaults tip. |
| `website/docs/.../configuration.mdx` | Added user-level config template section. |

## Test Instructions

```bash
cargo test --all-features
cargo clippy --all-targets --all-features -- -D warnings
pnpm run docs:build
```

## Checklist

- [x] Tests pass (`cargo test --all-features` — 403+ lib tests, 660+ total)
- [x] Clippy clean
- [x] Docs build clean
- [x] No new dependencies
- [x] Backward compatible (no flag + no XDG file = identical behavior)