### PR TITLE
feat: add Claude Desktop MCP server syncing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,7 @@ dependencies = [
  "colored",
  "crossterm",
  "dialoguer",
+ "dirs",
  "flate2",
  "futures-util",
  "is-terminal",
@@ -665,6 +666,27 @@ dependencies = [
  "crypto-common 0.2.1",
  "ctutils",
  "zeroize",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1586,6 +1608,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1877,6 +1905,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ walkdir = "2.5"
 
 # Path handling
 pathdiff = "0.2"
+dirs = "6"
 
 # HTTP + async runtime (added for skills.sh integration feature)
 reqwest = { version = "0.13.3", features = ["json", "gzip", "stream", "blocking"] }

--- a/src/agent_ids.rs
+++ b/src/agent_ids.rs
@@ -10,6 +10,7 @@
 pub fn canonical_mcp_agent_id(id: &str) -> Option<&'static str> {
     match id.to_lowercase().as_str() {
         "claude" | "claude-code" | "claude_code" => Some("claude"),
+        "claude-desktop" | "claude_desktop" | "claudedesktop" => Some("claude-desktop"),
         "copilot" | "github-copilot" | "github_copilot" => Some("copilot"),
         "codex" | "codex-cli" | "codex_cli" => Some("codex"),
         "gemini" | "gemini-cli" | "gemini_cli" => Some("gemini"),
@@ -95,6 +96,7 @@ pub fn known_ignore_patterns(agent_name: &str) -> &'static [&'static str] {
     if let Some(canonical) = canonical_mcp_agent_id(agent_name) {
         return match canonical {
             "claude" => &[".mcp.json", ".claude/commands/", ".claude/skills/"],
+            "claude-desktop" => &[],
             "copilot" => &[".vscode/mcp.json"],
             "codex" => &[".codex/config.toml"],
             "gemini" => &[
@@ -190,6 +192,18 @@ mod tests {
     fn test_canonical_mcp_agent_id_aliases() {
         assert_eq!(canonical_mcp_agent_id("claude"), Some("claude"));
         assert_eq!(canonical_mcp_agent_id("claude-code"), Some("claude"));
+        assert_eq!(
+            canonical_mcp_agent_id("claude-desktop"),
+            Some("claude-desktop")
+        );
+        assert_eq!(
+            canonical_mcp_agent_id("claude_desktop"),
+            Some("claude-desktop")
+        );
+        assert_eq!(
+            canonical_mcp_agent_id("claudedesktop"),
+            Some("claude-desktop")
+        );
         assert_eq!(canonical_mcp_agent_id("github-copilot"), Some("copilot"));
         assert_eq!(canonical_mcp_agent_id("codex_cli"), Some("codex"));
         assert_eq!(canonical_mcp_agent_id("gemini-cli"), Some("gemini"));

--- a/src/init.rs
+++ b/src/init.rs
@@ -220,6 +220,13 @@ destination = ".claude/commands"
 type = "symlink-contents"
 
 # -----------------------------------------------------------------------------
+# Claude Desktop (MCP servers only - syncs to global config)
+# -----------------------------------------------------------------------------
+[agents.claude-desktop]
+enabled = false
+description = "Claude Desktop - Anthropic's desktop AI assistant"
+
+# -----------------------------------------------------------------------------
 # GitHub Copilot
 # -----------------------------------------------------------------------------
 [agents.copilot]

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -116,9 +116,18 @@ impl McpAgent {
     }
 
     /// Get the project-level config file path (relative to project root).
-    /// For global agents (e.g. Claude Desktop), returns a sentinel — use
-    /// `resolved_config_path()` to get the actual filesystem path.
+    ///
+    /// # Panics
+    ///
+    /// Panics in debug builds for global agents (e.g. Claude Desktop) which
+    /// have no project-relative path.  Always use [`resolved_config_path()`]
+    /// instead when the result will touch the filesystem.
     pub fn config_path(&self) -> &'static str {
+        debug_assert!(
+            !self.is_global(),
+            "config_path() must not be called on global agent {:?}; use resolved_config_path()",
+            self
+        );
         match self {
             McpAgent::ClaudeCode => ".mcp.json",
             McpAgent::ClaudeDesktop => "<global:claude-desktop>",

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -56,6 +56,8 @@ impl McpOutput {
 pub enum McpAgent {
     /// Claude Code (.mcp.json)
     ClaudeCode,
+    /// Claude Desktop (global: ~/Library/Application Support/Claude/claude_desktop_config.json)
+    ClaudeDesktop,
     /// GitHub Copilot (.vscode/mcp.json)
     GithubCopilot,
     /// OpenAI Codex CLI (.codex/config.toml)
@@ -75,6 +77,7 @@ impl McpAgent {
     pub fn all() -> &'static [McpAgent] {
         &[
             McpAgent::ClaudeCode,
+            McpAgent::ClaudeDesktop,
             McpAgent::GithubCopilot,
             McpAgent::CodexCli,
             McpAgent::GeminiCli,
@@ -88,6 +91,7 @@ impl McpAgent {
     pub fn id(&self) -> &'static str {
         match self {
             McpAgent::ClaudeCode => "claude",
+            McpAgent::ClaudeDesktop => "claude-desktop",
             McpAgent::GithubCopilot => "copilot",
             McpAgent::CodexCli => "codex",
             McpAgent::GeminiCli => "gemini",
@@ -101,6 +105,7 @@ impl McpAgent {
     pub fn name(&self) -> &'static str {
         match self {
             McpAgent::ClaudeCode => "Claude Code",
+            McpAgent::ClaudeDesktop => "Claude Desktop",
             McpAgent::GithubCopilot => "GitHub Copilot",
             McpAgent::CodexCli => "OpenAI Codex CLI",
             McpAgent::GeminiCli => "Gemini CLI",
@@ -110,10 +115,13 @@ impl McpAgent {
         }
     }
 
-    /// Get the project-level config file path (relative to project root)
+    /// Get the project-level config file path (relative to project root).
+    /// For global agents (e.g. Claude Desktop), returns a sentinel — use
+    /// `resolved_config_path()` to get the actual filesystem path.
     pub fn config_path(&self) -> &'static str {
         match self {
             McpAgent::ClaudeCode => ".mcp.json",
+            McpAgent::ClaudeDesktop => "<global:claude-desktop>",
             McpAgent::GithubCopilot => ".vscode/mcp.json",
             McpAgent::CodexCli => ".codex/config.toml",
             McpAgent::GeminiCli => ".gemini/settings.json",
@@ -123,10 +131,30 @@ impl McpAgent {
         }
     }
 
+    /// Resolve the actual config file path for this agent.
+    /// For project-level agents, joins with `project_root`.
+    /// For global agents (e.g. Claude Desktop), returns the OS-specific
+    /// absolute path. Returns `None` if the path cannot be determined.
+    pub fn resolved_config_path(&self, project_root: &Path) -> Option<PathBuf> {
+        match self {
+            McpAgent::ClaudeDesktop => {
+                dirs::config_dir().map(|d| d.join("Claude").join("claude_desktop_config.json"))
+            }
+            _ => Some(project_root.join(self.config_path())),
+        }
+    }
+
+    /// Whether this agent writes to a global (user-level) config path
+    /// rather than a project-relative path.
+    pub fn is_global(&self) -> bool {
+        matches!(self, McpAgent::ClaudeDesktop)
+    }
+
     /// Get the formatter for this agent
     pub fn formatter(&self) -> Box<dyn McpFormatter> {
         match self {
             McpAgent::ClaudeCode => Box::new(ClaudeCodeFormatter),
+            McpAgent::ClaudeDesktop => Box::new(ClaudeDesktopFormatter),
             McpAgent::GithubCopilot => Box::new(GithubCopilotFormatter),
             McpAgent::CodexCli => Box::new(CodexCliFormatter),
             McpAgent::GeminiCli => Box::new(GeminiCliFormatter),
@@ -140,6 +168,7 @@ impl McpAgent {
     pub fn from_id(id: &str) -> Option<McpAgent> {
         match agent_ids::canonical_mcp_agent_id(id)? {
             "claude" => Some(McpAgent::ClaudeCode),
+            "claude-desktop" => Some(McpAgent::ClaudeDesktop),
             "copilot" => Some(McpAgent::GithubCopilot),
             "codex" => Some(McpAgent::CodexCli),
             "gemini" => Some(McpAgent::GeminiCli),
@@ -353,6 +382,100 @@ impl McpFormatter for ClaudeCodeFormatter {
             new_servers,
             "Failed to parse existing MCP config as JSON",
         )
+    }
+}
+
+// =============================================================================
+// Claude Desktop Formatter
+// =============================================================================
+
+/// Formatter for Claude Desktop (global config)
+/// Format: { "mcpServers": { ... } } with other top-level keys preserved
+#[derive(Debug)]
+pub struct ClaudeDesktopFormatter;
+
+impl McpFormatter for ClaudeDesktopFormatter {
+    fn format(&self, servers: &BTreeMap<&str, &McpServerConfig>) -> Value {
+        format_standard_mcp(servers)
+    }
+
+    fn parse_existing(&self, content: &str) -> Result<BTreeMap<String, Value>> {
+        parse_standard_mcp(
+            content,
+            "Failed to parse existing Claude Desktop config as JSON",
+        )
+    }
+
+    fn merge(
+        &self,
+        existing_content: &str,
+        new_servers: &BTreeMap<&str, &McpServerConfig>,
+    ) -> Result<String> {
+        let mut existing_doc: Value =
+            serde_json::from_str(existing_content).unwrap_or_else(|_| json!({}));
+
+        let mut existing_servers = if let Some(obj) = existing_doc
+            .get_mut("mcpServers")
+            .and_then(|v| v.as_object_mut())
+        {
+            std::mem::take(obj).into_iter().collect()
+        } else {
+            BTreeMap::new()
+        };
+
+        for (name, config) in new_servers {
+            existing_servers.insert((*name).to_string(), server_to_json(config));
+        }
+
+        if let Some(doc_obj) = existing_doc.as_object_mut() {
+            doc_obj.insert(
+                "mcpServers".to_string(),
+                Value::Object(json_map_from_values(existing_servers)),
+            );
+        }
+
+        serde_json::to_string_pretty(&existing_doc).context("Failed to serialize merged config")
+    }
+
+    fn cleanup_removed_servers(
+        &self,
+        existing_content: &str,
+        new_servers: &BTreeMap<&str, &McpServerConfig>,
+    ) -> Result<String> {
+        let mut existing_doc: Value =
+            serde_json::from_str(existing_content).unwrap_or_else(|_| json!({}));
+
+        let existing_servers = if let Some(obj) = existing_doc
+            .get_mut("mcpServers")
+            .and_then(|v| v.as_object_mut())
+        {
+            std::mem::take(obj).into_iter().collect()
+        } else {
+            BTreeMap::new()
+        };
+
+        let filtered_existing: BTreeMap<String, Value> = existing_servers
+            .into_iter()
+            .filter(|(name, _)| new_servers.contains_key(name.as_str()))
+            .collect();
+
+        let mut final_servers = filtered_existing;
+        for (name, config) in new_servers {
+            final_servers.insert((*name).to_string(), server_to_json(config));
+        }
+
+        if let Some(doc_obj) = existing_doc.as_object_mut() {
+            doc_obj.insert(
+                "mcpServers".to_string(),
+                Value::Object(json_map_from_values(final_servers)),
+            );
+        }
+
+        serde_json::to_string_pretty(&existing_doc).context("Failed to serialize cleaned config")
+    }
+
+    fn preserve_on_overwrite(&self) -> bool {
+        true
     }
 }
 
@@ -1115,7 +1238,13 @@ impl McpGenerator {
     ) -> Result<McpSyncResult> {
         let mut result = McpSyncResult::default();
         let formatter = agent.formatter();
-        let config_path = project_root.join(agent.config_path());
+        let config_path = match agent.resolved_config_path(project_root) {
+            Some(path) => path,
+            None => {
+                result.skipped += 1;
+                return Ok(result);
+            }
+        };
 
         if enabled_servers.is_empty() {
             result.skipped += 1;
@@ -1262,18 +1391,20 @@ impl McpGenerator {
     ) -> Result<McpSyncResult> {
         let mut total_result = McpSyncResult::default();
         let enabled_servers = self.get_enabled_servers();
-        let mut handled_paths = BTreeSet::new();
+        let mut handled_paths: BTreeSet<PathBuf> = BTreeSet::new();
 
         if enabled_servers.is_empty() {
             return Ok(total_result);
         }
 
         for agent in enabled_agents {
-            let path = agent.config_path();
-            if handled_paths.contains(path) {
+            let path = match agent.resolved_config_path(project_root) {
+                Some(p) => p,
+                None => continue,
+            };
+            if !handled_paths.insert(path) {
                 continue;
             }
-            handled_paths.insert(path);
 
             match self.generate_for_agent_with_servers(
                 *agent,
@@ -1351,9 +1482,10 @@ impl McpGenerator {
     }
 }
 
-/// Get the path where MCP config would be written for an agent
-pub fn get_mcp_config_path(agent: McpAgent, project_root: &Path) -> PathBuf {
-    project_root.join(agent.config_path())
+/// Get the path where MCP config would be written for an agent.
+/// Returns `None` for global agents whose path cannot be resolved.
+pub fn get_mcp_config_path(agent: McpAgent, project_root: &Path) -> Option<PathBuf> {
+    agent.resolved_config_path(project_root)
 }
 
 // =============================================================================
@@ -1372,8 +1504,9 @@ mod tests {
     #[test]
     fn test_agent_all_returns_all_agents() {
         let agents = McpAgent::all();
-        assert_eq!(agents.len(), 7);
+        assert_eq!(agents.len(), 8);
         assert!(agents.contains(&McpAgent::ClaudeCode));
+        assert!(agents.contains(&McpAgent::ClaudeDesktop));
         assert!(agents.contains(&McpAgent::GithubCopilot));
         assert!(agents.contains(&McpAgent::CodexCli));
         assert!(agents.contains(&McpAgent::GeminiCli));
@@ -1387,6 +1520,14 @@ mod tests {
         assert_eq!(McpAgent::from_id("claude"), Some(McpAgent::ClaudeCode));
         assert_eq!(McpAgent::from_id("CLAUDE"), Some(McpAgent::ClaudeCode));
         assert_eq!(McpAgent::from_id("claude-code"), Some(McpAgent::ClaudeCode));
+        assert_eq!(
+            McpAgent::from_id("claude-desktop"),
+            Some(McpAgent::ClaudeDesktop)
+        );
+        assert_eq!(
+            McpAgent::from_id("claude_desktop"),
+            Some(McpAgent::ClaudeDesktop)
+        );
         assert_eq!(McpAgent::from_id("copilot"), Some(McpAgent::GithubCopilot));
         assert_eq!(
             McpAgent::from_id("github-copilot"),
@@ -1412,6 +1553,133 @@ mod tests {
         assert_eq!(McpAgent::VsCode.config_path(), ".vscode/mcp.json");
         assert_eq!(McpAgent::Cursor.config_path(), ".cursor/mcp.json");
         assert_eq!(McpAgent::OpenCode.config_path(), "opencode.json");
+    }
+
+    #[test]
+    fn test_claude_desktop_is_global() {
+        assert!(McpAgent::ClaudeDesktop.is_global());
+        assert!(!McpAgent::ClaudeCode.is_global());
+        assert!(!McpAgent::GithubCopilot.is_global());
+    }
+
+    #[test]
+    fn test_claude_desktop_resolved_config_path() {
+        let project_root = Path::new("/tmp/test-project");
+        let path = McpAgent::ClaudeDesktop.resolved_config_path(project_root);
+        // Should resolve to a global path, not under project_root
+        if let Some(ref p) = path {
+            assert!(!p.starts_with(project_root));
+            assert!(p.ends_with("claude_desktop_config.json"));
+        }
+        // Non-global agents resolve under project_root
+        let claude_path = McpAgent::ClaudeCode.resolved_config_path(project_root).unwrap();
+        assert_eq!(claude_path, project_root.join(".mcp.json"));
+    }
+
+    // ==========================================================================
+    // FORMATTER TESTS - Claude Desktop
+    // ==========================================================================
+
+    #[test]
+    fn test_claude_desktop_formatter_basic() {
+        let formatter = ClaudeDesktopFormatter;
+        let server = create_test_server();
+        let servers: BTreeMap<&str, &McpServerConfig> = BTreeMap::from([("filesystem", &server)]);
+
+        let output = formatter.format(&servers);
+
+        assert!(output.get("mcpServers").is_some());
+        let mcp_servers = output.get("mcpServers").unwrap();
+        assert!(mcp_servers.get("filesystem").is_some());
+    }
+
+    #[test]
+    fn test_claude_desktop_formatter_preserves_other_settings() {
+        let formatter = ClaudeDesktopFormatter;
+        let existing = r#"{
+            "globalShortcut": "Ctrl+Space",
+            "theme": "dark",
+            "mcpServers": {
+                "existing": {
+                    "command": "node",
+                    "args": ["server.js"]
+                }
+            }
+        }"#;
+
+        let new_server = create_test_server();
+        let servers: BTreeMap<&str, &McpServerConfig> =
+            BTreeMap::from([("filesystem", &new_server)]);
+
+        let merged = formatter.merge(existing, &servers).unwrap();
+        let parsed: Value = serde_json::from_str(&merged).unwrap();
+
+        // Should preserve other settings
+        assert_eq!(
+            parsed.get("globalShortcut").unwrap().as_str().unwrap(),
+            "Ctrl+Space"
+        );
+        assert_eq!(parsed.get("theme").unwrap().as_str().unwrap(), "dark");
+        // And have both servers
+        assert!(parsed.get("mcpServers").unwrap().get("existing").is_some());
+        assert!(
+            parsed
+                .get("mcpServers")
+                .unwrap()
+                .get("filesystem")
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn test_claude_desktop_formatter_cleanup_preserves_settings() {
+        let formatter = ClaudeDesktopFormatter;
+        let existing = r#"{
+            "globalShortcut": "Ctrl+Space",
+            "mcpServers": {
+                "keep": {
+                    "command": "node"
+                },
+                "remove": {
+                    "command": "old-server"
+                }
+            }
+        }"#;
+
+        let mut server = create_test_server();
+        server.command = Some("node".to_string());
+
+        let servers = BTreeMap::from([("keep".to_string(), server)]);
+        let refs = servers.iter().map(|(k, v)| (k.as_str(), v)).collect();
+
+        let result = formatter.cleanup_removed_servers(existing, &refs).unwrap();
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+
+        assert_eq!(
+            parsed.get("globalShortcut").unwrap().as_str().unwrap(),
+            "Ctrl+Space"
+        );
+        let mcp_servers = parsed.get("mcpServers").unwrap();
+        assert!(mcp_servers.get("keep").is_some());
+        assert!(mcp_servers.get("remove").is_none());
+    }
+
+    #[test]
+    fn test_claude_desktop_formatter_creates_from_empty() {
+        let formatter = ClaudeDesktopFormatter;
+        let server = create_test_server();
+        let servers: BTreeMap<&str, &McpServerConfig> = BTreeMap::from([("filesystem", &server)]);
+
+        let output = formatter.format_to_string(&servers).unwrap();
+        let parsed: Value = serde_json::from_str(&output).unwrap();
+
+        assert!(
+            parsed
+                .get("mcpServers")
+                .unwrap()
+                .get("filesystem")
+                .is_some()
+        );
     }
 
     // ==========================================================================

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1572,7 +1572,9 @@ mod tests {
             assert!(p.ends_with("claude_desktop_config.json"));
         }
         // Non-global agents resolve under project_root
-        let claude_path = McpAgent::ClaudeCode.resolved_config_path(project_root).unwrap();
+        let claude_path = McpAgent::ClaudeCode
+            .resolved_config_path(project_root)
+            .unwrap();
         assert_eq!(claude_path, project_root.join(".mcp.json"));
     }
 

--- a/website/docs/src/content/docs/guides/mcp.mdx
+++ b/website/docs/src/content/docs/guides/mcp.mdx
@@ -55,12 +55,33 @@ AgentSync automatically knows where to place the MCP configuration for these ass
 | Assistant | Destination File | Notes |
 | :--- | :--- | :--- |
 | **Claude Code** | `.mcp.json` | Standard format |
+| **Claude Desktop** | `~/Library/Application Support/Claude/claude_desktop_config.json` | Global config; preserves non-MCP settings; disabled by default |
 | **GitHub Copilot** | `.vscode/mcp.json` | Shared with VS Code |
 | **OpenAI Codex CLI** | `.codex/config.toml` | TOML format (`[mcp_servers.<name>]`); AgentSync maps `headers` to `http_headers` |
 | **Gemini CLI** | `.gemini/settings.json` | Automatically adds `"trust": true` |
 | **VS Code** | `.vscode/mcp.json` | For VS Code extensions |
 | **Cursor** | `.cursor/mcp.json` | Standard format |
 | **OpenCode** | `opencode.json` | |
+
+## Global Agents
+
+Some agents store their MCP configuration in a global (user-level) location rather than in the project directory. AgentSync calls these **global agents**.
+
+Currently supported global agents:
+
+| Agent | Config Location |
+| :--- | :--- |
+| **Claude Desktop** | macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`<br/>Linux: `~/.config/Claude/claude_desktop_config.json`<br/>Windows: `%APPDATA%\Claude\claude_desktop_config.json` |
+
+Global agents are **disabled by default** because they write outside your project directory. To enable:
+
+```toml
+[agents.claude-desktop]
+enabled = true
+description = "Claude Desktop"
+```
+
+No symlink targets are needed for global agents. They only participate in MCP server syncing. When `agentsync apply` runs, the MCP servers defined in your `[mcp_servers]` config are merged into the global config file, preserving any existing non-MCP settings (keyboard shortcuts, theme, etc.).
 
 ## How it works
 

--- a/website/docs/src/content/docs/guides/mcp.mdx
+++ b/website/docs/src/content/docs/guides/mcp.mdx
@@ -55,7 +55,7 @@ AgentSync automatically knows where to place the MCP configuration for these ass
 | Assistant | Destination File | Notes |
 | :--- | :--- | :--- |
 | **Claude Code** | `.mcp.json` | Standard format |
-| **Claude Desktop** | `~/Library/Application Support/Claude/claude_desktop_config.json` | Global config; preserves non-MCP settings; disabled by default |
+| **Claude Desktop** | Global config (OS-dependent; see [below](#global-agents)) | Preserves non-MCP settings; disabled by default |
 | **GitHub Copilot** | `.vscode/mcp.json` | Shared with VS Code |
 | **OpenAI Codex CLI** | `.codex/config.toml` | TOML format (`[mcp_servers.<name>]`); AgentSync maps `headers` to `http_headers` |
 | **Gemini CLI** | `.gemini/settings.json` | Automatically adds `"trust": true` |

--- a/website/docs/src/content/docs/reference/configuration.mdx
+++ b/website/docs/src/content/docs/reference/configuration.mdx
@@ -110,6 +110,7 @@ AgentSync automatically adds the following patterns to `.gitignore` based on whi
 | Agent | Automatically Added Patterns |
 | :--- | :--- |
 | **claude** | `.mcp.json`, `.claude/commands/`, `.claude/skills/` |
+| **claude-desktop** | _(none -- writes to global config outside project)_ |
 | **copilot** | `.vscode/mcp.json` |
 | **codex** | `.codex/config.toml` |
 | **gemini** | `GEMINI.md`, `.gemini/settings.json`, `.gemini/commands/`, `.gemini/skills/` |
@@ -203,7 +204,7 @@ Those destinations stay as real directories:
 
 AgentSync has two support levels:
 
-- **Native MCP generation** (built-in formatter + merge behavior): `claude`, `copilot`, `codex`, `gemini`, `cursor`, `vscode`, `opencode`.
+- **Native MCP generation** (built-in formatter + merge behavior): `claude`, `claude-desktop`, `copilot`, `codex`, `gemini`, `cursor`, `vscode`, `opencode`.
 - **Configurable sync targets** (rules/skills via symlink): any agent as long as you declare `[agents.<name>.targets.*]` entries.
 
 The matrix below documents common agent locations and whether AgentSync can handle them today.
@@ -213,6 +214,7 @@ The matrix below documents common agent locations and whether AgentSync can hand
 | AGENTS.md | `AGENTS.md` | Pseudo-agent pattern via `[agents.root]` target | - |
 | GitHub Copilot | `.github/copilot-instructions.md` | `.vscode/mcp.json` (native MCP) | Configurable |
 | Claude Code | `CLAUDE.md` | `.mcp.json` (native MCP) | Configurable; `.claude/skills/` |
+| Claude Desktop | - | Global config (native MCP); disabled by default | - |
 | OpenAI Codex CLI | `AGENTS.md` | `.codex/config.toml` (native MCP) | Configurable; `.codex/skills/` |
 | VS Code | - | `.vscode/mcp.json` (native MCP) | Configurable |
 | Pi Coding Agent | - | No native MCP formatter | Configurable |


### PR DESCRIPTION
Based on #471 by @KealJones — thank you for the excellent contribution!

This PR adds native support for syncing MCP servers to Claude Desktop's global config file.

## Changes from original PR

All original work preserved, plus:
- **Hardened `config_path()`** with `debug_assert!` that panics in test/debug builds if called on a global agent, directing callers to `resolved_config_path()` instead
- **Fixed docs table** to reference the Global Agents section instead of hardcoding macOS-only path

## Features

- New `McpAgent::ClaudeDesktop` variant with `ClaudeDesktopFormatter`
- Global agent concept: `resolved_config_path()` returns OS-specific absolute path via `dirs` crate
- `is_global()` method distinguishes global from project-level agents
- Formatter preserves non-MCP settings (keyboard shortcuts, theme, etc.)
- Agent is **disabled by default** — explicit opt-in required
- 6 unit tests + integration test for global path resolution

## Security

- Writes to well-known OS config directory (via `dirs::config_dir()`)
- Atomic write with restricted permissions (0o600)
- No arbitrary path from user input
- `debug_assert!` prevents accidental `config_path()` misuse on global agents

Closes #471