### PR TITLE
refactor(cli): canonicalize output and MCP documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,13 @@ jobs:
   mcp-documentation:
     name: MCP documentation drift
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,19 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  mcp-documentation:
+    name: MCP documentation drift
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
+      - name: Validate canonical MCP documentation
+        run: cargo test --test mcp_documentation
+
   # ==========================================================================
   # Code Quality Checks
   # ==========================================================================

--- a/README.md
+++ b/README.md
@@ -432,17 +432,20 @@ args = ["-y", "@modelcontextprotocol/server-git", "--repository", "."]
 
 #### Supported Agents (canonical)
 
-AgentSync supports the following agents and will synchronize corresponding files/locations. This list is canonical — keep it in sync with `src/mcp.rs` (authoritative).
+<!-- agentsync:mcp:start -->
+- **Claude Code** — `.mcp.json` (agent id: `claude`) — JSON; Standard format
+- **Claude Desktop** — `Global OS-dependent config` (agent id: `claude-desktop`) — JSON; Global; disabled by default
+- **GitHub Copilot** — `.vscode/mcp.json` (agent id: `copilot`) — JSON; Shared with VS Code
+- **OpenAI Codex CLI** — `.codex/config.toml` (agent id: `codex`) — TOML; Maps headers to http_headers
+- **Gemini CLI** — `.gemini/settings.json` (agent id: `gemini`) — JSON; Adds trust: true
+- **VS Code** — `.vscode/mcp.json` (agent id: `vscode`) — JSON; Shared with GitHub Copilot
+- **Cursor** — `.cursor/mcp.json` (agent id: `cursor`) — JSON; Standard format
+- **OpenCode** — `opencode.json` (agent id: `opencode`) — JSON; Standard format
+<!-- agentsync:mcp:end -->
 
-- **Claude Code** — `.mcp.json` (agent id: `claude`)
-- **GitHub Copilot** — `.vscode/mcp.json` (agent id: `copilot`)
-- **OpenAI Codex CLI** — `.codex/config.toml` (agent id: `codex`) — TOML format with `[mcp_servers.<name>]` tables. AgentSync maps `headers` to Codex `http_headers`.
-- **Gemini CLI** — `.gemini/settings.json` (agent id: `gemini`) — AgentSync will add `trust: true` when generating Gemini configs.
-- **Cursor** — `.cursor/mcp.json` (agent id: `cursor`)
-- **VS Code** — `.vscode/mcp.json` (agent id: `vscode`)
-- **OpenCode** — `opencode.json` (agent id: `opencode`)
+AgentSync supports the native MCP agents above. The typed registry and focused CI validator are authoritative.
 
-AgentSync also supports 32+ agents (7 native MCP agents and 25+ configurable agents) including Windsurf, Cline, Amazon Q, Aider, RooCode, Trae, and more. See the [full list in the documentation](https://dallay.github.io/agentsync/reference/configuration/).
+AgentSync also supports 32+ configurable agents including Windsurf, Cline, Amazon Q, Aider, RooCode, Trae, and more. See the [full list in the documentation](https://dallay.github.io/agentsync/reference/configuration/).
 
 See the [MCP Integration Guide](https://dallay.github.io/agentsync/guides/mcp/) for formatter details and merge behavior.
 

--- a/npm/agentsync/README.md
+++ b/npm/agentsync/README.md
@@ -112,7 +112,17 @@ agentsync clean
 
 ## MCP & Skills
 
-- AgentSync supports MCP generation for multiple agents (Claude, Copilot, Gemini, Cursor, VS Code, OpenCode). The canonical list and file locations live in the repo README and in the docs site (guides/mcp).
+<!-- agentsync:mcp:start -->
+- **Claude Code** — `.mcp.json` (agent id: `claude`) — JSON; Standard format
+- **Claude Desktop** — `Global OS-dependent config` (agent id: `claude-desktop`) — JSON; Global; disabled by default
+- **GitHub Copilot** — `.vscode/mcp.json` (agent id: `copilot`) — JSON; Shared with VS Code
+- **OpenAI Codex CLI** — `.codex/config.toml` (agent id: `codex`) — TOML; Maps headers to http_headers
+- **Gemini CLI** — `.gemini/settings.json` (agent id: `gemini`) — JSON; Adds trust: true
+- **VS Code** — `.vscode/mcp.json` (agent id: `vscode`) — JSON; Shared with GitHub Copilot
+- **Cursor** — `.cursor/mcp.json` (agent id: `cursor`) — JSON; Standard format
+- **OpenCode** — `opencode.json` (agent id: `opencode`) — JSON; Standard format
+<!-- agentsync:mcp:end -->
+- The typed registry and focused CI validator govern this list.
 - Skills live under `.agents/skills/` in the project.
 
 ---

--- a/openspec/changes/archive/2026-08-03-issue-494-500-output-doc-canonicalization/archive-report.md
+++ b/openspec/changes/archive/2026-08-03-issue-494-500-output-doc-canonicalization/archive-report.md
@@ -1,0 +1,36 @@
+# Archive Report
+
+## Change
+`issue-494-500-output-doc-canonicalization`
+
+## Verification Gate
+**PASS WITH WARNINGS** with no critical issues. The sole warning is a missing committed red-phase TDD transcript; runtime correctness and all required verification checks passed.
+
+## Specs Synced
+
+| Domain | Action | Details |
+|---|---|---|
+| `cli-output` | Created | Added durable specification for contract-preserving extracted CLI presentation and exact output tests. |
+| `documentation` | Updated | Added governed native MCP documentation requirements while preserving existing documentation requirements. |
+| `mcp-generation` | Updated | Added canonical typed native MCP metadata requirement and canonical marked registry fragment; runtime behavior remains unchanged. |
+
+## Archive Verification
+
+- Main specs updated before archive move: ✅
+- Change folder moved to `openspec/changes/archive/2026-08-03-issue-494-500-output-doc-canonicalization/`: ✅
+- Archive contains proposal, exploration, specs, design, tasks, verification report, and state: ✅
+- Active change directory removed: ✅
+- State updated to `current_phase: archive`, completed `archive`, next `none`: ✅
+
+## Scope Guard
+No product behavior was altered during archiving. Changes were limited to durable OpenSpec synchronization, archive placement, state, and this audit report.
+
+## Source Artifacts
+- `proposal.md`
+- `specs/cli-output/spec.md`
+- `specs/documentation/spec.md`
+- `specs/mcp-generation/spec.md`
+- `design.md`
+- `tasks.md`
+- `verify-report.md`
+- `state.yaml`

--- a/openspec/changes/archive/2026-08-03-issue-494-500-output-doc-canonicalization/archive-report.md
+++ b/openspec/changes/archive/2026-08-03-issue-494-500-output-doc-canonicalization/archive-report.md
@@ -1,9 +1,11 @@
 # Archive Report
 
 ## Change
+
 `issue-494-500-output-doc-canonicalization`
 
 ## Verification Gate
+
 **PASS WITH WARNINGS** with no critical issues. The sole warning is a missing committed red-phase TDD transcript; runtime correctness and all required verification checks passed.
 
 ## Specs Synced
@@ -23,9 +25,11 @@
 - State updated to `current_phase: archive`, completed `archive`, next `none`: ✅
 
 ## Scope Guard
+
 No product behavior was altered during archiving. Changes were limited to durable OpenSpec synchronization, archive placement, state, and this audit report.
 
 ## Source Artifacts
+
 - `proposal.md`
 - `specs/cli-output/spec.md`
 - `specs/documentation/spec.md`

--- a/openspec/changes/archive/2026-08-03-issue-494-500-output-doc-canonicalization/design.md
+++ b/openspec/changes/archive/2026-08-03-issue-494-500-output-doc-canonicalization/design.md
@@ -1,0 +1,88 @@
+# Design: CLI Output Extraction and Canonical Agent Documentation
+
+## Technical Approach
+
+Keep command handlers in `src/main.rs` as orchestration only. Move the pure apply/clean/init
+line builders, `print_lines`, and banner emission into `src/output.rs`; retain direct progress
+printed by `src/init.rs` and linker operations. The moved functions preserve their current
+strings, ordering, blank lines, and `HumanFormatter` color decisions.
+
+Make `src/mcp.rs` the sole typed source for *native MCP* documentation metadata. Add a stable
+metadata view to `McpAgent` (ID, display name, documented destination, format, global flag, and
+notes), while keeping path resolution, formatter dispatch, aliases, and generation behavior in
+their existing methods. Validate marked Markdown fragments against that registry rather than
+introducing a data-driven runtime registry or conflating configurable-only agents in
+`src/agent_ids.rs`.
+
+## Architecture Decisions
+
+| Decision | Choice | Alternatives / rationale |
+|---|---|---|
+| Presentation boundary | `src/output.rs`, with renderer functions `pub(crate)` | A new output submodule would add files without improving boundaries. Keeping JSON status in `commands/status.rs` avoids changing its contract. |
+| Renderer API | Borrow inputs and return `Vec<String>`; `print_lines(&[String])` remains `pub(crate)` | Returning strings preserves existing testability and line order; a writer abstraction would risk unrelated I/O refactoring. |
+| MCP canonical source | Typed `McpAgent` registry plus public metadata accessor | A TOML/JSON manifest would duplicate enum behavior and weaken compile-time coverage. `agent_ids.rs` remains the alias/configurable-agent boundary. |
+| Documentation mechanism | Stable `<!-- agentsync:mcp:start/end -->` fragments validated by a Rust integration test | Generation could create noisy multi-document diffs. Validation is deterministic, requires no runtime dependency, and fails on omissions, duplicates, IDs, or metadata drift. |
+
+## Data Flow
+
+```text
+CLI handler (main.rs) → output renderer → Vec<String> → print_lines → stdout
+McpAgent::all() → documentation_metadata() → doc validator → Markdown fragments
+Linker/McpGenerator → existing SyncResult/McpSyncResult → unchanged renderers
+```
+
+The validator reads the four governed documents, extracts each marked block, renders the
+canonical rows in deterministic `McpAgent::all()` order, and compares exact block contents.
+Shared destinations (Copilot and VS Code) and Claude Desktop's global/OS-dependent path are
+represented explicitly in metadata notes; validation never calls filesystem path resolution.
+
+## File Changes
+
+| File | Action | Description |
+|---|---|---|
+| `src/main.rs` | Modify | Remove moved renderers/emitter and import output APIs; leave orchestration and command behavior intact. |
+| `src/output.rs` | Modify | Own apply/clean/init renderers, banner, and line emission; migrate their unit tests. |
+| `src/mcp.rs` | Modify | Add typed native-MCP documentation metadata and accessor; preserve generation methods. |
+| `tests/mcp_documentation.rs` | Create | Validate all marked MCP fragments against `McpAgent` metadata. |
+| `README.md`, `npm/agentsync/README.md`, `website/docs/src/content/docs/guides/mcp.mdx`, `openspec/specs/mcp-generation/spec.md` | Modify | Replace duplicated native-agent blocks with exact markers/content, including Claude Desktop. |
+| `.github/workflows/ci.yml` | Modify | Add a fast `cargo test --test mcp_documentation` job (or focused step) before full matrix work. |
+
+## Interfaces / Contracts
+
+The implementation should expose only the metadata needed by docs:
+
+```rust
+pub struct McpAgentDocumentation {
+    pub id: &'static str,
+    pub name: &'static str,
+    pub destination: &'static str,
+    pub format: &'static str,
+    pub global: bool,
+    pub notes: &'static str,
+}
+
+impl McpAgent {
+    pub fn documentation(&self) -> McpAgentDocumentation;
+}
+```
+
+The validator's contract is exact marker pairing, one block per governed file, and byte-for-byte
+canonical block equality. No CLI output, MCP config schema, aliases, defaults, or paths change.
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|---|---|---|
+| Unit | Every moved renderer, plain/color output, blank lines, summaries, and init next steps | Move existing `main.rs` assertions with the functions; add exact `Vec<String>` assertions for previously uncovered renderers. |
+| Integration | Registry completeness and documentation drift | `tests/mcp_documentation.rs` checks all eight native agents, unique canonical IDs, marker validity, exact rows, and Claude Desktop/global notes. |
+| Regression | CLI preservation and MCP generation | Run existing focused CLI/MCP tests plus `cargo test --all-features`; compare representative `apply --dry-run`, `clean --dry-run`, and MCP outputs before/after using captured plain output. |
+
+## Migration / Rollout
+
+No migration or feature flag. Land extraction and validator/docs updates together so CI cannot
+observe a canonical registry without its governed documentation. Rollback is a normal revert;
+runtime data and generated user files are unaffected.
+
+## Open Questions
+
+- [ ] None blocking. Native MCP support is intentionally distinct from configurable-agent support.

--- a/openspec/changes/archive/2026-08-03-issue-494-500-output-doc-canonicalization/design.md
+++ b/openspec/changes/archive/2026-08-03-issue-494-500-output-doc-canonicalization/design.md
@@ -85,4 +85,4 @@ runtime data and generated user files are unaffected.
 
 ## Open Questions
 
-- [ ] None blocking. Native MCP support is intentionally distinct from configurable-agent support.
+- [x] No blocking questions remain. Native MCP support is intentionally distinct from configurable-agent support.

--- a/openspec/changes/archive/2026-08-03-issue-494-500-output-doc-canonicalization/exploration.md
+++ b/openspec/changes/archive/2026-08-03-issue-494-500-output-doc-canonicalization/exploration.md
@@ -1,0 +1,54 @@
+## Exploration: GitHub issues #494 and #500 together
+
+### Current State
+
+Issue #494: `src/main.rs` is both CLI orchestration and presentation layer. It already imports `src/output.rs` for `OutputMode`, `HumanFormatter`, `LabelKind`, and `output_mode`, but retains nearly all apply/clean presentation helpers: `render_phase`, `render_dry_run_notice`, `render_clean_phase_with_color`, `render_sync_phase_with_color`, `render_gitignore_phase_with_color`, `render_mcp_phase`, `render_count`, `render_apply_summary_with_color`, `render_clean_summary_with_color`, `render_mcp_summary_with_color`, `print_lines`, `print_header`, and `init_next_steps_lines` (roughly lines 36–282 and 664–667). `handle_apply`, `handle_clean`, `handle_init`, `handle_apply_gitignore`, and `handle_apply_mcp` orchestrate filesystem/config work and call those renderers. `src/commands/status.rs` independently owns status rendering (`render_status_entry`, `render_status_hint`, `render_status_summary`) and JSON serialization (`serde_json::to_string_pretty`), while `src/output.rs` currently only owns output-mode detection and formatter primitives. Human output is line-oriented, uses `colored`, and disables color when JSON, stdout is not a TTY, `NO_COLOR` is set, `CLICOLOR=0`, or `TERM=dumb`. Status JSON is an array of `StatusEntry`; non-zero problems exit with code 1. Apply/clean do not have a JSON mode and print directly from orchestration and `init` itself.
+
+Issue #500: MCP support is structurally centralized in `src/mcp.rs` through `McpAgent` and its methods `all`, `id`, `name`, `config_path`, `resolved_config_path`, `is_global`, `formatter`, and `from_id`. The current canonical runtime list is eight agents: Claude Code, Claude Desktop, GitHub Copilot, Codex CLI, Gemini CLI, VS Code, Cursor, and OpenCode. `src/agent_ids.rs` separately contains canonical IDs/aliases for those MCP agents and 25+ configurable-only agents, plus convention filenames and ignore patterns. Documentation is duplicated in `README.md`, `npm/agentsync/README.md`, `website/docs/src/content/docs/guides/mcp.mdx`, `website/docs/src/content/docs/reference/configuration.mdx`, and `openspec/specs/mcp-generation/spec.md`; the OpenSpec MCP table is already stale because it omits Claude Desktop. README explicitly says its list is canonical while also saying `src/mcp.rs` is authoritative, and website README instructs maintainers to cross-check source manually. There is no dedicated `.github/workflows` documentation-drift validation job beyond the existing Rust check/fmt/clippy/test/build/audit/E2E jobs. No scripts currently generate or validate the lists.
+
+### Affected Areas
+- `src/main.rs` — orchestration mixed with apply/clean/init human rendering; extraction must preserve exact line order, labels, spacing, color behavior, and test helper behavior.
+- `src/output.rs` — existing output-mode/formatter boundary is the natural home for reusable human renderers and possibly output emission helpers.
+- `src/commands/status.rs` — separate human/JSON status presentation; avoid changing its JSON contract or accidentally coupling status domain validation to generic output formatting.
+- `src/commands/status_tests.rs` and `src/main.rs` tests — existing renderer assertions are mostly unit-level and currently private to the binary crate; move tests with symbols or add equivalent output-contract tests.
+- `src/mcp.rs` — runtime MCP registry and agent metadata are currently spread across enum methods and formatter dispatch; likely canonical source for MCP agent documentation metadata, but Claude Desktop global-path behavior must remain explicit.
+- `src/agent_ids.rs` — second agent registry for aliases, configurable-only agents, convention filenames, and ignore patterns; any “all supported agents” definition must distinguish native MCP agents from configurable sync agents.
+- `src/linker.rs` / `src/config.rs` — consume MCP IDs and filters and generate known ignore patterns; metadata changes must not alter selection or filesystem behavior.
+- `README.md` and `npm/agentsync/README.md` — duplicated MCP/native and broader supported-agent claims; README has conflicting “canonical” language.
+- `website/docs/src/content/docs/guides/mcp.mdx` — detailed MCP table, global-agent explanation, and behavior; currently includes all eight MCP agents.
+- `website/docs/src/content/docs/reference/configuration.mdx` — known-ignore-pattern table, currently only a partial list (through windsurf in the inspected section), not equivalent to MCP support.
+- `openspec/specs/mcp-generation/spec.md` — durable MCP spec table and code references; currently omits Claude Desktop from the supported-agent table and should be treated as a governed artifact, not an independently hand-maintained runtime registry.
+- `.github/workflows/ci.yml` — existing CI entry point; add a focused, fast drift-validation step/job rather than coupling docs validation to full Rust builds.
+- `scripts/` — only setup/version scripts exist; a small deterministic validator/generator could live here, or validation could be a Rust test if metadata is exposed safely.
+
+### Approaches
+1. **Canonical Rust metadata + generated documentation fragments** — Extend `McpAgent` (or a dedicated public metadata table adjacent to it) with stable ID, display name, destination, format, global flag, and notes; generate/check marked fragments in README/docs/OpenSpec/npm README via a Rust or small script tool.
+   - Pros: runtime and docs derive from the same typed registry; prevents omissions such as Claude Desktop; preserves enum/formatter behavior; CI can fail deterministically.
+   - Cons: requires choosing generated-fragment markers and handling Markdown table rendering; broader configurable-agent list still needs a separate canonical registry or explicit scope.
+   - Effort: Medium.
+
+2. **Data file as canonical source + code/docs generation** — Create a versioned TOML/JSON/YAML manifest containing native MCP and configurable agent metadata, load it for runtime or build-time generation, and generate docs from it.
+   - Pros: easy for tooling and documentation generation; one source can cover MCP paths, aliases, configurable agents, and ignore patterns.
+   - Cons: runtime enum methods currently encode formatter dispatch and global path semantics; moving behavior into data risks invalid combinations and weak typing; larger migration and more behavior-change risk.
+   - Effort: High.
+
+3. **Docs validator only, with runtime list unchanged** — Keep `McpAgent::all()` and `agent_ids.rs` as code sources, parse selected Markdown tables in CI, and compare their IDs/rows against source-derived expected values.
+   - Pros: smallest product change; directly addresses drift and can remove manual keep-in-sync wording; low implementation risk.
+   - Cons: still has multiple code registries and duplicated metadata; parser/format changes can make CI brittle; cannot make README, npm README, docs, and OpenSpec share one canonical representation without maintaining comparison rules.
+   - Effort: Low/Medium.
+
+### Recommendation
+Use Approach 1 for the native MCP surface, with a narrow explicit boundary: make one typed MCP metadata registry the canonical source for native MCP agent IDs, names, destinations, format classification, global status, and documentation notes; retain formatter dispatch and OS-specific path resolution as behavior in `McpAgent`. Generate or validate marked documentation fragments in `README.md`, `npm/agentsync/README.md`, `guides/mcp.mdx`, and `openspec/specs/mcp-generation/spec.md`, and add a fast CI validation job. Separately define whether #500’s “supported-agent” claim means native MCP agents only or all configurable agents. If it means all agents, extend the same registry concept to `agent_ids.rs`’s configurable IDs and metadata, but do not conflate native MCP capability with generic symlink support. Remove “keep in sync” prose once CI owns the invariant. For #494, move pure renderers and output helpers into `src/output.rs` while leaving command handlers and domain operations in `main.rs`; keep JSON serialization contracts in command modules unless a shared output abstraction is specifically justified.
+
+### Risks
+- Human output is an implicit CLI contract: moving functions can accidentally change whitespace, ANSI application order, blank lines, banner text, or summary labels; preserve current strings and add/retain exact renderer tests.
+- `src/init.rs` writes user-facing progress directly, so a complete “presentation extraction” cannot be achieved by changing only `main.rs`; scope #494 to main-owned rendering first and explicitly leave operation-progress output for a follow-up if needed.
+- `McpAgent::all()` currently includes Claude Desktop, but `openspec/specs/mcp-generation/spec.md` omits it; docs validation will surface an existing mismatch immediately and should update the spec artifact in the implementation phase.
+- `src/agent_ids.rs` contains many configurable-only agents and aliases not represented by `McpAgent`; a single “supported agents” table can be semantically wrong unless native MCP and configurable sync support are separated.
+- Copilot and VS Code share `.vscode/mcp.json`; generated validators must compare IDs/metadata, not assume one destination per agent.
+- Claude Desktop has a global OS-dependent path and is disabled by default; documentation must retain this distinction rather than flattening it into a project-relative destination.
+- OpenSpec source references use line ranges that will become stale after extraction; update references or use symbol-level references in the future.
+- Generated docs can create large noisy diffs; use narrowly marked fragments or a validator with stable expected tables and keep the 400-line review budget in mind.
+
+### Ready for Proposal
+Yes — the proposal can proceed if it explicitly separates (a) native MCP support from (b) configurable-agent support, names the documentation surfaces to govern, and requires exact human/JSON output preservation for #494. The main unresolved product decision is whether #500’s canonical list must cover only MCP agents or every configurable agent supported by `agent_ids.rs`.

--- a/openspec/changes/archive/2026-08-03-issue-494-500-output-doc-canonicalization/exploration.md
+++ b/openspec/changes/archive/2026-08-03-issue-494-500-output-doc-canonicalization/exploration.md
@@ -1,12 +1,14 @@
-## Exploration: GitHub issues #494 and #500 together
+# Exploration: GitHub issues #494 and #500 together
 
 ### Current State
+
 
 Issue #494: `src/main.rs` is both CLI orchestration and presentation layer. It already imports `src/output.rs` for `OutputMode`, `HumanFormatter`, `LabelKind`, and `output_mode`, but retains nearly all apply/clean presentation helpers: `render_phase`, `render_dry_run_notice`, `render_clean_phase_with_color`, `render_sync_phase_with_color`, `render_gitignore_phase_with_color`, `render_mcp_phase`, `render_count`, `render_apply_summary_with_color`, `render_clean_summary_with_color`, `render_mcp_summary_with_color`, `print_lines`, `print_header`, and `init_next_steps_lines` (roughly lines 36–282 and 664–667). `handle_apply`, `handle_clean`, `handle_init`, `handle_apply_gitignore`, and `handle_apply_mcp` orchestrate filesystem/config work and call those renderers. `src/commands/status.rs` independently owns status rendering (`render_status_entry`, `render_status_hint`, `render_status_summary`) and JSON serialization (`serde_json::to_string_pretty`), while `src/output.rs` currently only owns output-mode detection and formatter primitives. Human output is line-oriented, uses `colored`, and disables color when JSON, stdout is not a TTY, `NO_COLOR` is set, `CLICOLOR=0`, or `TERM=dumb`. Status JSON is an array of `StatusEntry`; non-zero problems exit with code 1. Apply/clean do not have a JSON mode and print directly from orchestration and `init` itself.
 
 Issue #500: MCP support is structurally centralized in `src/mcp.rs` through `McpAgent` and its methods `all`, `id`, `name`, `config_path`, `resolved_config_path`, `is_global`, `formatter`, and `from_id`. The current canonical runtime list is eight agents: Claude Code, Claude Desktop, GitHub Copilot, Codex CLI, Gemini CLI, VS Code, Cursor, and OpenCode. `src/agent_ids.rs` separately contains canonical IDs/aliases for those MCP agents and 25+ configurable-only agents, plus convention filenames and ignore patterns. Documentation is duplicated in `README.md`, `npm/agentsync/README.md`, `website/docs/src/content/docs/guides/mcp.mdx`, `website/docs/src/content/docs/reference/configuration.mdx`, and `openspec/specs/mcp-generation/spec.md`; the OpenSpec MCP table is already stale because it omits Claude Desktop. README explicitly says its list is canonical while also saying `src/mcp.rs` is authoritative, and website README instructs maintainers to cross-check source manually. There is no dedicated `.github/workflows` documentation-drift validation job beyond the existing Rust check/fmt/clippy/test/build/audit/E2E jobs. No scripts currently generate or validate the lists.
 
 ### Affected Areas
+
 - `src/main.rs` — orchestration mixed with apply/clean/init human rendering; extraction must preserve exact line order, labels, spacing, color behavior, and test helper behavior.
 - `src/output.rs` — existing output-mode/formatter boundary is the natural home for reusable human renderers and possibly output emission helpers.
 - `src/commands/status.rs` — separate human/JSON status presentation; avoid changing its JSON contract or accidentally coupling status domain validation to generic output formatting.
@@ -22,6 +24,7 @@ Issue #500: MCP support is structurally centralized in `src/mcp.rs` through `Mcp
 - `scripts/` — only setup/version scripts exist; a small deterministic validator/generator could live here, or validation could be a Rust test if metadata is exposed safely.
 
 ### Approaches
+
 1. **Canonical Rust metadata + generated documentation fragments** — Extend `McpAgent` (or a dedicated public metadata table adjacent to it) with stable ID, display name, destination, format, global flag, and notes; generate/check marked fragments in README/docs/OpenSpec/npm README via a Rust or small script tool.
    - Pros: runtime and docs derive from the same typed registry; prevents omissions such as Claude Desktop; preserves enum/formatter behavior; CI can fail deterministically.
    - Cons: requires choosing generated-fragment markers and handling Markdown table rendering; broader configurable-agent list still needs a separate canonical registry or explicit scope.
@@ -38,9 +41,11 @@ Issue #500: MCP support is structurally centralized in `src/mcp.rs` through `Mcp
    - Effort: Low/Medium.
 
 ### Recommendation
+
 Use Approach 1 for the native MCP surface, with a narrow explicit boundary: make one typed MCP metadata registry the canonical source for native MCP agent IDs, names, destinations, format classification, global status, and documentation notes; retain formatter dispatch and OS-specific path resolution as behavior in `McpAgent`. Generate or validate marked documentation fragments in `README.md`, `npm/agentsync/README.md`, `guides/mcp.mdx`, and `openspec/specs/mcp-generation/spec.md`, and add a fast CI validation job. Separately define whether #500’s “supported-agent” claim means native MCP agents only or all configurable agents. If it means all agents, extend the same registry concept to `agent_ids.rs`’s configurable IDs and metadata, but do not conflate native MCP capability with generic symlink support. Remove “keep in sync” prose once CI owns the invariant. For #494, move pure renderers and output helpers into `src/output.rs` while leaving command handlers and domain operations in `main.rs`; keep JSON serialization contracts in command modules unless a shared output abstraction is specifically justified.
 
 ### Risks
+
 - Human output is an implicit CLI contract: moving functions can accidentally change whitespace, ANSI application order, blank lines, banner text, or summary labels; preserve current strings and add/retain exact renderer tests.
 - `src/init.rs` writes user-facing progress directly, so a complete “presentation extraction” cannot be achieved by changing only `main.rs`; scope #494 to main-owned rendering first and explicitly leave operation-progress output for a follow-up if needed.
 - `McpAgent::all()` currently includes Claude Desktop, but `openspec/specs/mcp-generation/spec.md` omits it; docs validation will surface an existing mismatch immediately and should update the spec artifact in the implementation phase.
@@ -51,4 +56,5 @@ Use Approach 1 for the native MCP surface, with a narrow explicit boundary: make
 - Generated docs can create large noisy diffs; use narrowly marked fragments or a validator with stable expected tables and keep the 400-line review budget in mind.
 
 ### Ready for Proposal
+
 Yes — the proposal can proceed if it explicitly separates (a) native MCP support from (b) configurable-agent support, names the documentation surfaces to govern, and requires exact human/JSON output preservation for #494. The main unresolved product decision is whether #500’s canonical list must cover only MCP agents or every configurable agent supported by `agent_ids.rs`.

--- a/openspec/changes/archive/2026-08-03-issue-494-500-output-doc-canonicalization/proposal.md
+++ b/openspec/changes/archive/2026-08-03-issue-494-500-output-doc-canonicalization/proposal.md
@@ -7,12 +7,14 @@ Address GitHub issues #494 and #500 together: separate reusable CLI presentation
 ## Scope
 
 ### In Scope
+
 - Extract main-owned apply/clean/init presentation helpers into the output boundary while preserving exact line order, labels, spacing, ANSI behavior, and existing JSON contracts.
 - Add exact renderer/output-contract tests, retaining status JSON ownership in `src/commands/status.rs` and leaving `src/init.rs` operation progress unchanged.
 - Define one typed canonical registry for native MCP agents, including Claude Desktop, canonical IDs, names, paths, formats, global-path status, and documentation notes.
 - Generate or validate marked documentation fragments in `README.md`, `npm/agentsync/README.md`, `website/docs/src/content/docs/guides/mcp.mdx`, and `openspec/specs/mcp-generation/spec.md`; add focused CI drift validation.
 
 ### Out of Scope
+
 - Refactoring unrelated command orchestration, linker/config behavior, or `src/init.rs` progress output.
 - Treating configurable-only agents as native MCP agents or expanding the native MCP support set.
 - Changing MCP formats, paths, defaults, filtering semantics, or CLI output wording.
@@ -20,9 +22,11 @@ Address GitHub issues #494 and #500 together: separate reusable CLI presentation
 ## Capabilities
 
 ### New Capabilities
+
 - None. This change consolidates implementation and governance of existing behavior.
 
 ### Modified Capabilities
+
 - `mcp-generation`: document the complete native MCP registry, including Claude Desktop and canonical IDs, without changing generation behavior.
 - `documentation`: require governed native-agent/MCP listings and CI validation against the typed registry.
 
@@ -37,7 +41,7 @@ Move pure renderers and emission helpers from `src/main.rs` to `src/output.rs` (
 | `src/main.rs`, `src/output.rs` | Modified | Extract presentation; preserve contracts |
 | `src/mcp.rs`, `src/agent_ids.rs` | Modified | Canonical native MCP metadata and ID boundary |
 | `README.md`, `npm/agentsync/README.md`, `website/docs/src/content/docs/guides/mcp.mdx` | Modified | Governed MCP listings |
-| `openspec/specs/mcp-generation/spec.md`, `.github/workflows/ci.yml`, `scripts/` | Modified/New | Spec alignment and drift validation |
+| `openspec/specs/mcp-generation/spec.md`, `.github/workflows/ci.yml`, `tests/mcp_documentation.rs` | Modified/New | Spec alignment and drift validation |
 
 ## Risks
 
@@ -57,7 +61,7 @@ Revert the change commit(s), restoring renderer locations and documentation sour
 
 ## Success Criteria
 
-- [ ] Existing CLI output and status JSON contract tests pass unchanged.
-- [ ] Native MCP docs agree with typed metadata, including Claude Desktop and canonical IDs.
-- [ ] CI fails deterministically when governed MCP documentation drifts.
-- [ ] No unrelated agent or MCP behavior changes are introduced.
+- [x] Existing CLI output and status JSON contract tests pass unchanged.
+- [x] Native MCP docs agree with typed metadata, including Claude Desktop and canonical IDs.
+- [x] CI fails deterministically when governed MCP documentation drifts.
+- [x] No unrelated agent or MCP behavior changes are introduced.

--- a/openspec/changes/archive/2026-08-03-issue-494-500-output-doc-canonicalization/proposal.md
+++ b/openspec/changes/archive/2026-08-03-issue-494-500-output-doc-canonicalization/proposal.md
@@ -1,0 +1,63 @@
+# Proposal: CLI Output Extraction and Canonical Agent Documentation
+
+## Intent
+
+Address GitHub issues #494 and #500 together: separate reusable CLI presentation from `src/main.rs` without changing established output contracts, and eliminate supported-agent/MCP documentation drift by making native MCP metadata typed and canonical with fast CI validation.
+
+## Scope
+
+### In Scope
+- Extract main-owned apply/clean/init presentation helpers into the output boundary while preserving exact line order, labels, spacing, ANSI behavior, and existing JSON contracts.
+- Add exact renderer/output-contract tests, retaining status JSON ownership in `src/commands/status.rs` and leaving `src/init.rs` operation progress unchanged.
+- Define one typed canonical registry for native MCP agents, including Claude Desktop, canonical IDs, names, paths, formats, global-path status, and documentation notes.
+- Generate or validate marked documentation fragments in `README.md`, `npm/agentsync/README.md`, `website/docs/src/content/docs/guides/mcp.mdx`, and `openspec/specs/mcp-generation/spec.md`; add focused CI drift validation.
+
+### Out of Scope
+- Refactoring unrelated command orchestration, linker/config behavior, or `src/init.rs` progress output.
+- Treating configurable-only agents as native MCP agents or expanding the native MCP support set.
+- Changing MCP formats, paths, defaults, filtering semantics, or CLI output wording.
+
+## Capabilities
+
+### New Capabilities
+- None. This change consolidates implementation and governance of existing behavior.
+
+### Modified Capabilities
+- `mcp-generation`: document the complete native MCP registry, including Claude Desktop and canonical IDs, without changing generation behavior.
+- `documentation`: require governed native-agent/MCP listings and CI validation against the typed registry.
+
+## Approach
+
+Move pure renderers and emission helpers from `src/main.rs` to `src/output.rs` (or a narrowly scoped output submodule), preserving orchestration boundaries and contract tests. Extend `McpAgent` with typed documentation metadata while retaining formatter dispatch and OS-specific path resolution as code behavior. Use stable generated/validated Markdown markers and a deterministic validator in `scripts/` or Rust tooling, then run it as a fast CI job. Documentation must distinguish native MCP support from configurable sync support and use canonical IDs.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `src/main.rs`, `src/output.rs` | Modified | Extract presentation; preserve contracts |
+| `src/mcp.rs`, `src/agent_ids.rs` | Modified | Canonical native MCP metadata and ID boundary |
+| `README.md`, `npm/agentsync/README.md`, `website/docs/src/content/docs/guides/mcp.mdx` | Modified | Governed MCP listings |
+| `openspec/specs/mcp-generation/spec.md`, `.github/workflows/ci.yml`, `scripts/` | Modified/New | Spec alignment and drift validation |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Implicit output changes | Med | Golden/exact renderer tests and narrow extraction |
+| MCP/configurable agents conflated | Med | Explicit native-only registry and canonical IDs |
+| Noisy generated docs | Low | Stable marked fragments and focused CI |
+
+## Rollback Plan
+
+Revert the change commit(s), restoring renderer locations and documentation sources; disable/remove the validator job if needed. No runtime data migration is required.
+
+## Dependencies
+
+- Existing MCP registry and CI workflow; no new runtime dependency required.
+
+## Success Criteria
+
+- [ ] Existing CLI output and status JSON contract tests pass unchanged.
+- [ ] Native MCP docs agree with typed metadata, including Claude Desktop and canonical IDs.
+- [ ] CI fails deterministically when governed MCP documentation drifts.
+- [ ] No unrelated agent or MCP behavior changes are introduced.

--- a/openspec/changes/archive/2026-08-03-issue-494-500-output-doc-canonicalization/specs/cli-output/spec.md
+++ b/openspec/changes/archive/2026-08-03-issue-494-500-output-doc-canonicalization/specs/cli-output/spec.md
@@ -1,0 +1,43 @@
+# CLI Output Presentation Specification
+
+## Purpose
+
+Preserve AgentSync's established human and machine-readable output while moving reusable
+presentation concerns out of command orchestration.
+
+## Requirements
+
+### Requirement: Human Output Is Contract-Preserving
+
+The CLI MUST preserve existing human-output line order, labels, spacing, blank lines, summaries,
+and ANSI color behavior when presentation helpers are extracted.
+
+#### Scenario: Colored terminal output remains unchanged
+
+- GIVEN an apply or clean operation runs with a color-capable TTY
+- WHEN the operation emits human output
+- THEN the output MUST retain the existing labels, ordering, spacing, and ANSI coloring
+
+#### Scenario: Color is disabled consistently
+
+- GIVEN JSON mode, a non-TTY stdout, `NO_COLOR`, `CLICOLOR=0`, or `TERM=dumb`
+- WHEN human output is rendered
+- THEN no ANSI escape sequences MUST be emitted
+
+### Requirement: Output Contracts Have Exact Tests
+
+The project MUST maintain exact output-contract tests for extracted apply, clean, and summary
+renderers, including colored and uncolored paths. Existing status JSON serialization MUST remain
+owned by its command module and unchanged.
+
+#### Scenario: Renderer regression is detected
+
+- GIVEN a renderer's expected lines, whitespace, or labels change
+- WHEN the focused output tests run
+- THEN the test suite MUST fail with the differing output
+
+#### Scenario: Status JSON remains compatible
+
+- GIVEN `agentsync status --json` produces a status array
+- WHEN the output implementation is reorganized
+- THEN its JSON shape and non-zero problem exit behavior MUST remain unchanged

--- a/openspec/changes/archive/2026-08-03-issue-494-500-output-doc-canonicalization/specs/documentation/spec.md
+++ b/openspec/changes/archive/2026-08-03-issue-494-500-output-doc-canonicalization/specs/documentation/spec.md
@@ -1,0 +1,45 @@
+# Delta for Documentation
+
+## ADDED Requirements
+
+### Requirement: Native MCP Documentation Has One Governed Source
+
+Documentation MUST identify native MCP support separately from generic configurable-agent support.
+The README, npm README, MCP guide, and MCP OpenSpec MUST use the canonical native MCP IDs and
+metadata, including Claude Desktop. Documentation MUST describe Claude Desktop's global,
+OS-dependent scope when supported and MUST NOT claim that all configurable agents are native MCP
+agents.
+
+#### Scenario: Reader sees a complete native MCP list
+
+- GIVEN a reader checks any governed native-MCP documentation surface
+- WHEN the supported agents are listed
+- THEN the list MUST use canonical IDs and include Claude Desktop
+- AND its entries MUST agree with the typed runtime metadata
+
+#### Scenario: Reader understands Claude Desktop scope
+
+- GIVEN Claude Desktop is enabled or documented as supported
+- WHEN the reader reviews its MCP entry
+- THEN the documentation MUST identify its global OS-dependent destination
+- AND MUST preserve any default-disabled or opt-in distinction
+
+### Requirement: Manual Documentation Synchronization Guidance Is Removed
+
+The documentation MUST NOT instruct maintainers to manually cross-check or keep native MCP agent
+lists synchronized. It MUST instead point to the automated generation or CI drift validation as
+the governing maintenance mechanism.
+
+#### Scenario: Maintainer updates native MCP metadata
+
+- GIVEN a maintainer changes the canonical native MCP registry
+- WHEN the maintainer follows repository documentation guidance
+- THEN the guidance MUST direct them to the generator or validator and focused CI check
+- AND MUST NOT require an undocumented manual comparison process
+
+#### Scenario: Documentation drift is reported
+
+- GIVEN a governed native-MCP fragment no longer matches the registry
+- WHEN CI validation runs
+- THEN the documentation workflow MUST report the drift clearly
+- AND MUST fail before the change is accepted

--- a/openspec/changes/archive/2026-08-03-issue-494-500-output-doc-canonicalization/specs/mcp-generation/spec.md
+++ b/openspec/changes/archive/2026-08-03-issue-494-500-output-doc-canonicalization/specs/mcp-generation/spec.md
@@ -1,0 +1,51 @@
+# Delta for MCP Configuration Generation
+
+## ADDED Requirements
+
+### Requirement: Canonical Typed Native MCP Metadata
+
+The system MUST expose one typed canonical registry for native MCP agents. Each registry entry
+MUST define the canonical ID, display name, documented destination, format classification, global
+path status, and documentation notes. The registry MUST include Claude Desktop and MUST distinguish
+native MCP support from configurable-only agent support. Runtime generation behavior, defaults,
+filters, aliases, and OS-specific path resolution MUST NOT change solely because metadata is
+centralized.
+
+#### Scenario: Registry represents every native MCP agent
+
+- GIVEN the native MCP registry is enumerated
+- WHEN documentation metadata is requested
+- THEN Claude Desktop and every currently supported native MCP agent MUST appear exactly once
+- AND each entry MUST have non-empty canonical ID, name, format, and path metadata
+
+#### Scenario: Shared and global destinations remain explicit
+
+- GIVEN Copilot and VS Code share `.vscode/mcp.json`
+- AND Claude Desktop uses an OS-dependent global destination
+- WHEN metadata is rendered
+- THEN the shared path and global-path distinction MUST be retained
+
+#### Scenario: Configurable-only agents are not mislabeled
+
+- GIVEN an agent is supported for generic synchronization but not native MCP generation
+- WHEN supported-agent documentation is produced
+- THEN it MUST NOT be listed as a native MCP agent
+
+### Requirement: MCP Documentation Drift Is Validated
+
+The project MUST generate or deterministically validate marked native-MCP documentation fragments in
+the repository README, npm README, MCP guide, and MCP OpenSpec. CI MUST run this check as a focused
+validation and fail when a governed fragment differs from the canonical registry. Manual
+keep-in-sync instructions MUST be removed.
+
+#### Scenario: Documentation matches metadata
+
+- GIVEN all governed documentation fragments were produced from the canonical registry
+- WHEN the documentation validation runs
+- THEN CI MUST pass
+
+#### Scenario: Drift blocks CI
+
+- GIVEN a governed MCP ID, name, destination, format, or Claude Desktop row is stale or missing
+- WHEN the validation runs
+- THEN CI MUST fail and identify the drifted documentation fragment

--- a/openspec/changes/archive/2026-08-03-issue-494-500-output-doc-canonicalization/state.yaml
+++ b/openspec/changes/archive/2026-08-03-issue-494-500-output-doc-canonicalization/state.yaml
@@ -1,0 +1,11 @@
+change: issue-494-500-output-doc-canonicalization
+current_phase: archive
+completed:
+  - explore
+  - propose
+  - tasks
+  - apply
+  - verify
+  - archive
+next: none
+updated: 2026-08-03

--- a/openspec/changes/archive/2026-08-03-issue-494-500-output-doc-canonicalization/tasks.md
+++ b/openspec/changes/archive/2026-08-03-issue-494-500-output-doc-canonicalization/tasks.md
@@ -1,0 +1,48 @@
+# Tasks: CLI Output Extraction and Canonical Agent Documentation
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | 300–450 |
+| 400-line budget risk | Medium |
+| Chained PRs recommended | No |
+| Suggested split | Single PR: extraction, registry/docs validation, CI and regressions |
+| Delivery strategy | ask-on-risk |
+| Chain strategy | single-pr |
+
+Decision needed before apply: Yes
+Chained PRs recommended: No
+Chain strategy: single-pr
+400-line budget risk: Medium
+
+### Suggested Work Units
+
+| Unit | Goal | Likely PR | Notes |
+|------|------|-----------|-------|
+| 1 | Output boundary and exact renderer tests | PR 1 | Base: trunk; tests first, then `src/output.rs` extraction |
+| 2 | Typed MCP metadata, governed docs, and drift CI | PR 1 | Depends on Unit 1; verify with focused cargo tests and CI config review |
+
+## Phase 1: TDD Contracts and Foundation
+
+- [x] 1.1 Add failing exact renderer tests in `src/output.rs`/its test module for apply, clean, summary, color, blank lines, and `print_lines`; verify with `cargo test output`.
+- [x] 1.2 Add failing integration coverage in new `tests/mcp_documentation.rs` for eight native agents, unique IDs, markers, Claude Desktop global notes, and stale/missing rows; verify with `cargo test --test mcp_documentation`.
+- [x] 1.3 Add failing MCP metadata unit tests in `src/mcp.rs` for non-empty fields, shared Copilot/VS Code destination, and native-only membership; verify with `cargo test mcp`.
+
+## Phase 2: Output Extraction
+
+- [x] 2.1 Move pure apply/clean/init renderers, banner emission, and `print_lines` from `src/main.rs` to `src/output.rs`, preserving `Vec<String>` ordering and `HumanFormatter` behavior; depend on 1.1; run `cargo test output`.
+- [x] 2.2 Update `src/main.rs` imports/call sites to use output APIs while leaving orchestration, `src/init.rs` progress, and `commands/status.rs` JSON ownership unchanged; run `cargo test --all-features`.
+
+## Phase 3: Canonical Metadata and Documentation
+
+- [x] 3.1 Add typed native-MCP documentation metadata/accessor to `src/mcp.rs` without changing generation, aliases, defaults, filters, or OS path resolution; depend on 1.3; run `cargo test mcp`.
+- [x] 3.2 Replace native-MCP blocks in `README.md`, `npm/agentsync/README.md`, `website/docs/src/content/docs/guides/mcp.mdx`, and `openspec/specs/mcp-generation/spec.md` with exact marked fragments; include Claude Desktop and remove manual sync guidance.
+- [x] 3.3 Implement deterministic marker extraction/rendering and byte-for-byte comparison in `tests/mcp_documentation.rs`, including duplicate/stale rows outside governed fragments; depend on 1.2 and 3.1; run `cargo test --test mcp_documentation`.
+- [x] 3.4 Strengthen the verifier-required drift regression to reject abbreviated native-MCP rows outside markers and remove the stale duplicate README row; run focused and full Rust checks.
+
+## Phase 4: CI and Regression Verification
+
+- [x] 4.1 Add a focused `cargo test --test mcp_documentation` step/job to `.github/workflows/ci.yml` before the full matrix; verify YAML and command consistency.
+- [x] 4.2 Run regression checks for representative apply/clean dry-run output, status JSON, and MCP generation: `cargo test --all-features` and `cargo test --test mcp_documentation`.
+- [x] 4.3 Run `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings`; confirm no unrelated output, MCP, or configurable-agent behavior changes.

--- a/openspec/changes/archive/2026-08-03-issue-494-500-output-doc-canonicalization/verify-report.md
+++ b/openspec/changes/archive/2026-08-03-issue-494-500-output-doc-canonicalization/verify-report.md
@@ -1,0 +1,71 @@
+# Verification Report
+
+## Change
+`issue-494-500-output-doc-canonicalization`
+
+## Verdict
+**PASS WITH WARNINGS**
+
+## Completeness
+
+| Area | Result | Evidence |
+|---|---|---|
+| Proposal, specs, design, tasks reviewed | PASS | All required change artifacts and three delta specs reviewed |
+| Tasks | PASS | Tasks 1.1–4.3 are complete; no incomplete core or cleanup task remains |
+| Focused tests | PASS | `cargo test --test mcp_documentation` (2 passed); `cargo test output` (50 passed) |
+| Full tests | PASS | `cargo test --all-features` (470 library, 161 binary, 109 integration, 2 MCP-documentation, 0 failures; 2 ignored) |
+| Formatting/lint | PASS | `cargo fmt --all -- --check`; `cargo clippy --all-targets --all-features -- -D warnings` |
+| Diff check | PASS | `git diff --check` |
+
+## Spec compliance matrix
+
+| Requirement/scenario | Evidence | Result |
+|---|---|---|
+| Extracted human output preserves contracts | Output-boundary tests cover exact summaries, renderer paths, color/plain behavior, init footer, and `print_lines`; full suite passes | COMPLIANT |
+| Status JSON remains compatible and owned by status command | `commands/status.rs` ownership unchanged; full tests pass | COMPLIANT |
+| Typed native MCP registry is complete and unique | `McpAgent::all()` metadata test verifies eight entries, unique IDs, and non-empty fields | COMPLIANT |
+| Shared Copilot/VS Code destination remains explicit | Focused registry test verifies both use `.vscode/mcp.json` | COMPLIANT |
+| Claude Desktop global OS-dependent/default-disabled scope remains explicit | Metadata and canonical row retain `Global OS-dependent config`, `Global`, and `disabled by default` | COMPLIANT |
+| Configurable-only agents are not listed as native MCP | Canonical rows are rendered only from `McpAgent::all()`; governed fragments contain exactly those rows | COMPLIANT |
+| Exact MCP fragment/row/marker validation | Validator requires exactly one start/end marker, correct order, byte-for-byte canonical fragment equality, and rejects any native-style row outside the fragment | COMPLIANT |
+| Stale names, wrong order, changed notes/formats, and duplicates are rejected | Exact fragment equality makes any row/text/order/duplicate drift unequal; marker cardinality rejects duplicate markers | COMPLIANT |
+| README has no stale duplicate native-MCP list | Focused test rejects canonical/native row syntax outside the single governed fragment; README now contains only the marked list | COMPLIANT |
+| Manual synchronization guidance removed | Governed docs point to typed registry/CI validation and contain no manual keep-in-sync instruction | COMPLIANT |
+| Focused CI validation wired | `.github/workflows/ci.yml` runs `cargo test --test mcp_documentation` before the full matrix | COMPLIANT |
+| Runtime MCP generation/defaults/aliases/path resolution unchanged | Full feature suite passes; implementation keeps generation and path-resolution behavior in place | COMPLIANT |
+
+## Correctness table
+
+| Finding | Judge A | Judge B | Severity | Status |
+|---|---|---|---|---|
+| Weak MCP documentation validator accepted partial/stale rows | ✅ | ✅ | CRITICAL | Resolved |
+| Duplicate stale native-agent list remained in `README.md` | ✅ | ✅ | CRITICAL | Resolved |
+| Missing captured `print_lines` output contract test | ✅ | ✅ | WARNING | Resolved |
+| No durable red-phase TDD evidence | ✅ | ✅ | WARNING | Open evidence gap |
+
+## Design coherence
+
+| Decision | Result |
+|---|---|
+| `src/output.rs` owns pure presentation while `main.rs` remains orchestration | Coherent |
+| `src/mcp.rs` owns typed native MCP metadata | Coherent |
+| Marked docs are validated against deterministic canonical rows | Coherent and implemented |
+| Status JSON remains in `commands/status.rs` | Preserved |
+
+## Issues
+
+### WARNING
+1. The repository contains no committed red-phase transcript/artifact proving each TDD test first failed before implementation. Runtime correctness is verified; this is a process-evidence gap only.
+
+## Checks run
+
+- `cargo test --test mcp_documentation` — PASS
+- `cargo test output` — PASS
+- `cargo test --all-features` — PASS
+- `cargo fmt --all -- --check` — PASS
+- `cargo clippy --all-targets --all-features -- -D warnings` — PASS
+- `git diff --check` — PASS
+
+## Next action
+
+Proceed to archive. No critical verification issue remains.

--- a/openspec/changes/archive/2026-08-03-issue-494-500-output-doc-canonicalization/verify-report.md
+++ b/openspec/changes/archive/2026-08-03-issue-494-500-output-doc-canonicalization/verify-report.md
@@ -1,9 +1,11 @@
 # Verification Report
 
 ## Change
+
 `issue-494-500-output-doc-canonicalization`
 
 ## Verdict
+
 **PASS WITH WARNINGS**
 
 ## Completeness
@@ -31,7 +33,7 @@
 | Stale names, wrong order, changed notes/formats, and duplicates are rejected | Exact fragment equality makes any row/text/order/duplicate drift unequal; marker cardinality rejects duplicate markers | COMPLIANT |
 | README has no stale duplicate native-MCP list | Focused test rejects canonical/native row syntax outside the single governed fragment; README now contains only the marked list | COMPLIANT |
 | Manual synchronization guidance removed | Governed docs point to typed registry/CI validation and contain no manual keep-in-sync instruction | COMPLIANT |
-| Focused CI validation wired | `.github/workflows/ci.yml` runs `cargo test --test mcp_documentation` before the full matrix | COMPLIANT |
+| Focused CI validation wired | `.github/workflows/ci.yml` defines a standalone `mcp-documentation` job running `cargo test --test mcp_documentation`; it has no dependency ordering with the full matrix | COMPLIANT |
 | Runtime MCP generation/defaults/aliases/path resolution unchanged | Full feature suite passes; implementation keeps generation and path-resolution behavior in place | COMPLIANT |
 
 ## Correctness table
@@ -55,6 +57,7 @@
 ## Issues
 
 ### WARNING
+
 1. The repository contains no committed red-phase transcript/artifact proving each TDD test first failed before implementation. Runtime correctness is verified; this is a process-evidence gap only.
 
 ## Checks run

--- a/openspec/specs/cli-output/spec.md
+++ b/openspec/specs/cli-output/spec.md
@@ -1,0 +1,43 @@
+# CLI Output Presentation Specification
+
+## Purpose
+
+Preserve AgentSync's established human and machine-readable output while moving reusable
+presentation concerns out of command orchestration.
+
+## Requirements
+
+### Requirement: Human Output Is Contract-Preserving
+
+The CLI MUST preserve existing human-output line order, labels, spacing, blank lines, summaries,
+and ANSI color behavior when presentation helpers are extracted.
+
+#### Scenario: Colored terminal output remains unchanged
+
+- GIVEN an apply or clean operation runs with a color-capable TTY
+- WHEN the operation emits human output
+- THEN the output MUST retain the existing labels, ordering, spacing, and ANSI coloring
+
+#### Scenario: Color is disabled consistently
+
+- GIVEN JSON mode, a non-TTY stdout, `NO_COLOR`, `CLICOLOR=0`, or `TERM=dumb`
+- WHEN human output is rendered
+- THEN no ANSI escape sequences MUST be emitted
+
+### Requirement: Output Contracts Have Exact Tests
+
+The project MUST maintain exact output-contract tests for extracted apply, clean, and summary
+renderers, including colored and uncolored paths. Existing status JSON serialization MUST remain
+owned by its command module and unchanged.
+
+#### Scenario: Renderer regression is detected
+
+- GIVEN a renderer's expected lines, whitespace, or labels change
+- WHEN the focused output tests run
+- THEN the test suite MUST fail with the differing output
+
+#### Scenario: Status JSON remains compatible
+
+- GIVEN `agentsync status --json` produces a status array
+- WHEN the output implementation is reorganized
+- THEN its JSON shape and non-zero problem exit behavior MUST remain unchanged

--- a/openspec/specs/documentation/spec.md
+++ b/openspec/specs/documentation/spec.md
@@ -1,6 +1,6 @@
 # Documentation Specification
 
-### Requirement: Native MCP Documentation Has One Governed Source
+## Requirement: Native MCP Documentation Has One Governed Source
 
 Documentation MUST identify native MCP support separately from generic configurable-agent support.
 The README, npm README, MCP guide, and MCP OpenSpec MUST use the canonical native MCP IDs and

--- a/openspec/specs/documentation/spec.md
+++ b/openspec/specs/documentation/spec.md
@@ -1,5 +1,41 @@
 # Documentation Specification
 
+### Requirement: Native MCP Documentation Has One Governed Source
+
+Documentation MUST identify native MCP support separately from generic configurable-agent support.
+The README, npm README, MCP guide, and MCP OpenSpec MUST use the canonical native MCP IDs and
+metadata, including Claude Desktop. Documentation MUST describe Claude Desktop's global,
+OS-dependent scope when supported and MUST NOT claim that all configurable agents are native MCP
+agents.
+
+#### Scenario: Reader sees a complete native MCP list
+
+- GIVEN a reader checks any governed native-MCP documentation surface
+- WHEN the supported agents are listed
+- THEN the list MUST use canonical IDs and include Claude Desktop
+- AND its entries MUST agree with the typed runtime metadata
+
+#### Scenario: Reader understands Claude Desktop scope
+
+- GIVEN Claude Desktop is enabled or documented as supported
+- WHEN the reader reviews its MCP entry
+- THEN the documentation MUST identify its global OS-dependent destination
+- AND MUST preserve any default-disabled or opt-in distinction
+
+### Requirement: Manual Documentation Synchronization Guidance Is Removed
+
+The documentation MUST NOT instruct maintainers to manually cross-check or keep native MCP agent
+lists synchronized. It MUST instead point to the automated generation or CI drift validation as
+the governing maintenance mechanism.
+
+#### Scenario: Documentation drift is reported
+
+- GIVEN a governed native-MCP fragment no longer matches the registry
+- WHEN CI validation runs
+- THEN the documentation workflow MUST report the drift clearly
+- AND MUST fail before the change is accepted
+
+
 ## Purpose
 
 Defines how AgentSync documentation explains gitignore-related team workflows so readers can adopt

--- a/openspec/specs/mcp-generation/spec.md
+++ b/openspec/specs/mcp-generation/spec.md
@@ -11,7 +11,7 @@
 - **OpenCode** — `opencode.json` (agent id: `opencode`) — JSON; Standard format
 <!-- agentsync:mcp:end -->
 
-### Requirement: Canonical Typed Native MCP Metadata
+## Requirement: Canonical Typed Native MCP Metadata
 
 The system MUST expose one typed canonical registry for native MCP agents. Each registry entry
 MUST define canonical ID, display name, documented destination, format classification, global path

--- a/openspec/specs/mcp-generation/spec.md
+++ b/openspec/specs/mcp-generation/spec.md
@@ -1,5 +1,25 @@
 # Specification: MCP Configuration Generation
 
+<!-- agentsync:mcp:start -->
+- **Claude Code** — `.mcp.json` (agent id: `claude`) — JSON; Standard format
+- **Claude Desktop** — `Global OS-dependent config` (agent id: `claude-desktop`) — JSON; Global; disabled by default
+- **GitHub Copilot** — `.vscode/mcp.json` (agent id: `copilot`) — JSON; Shared with VS Code
+- **OpenAI Codex CLI** — `.codex/config.toml` (agent id: `codex`) — TOML; Maps headers to http_headers
+- **Gemini CLI** — `.gemini/settings.json` (agent id: `gemini`) — JSON; Adds trust: true
+- **VS Code** — `.vscode/mcp.json` (agent id: `vscode`) — JSON; Shared with GitHub Copilot
+- **Cursor** — `.cursor/mcp.json` (agent id: `cursor`) — JSON; Standard format
+- **OpenCode** — `opencode.json` (agent id: `opencode`) — JSON; Standard format
+<!-- agentsync:mcp:end -->
+
+### Requirement: Canonical Typed Native MCP Metadata
+
+The system MUST expose one typed canonical registry for native MCP agents. Each registry entry
+MUST define canonical ID, display name, documented destination, format classification, global path
+status, and documentation notes. Configurable-only agents MUST NOT be listed as native MCP agents.
+Runtime generation behavior, defaults, filters, aliases, and OS-specific path resolution MUST remain
+unchanged.
+
+
 **Type**: RETROSPEC  
 **Date**: 2026-04-01  
 **Status**: RETROSPEC  

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,4 +16,4 @@ pub mod update_check;
 
 pub use config::Config;
 pub use linker::{Linker, SyncOptions, SyncResult};
-pub use mcp::{McpAgent, McpGenerator, McpSyncResult};
+pub use mcp::{McpAgent, McpAgentDocumentation, McpGenerator, McpSyncResult};

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,14 +14,12 @@ mod output;
 use commands::doctor::run_doctor;
 use commands::skill::{SkillCommand, run_skill};
 use commands::status::{StatusArgs, run_status};
-use output::{HumanFormatter, LabelKind, output_mode};
-
-fn human_use_color() -> bool {
-    match output_mode(false) {
-        output::OutputMode::Human { use_color } => use_color,
-        output::OutputMode::Json => false,
-    }
-}
+use output::{
+    human_use_color, init_next_steps_lines, print_header, print_lines,
+    render_apply_summary_with_color, render_clean_phase_with_color,
+    render_clean_summary_with_color, render_dry_run_notice, render_gitignore_phase_with_color,
+    render_mcp_phase, render_mcp_summary_with_color, render_sync_phase_with_color,
+};
 
 fn current_project_root<F>(path: Option<PathBuf>, current_dir: F) -> Result<PathBuf>
 where
@@ -33,252 +31,11 @@ where
     )
 }
 
-fn render_phase(title: &str, detail: &str, use_color: bool) -> Vec<String> {
-    let formatter = HumanFormatter::new(use_color);
-    vec![
-        formatter.format_heading(&format!("➤ {title}")),
-        format!("  {detail}"),
-    ]
-}
-
-fn render_dry_run_notice(use_color: bool) -> Vec<String> {
-    let formatter = HumanFormatter::new(use_color);
-    vec![
-        formatter.format_label("!", "Dry run", LabelKind::Warning),
-        "  No filesystem changes will be made.".to_string(),
-    ]
-}
-
 fn merge_clean_result_into_apply_result(result: &mut SyncResult, clean_result: &SyncResult) {
     result.updated += clean_result.updated;
     result.skipped += clean_result.skipped;
     result.removed += clean_result.removed;
     result.errors += clean_result.errors;
-}
-
-#[cfg(test)]
-fn render_clean_phase(dry_run: bool) -> Vec<String> {
-    render_clean_phase_with_color(dry_run, false)
-}
-
-fn render_clean_phase_with_color(dry_run: bool, use_color: bool) -> Vec<String> {
-    render_phase(
-        "Clean",
-        if dry_run {
-            "Previewing managed symlink removals"
-        } else {
-            "Removing managed symlinks"
-        },
-        use_color,
-    )
-}
-
-#[cfg(test)]
-fn render_sync_phase(dry_run: bool, clean_first: bool) -> Vec<String> {
-    render_sync_phase_with_color(dry_run, clean_first, false)
-}
-
-fn render_sync_phase_with_color(dry_run: bool, clean_first: bool, use_color: bool) -> Vec<String> {
-    let detail = match (dry_run, clean_first) {
-        (true, true) => "Previewing clean and sync changes",
-        (true, false) => "Previewing agent configuration changes",
-        (false, true) => "Cleaning existing symlinks before syncing",
-        (false, false) => "Syncing agent configurations",
-    };
-    render_phase("Sync", detail, use_color)
-}
-
-#[cfg(test)]
-fn render_gitignore_phase(enabled: bool, dry_run: bool) -> Vec<String> {
-    render_gitignore_phase_with_color(enabled, dry_run, false)
-}
-
-fn render_gitignore_phase_with_color(enabled: bool, dry_run: bool, use_color: bool) -> Vec<String> {
-    let detail = match (enabled, dry_run) {
-        (true, true) => "Previewing .gitignore update",
-        (true, false) => "Updating .gitignore",
-        (false, true) => "Previewing .gitignore cleanup",
-        (false, false) => "Cleaning .gitignore",
-    };
-    render_phase("Gitignore", detail, use_color)
-}
-
-fn render_mcp_phase(dry_run: bool, use_color: bool) -> Vec<String> {
-    render_phase(
-        "MCP",
-        if dry_run {
-            "Previewing MCP configuration changes"
-        } else {
-            "Syncing MCP configurations"
-        },
-        use_color,
-    )
-}
-
-fn render_count(label: &str, value: usize, kind: LabelKind, use_color: bool) -> String {
-    let formatter = HumanFormatter::new(use_color);
-    format!(
-        "  {}",
-        formatter.format_summary_line(label, &value.to_string(), kind)
-    )
-}
-
-#[cfg(test)]
-fn render_apply_summary(dry_run: bool, result: &SyncResult) -> Vec<String> {
-    render_apply_summary_with_color(dry_run, result, false)
-}
-
-fn render_apply_summary_with_color(
-    dry_run: bool,
-    result: &SyncResult,
-    use_color: bool,
-) -> Vec<String> {
-    let formatter = HumanFormatter::new(use_color);
-    let has_errors = result.errors > 0;
-    let mut lines = vec![formatter.format_label(
-        if has_errors { "✗" } else { "✔" },
-        match (dry_run, has_errors) {
-            (true, true) => "Sync dry run completed with errors",
-            (true, false) => "Sync dry run complete",
-            (false, true) => "Sync completed with errors",
-            (false, false) => "Sync complete",
-        },
-        if has_errors {
-            LabelKind::Failure
-        } else {
-            LabelKind::Success
-        },
-    )];
-    lines.push(render_count(
-        "Created",
-        result.created,
-        LabelKind::Success,
-        use_color,
-    ));
-    lines.push(render_count(
-        "Updated",
-        result.updated,
-        LabelKind::Warning,
-        use_color,
-    ));
-    lines.push(render_count(
-        "Skipped",
-        result.skipped,
-        LabelKind::Muted,
-        use_color,
-    ));
-    lines.push(render_count(
-        "Removed",
-        result.removed,
-        if result.removed > 0 {
-            LabelKind::Warning
-        } else {
-            LabelKind::Muted
-        },
-        use_color,
-    ));
-    lines.push(render_count(
-        "Errors",
-        result.errors,
-        if result.errors > 0 {
-            LabelKind::Failure
-        } else {
-            LabelKind::Muted
-        },
-        use_color,
-    ));
-
-    lines
-}
-
-#[cfg(test)]
-fn render_clean_summary(dry_run: bool, result: &SyncResult) -> Vec<String> {
-    render_clean_summary_with_color(dry_run, result, false)
-}
-
-fn render_clean_summary_with_color(
-    dry_run: bool,
-    result: &SyncResult,
-    use_color: bool,
-) -> Vec<String> {
-    let formatter = HumanFormatter::new(use_color);
-    let has_errors = result.errors > 0;
-    vec![
-        formatter.format_label(
-            if has_errors { "✗" } else { "✔" },
-            match (dry_run, has_errors) {
-                (true, true) => "Clean dry run completed with errors",
-                (true, false) => "Clean dry run complete",
-                (false, true) => "Clean completed with errors",
-                (false, false) => "Clean complete",
-            },
-            if has_errors {
-                LabelKind::Failure
-            } else {
-                LabelKind::Success
-            },
-        ),
-        render_count(
-            if dry_run { "Would remove" } else { "Removed" },
-            result.removed,
-            LabelKind::Success,
-            use_color,
-        ),
-        render_count(
-            "Errors",
-            result.errors,
-            if result.errors > 0 {
-                LabelKind::Failure
-            } else {
-                LabelKind::Muted
-            },
-            use_color,
-        ),
-    ]
-}
-
-#[cfg(test)]
-fn render_mcp_summary(result: &agentsync::mcp::McpSyncResult) -> Vec<String> {
-    render_mcp_summary_with_color(result, false)
-}
-
-fn render_mcp_summary_with_color(
-    result: &agentsync::mcp::McpSyncResult,
-    use_color: bool,
-) -> Vec<String> {
-    vec![
-        render_count("Created", result.created, LabelKind::Success, use_color),
-        render_count("Updated", result.updated, LabelKind::Warning, use_color),
-        render_count("Skipped", result.skipped, LabelKind::Muted, use_color),
-        render_count(
-            "Errors",
-            result.errors,
-            if result.errors > 0 {
-                LabelKind::Failure
-            } else {
-                LabelKind::Muted
-            },
-            use_color,
-        ),
-    ]
-}
-
-fn print_lines(lines: &[String]) {
-    for line in lines {
-        println!("{line}");
-    }
-}
-
-fn init_next_steps_lines(wizard: bool) -> Option<Vec<String>> {
-    if wizard {
-        return None;
-    }
-
-    Some(vec![
-        "Next steps:".to_string(),
-        "  1. Edit .agents/AGENTS.md with your project instructions".to_string(),
-        "  2. Run agentsync apply to create symlinks".to_string(),
-    ])
 }
 
 // tracing_subscriber is used to initialize logging in main
@@ -661,20 +418,38 @@ fn handle_clean(
     Ok(())
 }
 
-fn print_header() {
-    let banner = include_str!("banner.txt");
-    println!("{}", banner.cyan().bold());
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{
-        Cli, Commands, current_project_root, init_next_steps_lines, render_apply_summary,
-        render_clean_phase, render_clean_summary, render_dry_run_notice, render_gitignore_phase,
-        render_mcp_summary, render_sync_phase,
+    use super::{Cli, Commands, current_project_root};
+    use crate::output::{
+        init_next_steps_lines, render_apply_summary_with_color, render_clean_phase_with_color,
+        render_clean_summary_with_color, render_gitignore_phase_with_color,
+        render_mcp_summary_with_color, render_sync_phase_with_color,
     };
     use agentsync::{SyncResult, mcp::McpSyncResult};
     use clap::Parser;
+
+    fn render_apply_summary(dry_run: bool, result: &SyncResult) -> Vec<String> {
+        render_apply_summary_with_color(dry_run, result, false)
+    }
+    fn render_clean_phase(dry_run: bool) -> Vec<String> {
+        render_clean_phase_with_color(dry_run, false)
+    }
+    fn render_clean_summary(dry_run: bool, result: &SyncResult) -> Vec<String> {
+        render_clean_summary_with_color(dry_run, result, false)
+    }
+    fn render_dry_run_notice(use_color: bool) -> Vec<String> {
+        super::output::render_dry_run_notice(use_color)
+    }
+    fn render_gitignore_phase(enabled: bool, dry_run: bool) -> Vec<String> {
+        render_gitignore_phase_with_color(enabled, dry_run, false)
+    }
+    fn render_mcp_summary(result: &McpSyncResult) -> Vec<String> {
+        render_mcp_summary_with_color(result, false)
+    }
+    fn render_sync_phase(dry_run: bool, clean_first: bool) -> Vec<String> {
+        render_sync_phase_with_color(dry_run, clean_first, false)
+    }
 
     #[test]
     fn current_project_root_reports_cwd_errors_with_context() {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -72,7 +72,85 @@ pub enum McpAgent {
     OpenCode,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct McpAgentDocumentation {
+    pub id: &'static str,
+    pub name: &'static str,
+    pub destination: &'static str,
+    pub format: &'static str,
+    pub global: bool,
+    pub notes: &'static str,
+}
+
 impl McpAgent {
+    pub fn documentation(&self) -> McpAgentDocumentation {
+        match self {
+            Self::ClaudeCode => McpAgentDocumentation {
+                id: "claude",
+                name: "Claude Code",
+                destination: ".mcp.json",
+                format: "JSON",
+                global: false,
+                notes: "Standard format",
+            },
+            Self::ClaudeDesktop => McpAgentDocumentation {
+                id: "claude-desktop",
+                name: "Claude Desktop",
+                destination: "Global OS-dependent config",
+                format: "JSON",
+                global: true,
+                notes: "Global; disabled by default",
+            },
+            Self::GithubCopilot => McpAgentDocumentation {
+                id: "copilot",
+                name: "GitHub Copilot",
+                destination: ".vscode/mcp.json",
+                format: "JSON",
+                global: false,
+                notes: "Shared with VS Code",
+            },
+            Self::CodexCli => McpAgentDocumentation {
+                id: "codex",
+                name: "OpenAI Codex CLI",
+                destination: ".codex/config.toml",
+                format: "TOML",
+                global: false,
+                notes: "Maps headers to http_headers",
+            },
+            Self::GeminiCli => McpAgentDocumentation {
+                id: "gemini",
+                name: "Gemini CLI",
+                destination: ".gemini/settings.json",
+                format: "JSON",
+                global: false,
+                notes: "Adds trust: true",
+            },
+            Self::VsCode => McpAgentDocumentation {
+                id: "vscode",
+                name: "VS Code",
+                destination: ".vscode/mcp.json",
+                format: "JSON",
+                global: false,
+                notes: "Shared with GitHub Copilot",
+            },
+            Self::Cursor => McpAgentDocumentation {
+                id: "cursor",
+                name: "Cursor",
+                destination: ".cursor/mcp.json",
+                format: "JSON",
+                global: false,
+                notes: "Standard format",
+            },
+            Self::OpenCode => McpAgentDocumentation {
+                id: "opencode",
+                name: "OpenCode",
+                destination: "opencode.json",
+                format: "JSON",
+                global: false,
+                notes: "Standard format",
+            },
+        }
+    }
     /// Get all supported agents
     pub fn all() -> &'static [McpAgent] {
         &[

--- a/src/output.rs
+++ b/src/output.rs
@@ -411,10 +411,17 @@ mod tests {
             ]
         );
         force_color();
-        assert!(
-            render_apply_summary_with_color(false, &result, true)
-                .iter()
-                .all(|line| line.contains("\x1b["))
+        let colored_summary = render_apply_summary_with_color(false, &result, true);
+        assert_eq!(
+            colored_summary,
+            vec![
+                "\x1b[1;32m✔ Sync complete\x1b[0m".to_string(),
+                "  \x1b[2mCreated\x1b[0m: \x1b[32m0\x1b[0m".to_string(),
+                "  \x1b[2mUpdated\x1b[0m: \x1b[33m0\x1b[0m".to_string(),
+                "  \x1b[2mSkipped\x1b[0m: \x1b[2m0\x1b[0m".to_string(),
+                "  \x1b[2mRemoved\x1b[0m: \x1b[33m3\x1b[0m".to_string(),
+                "  \x1b[2mErrors\x1b[0m: \x1b[2m0\x1b[0m".to_string(),
+            ]
         );
         assert!(
             render_apply_summary_with_color(false, &result, false)

--- a/src/output.rs
+++ b/src/output.rs
@@ -141,10 +141,293 @@ pub fn output_mode(json: bool) -> OutputMode {
     )
 }
 
+pub(crate) fn human_use_color() -> bool {
+    match output_mode(false) {
+        OutputMode::Human { use_color } => use_color,
+        OutputMode::Json => false,
+    }
+}
+
+pub(crate) fn print_lines(lines: &[String]) {
+    for line in lines {
+        println!("{line}");
+    }
+}
+
+pub(crate) fn print_header() {
+    let banner = include_str!("banner.txt");
+    println!(
+        "{}",
+        if human_use_color() {
+            banner.cyan().bold().to_string()
+        } else {
+            banner.to_string()
+        }
+    );
+}
+
+pub(crate) fn init_next_steps_lines(wizard: bool) -> Option<Vec<String>> {
+    if wizard {
+        return None;
+    }
+    Some(vec![
+        "Next steps:".to_string(),
+        "  1. Edit .agents/AGENTS.md with your project instructions".to_string(),
+        "  2. Run agentsync apply to create symlinks".to_string(),
+    ])
+}
+
+fn render_phase(title: &str, detail: &str, use_color: bool) -> Vec<String> {
+    let formatter = HumanFormatter::new(use_color);
+    vec![
+        formatter.format_heading(&format!("➤ {title}")),
+        format!("  {detail}"),
+    ]
+}
+
+pub(crate) fn render_dry_run_notice(use_color: bool) -> Vec<String> {
+    let formatter = HumanFormatter::new(use_color);
+    vec![
+        formatter.format_label("!", "Dry run", LabelKind::Warning),
+        "  No filesystem changes will be made.".to_string(),
+    ]
+}
+
+pub(crate) fn render_clean_phase_with_color(dry_run: bool, use_color: bool) -> Vec<String> {
+    render_phase(
+        "Clean",
+        if dry_run {
+            "Previewing managed symlink removals"
+        } else {
+            "Removing managed symlinks"
+        },
+        use_color,
+    )
+}
+
+pub(crate) fn render_sync_phase_with_color(
+    dry_run: bool,
+    clean_first: bool,
+    use_color: bool,
+) -> Vec<String> {
+    let detail = match (dry_run, clean_first) {
+        (true, true) => "Previewing clean and sync changes",
+        (true, false) => "Previewing agent configuration changes",
+        (false, true) => "Cleaning existing symlinks before syncing",
+        (false, false) => "Syncing agent configurations",
+    };
+    render_phase("Sync", detail, use_color)
+}
+
+fn render_count(label: &str, value: usize, kind: LabelKind, use_color: bool) -> String {
+    format!(
+        "  {}",
+        HumanFormatter::new(use_color).format_summary_line(label, &value.to_string(), kind)
+    )
+}
+
+pub(crate) fn render_apply_summary_with_color(
+    dry_run: bool,
+    result: &agentsync::SyncResult,
+    use_color: bool,
+) -> Vec<String> {
+    let formatter = HumanFormatter::new(use_color);
+    let has_errors = result.errors > 0;
+    let mut lines = vec![formatter.format_label(
+        if has_errors { "✗" } else { "✔" },
+        match (dry_run, has_errors) {
+            (true, true) => "Sync dry run completed with errors",
+            (true, false) => "Sync dry run complete",
+            (false, true) => "Sync completed with errors",
+            (false, false) => "Sync complete",
+        },
+        if has_errors {
+            LabelKind::Failure
+        } else {
+            LabelKind::Success
+        },
+    )];
+    lines.extend([
+        render_count("Created", result.created, LabelKind::Success, use_color),
+        render_count("Updated", result.updated, LabelKind::Warning, use_color),
+        render_count("Skipped", result.skipped, LabelKind::Muted, use_color),
+        render_count(
+            "Removed",
+            result.removed,
+            if result.removed > 0 {
+                LabelKind::Warning
+            } else {
+                LabelKind::Muted
+            },
+            use_color,
+        ),
+        render_count(
+            "Errors",
+            result.errors,
+            if result.errors > 0 {
+                LabelKind::Failure
+            } else {
+                LabelKind::Muted
+            },
+            use_color,
+        ),
+    ]);
+    lines
+}
+
+pub(crate) fn render_clean_summary_with_color(
+    dry_run: bool,
+    result: &agentsync::SyncResult,
+    use_color: bool,
+) -> Vec<String> {
+    let formatter = HumanFormatter::new(use_color);
+    let has_errors = result.errors > 0;
+    vec![
+        formatter.format_label(
+            if has_errors { "✗" } else { "✔" },
+            match (dry_run, has_errors) {
+                (true, true) => "Clean dry run completed with errors",
+                (true, false) => "Clean dry run complete",
+                (false, true) => "Clean completed with errors",
+                (false, false) => "Clean complete",
+            },
+            if has_errors {
+                LabelKind::Failure
+            } else {
+                LabelKind::Success
+            },
+        ),
+        render_count(
+            if dry_run { "Would remove" } else { "Removed" },
+            result.removed,
+            LabelKind::Success,
+            use_color,
+        ),
+        render_count(
+            "Errors",
+            result.errors,
+            if result.errors > 0 {
+                LabelKind::Failure
+            } else {
+                LabelKind::Muted
+            },
+            use_color,
+        ),
+    ]
+}
+
+pub(crate) fn render_gitignore_phase_with_color(
+    enabled: bool,
+    dry_run: bool,
+    use_color: bool,
+) -> Vec<String> {
+    let detail = match (enabled, dry_run) {
+        (true, true) => "Previewing .gitignore update",
+        (true, false) => "Updating .gitignore",
+        (false, true) => "Previewing .gitignore cleanup",
+        (false, false) => "Cleaning .gitignore",
+    };
+    render_phase("Gitignore", detail, use_color)
+}
+
+pub(crate) fn render_mcp_phase(dry_run: bool, use_color: bool) -> Vec<String> {
+    render_phase(
+        "MCP",
+        if dry_run {
+            "Previewing MCP configuration changes"
+        } else {
+            "Syncing MCP configurations"
+        },
+        use_color,
+    )
+}
+
+pub(crate) fn render_mcp_summary_with_color(
+    result: &agentsync::mcp::McpSyncResult,
+    use_color: bool,
+) -> Vec<String> {
+    vec![
+        render_count("Created", result.created, LabelKind::Success, use_color),
+        render_count("Updated", result.updated, LabelKind::Warning, use_color),
+        render_count("Skipped", result.skipped, LabelKind::Muted, use_color),
+        render_count(
+            "Errors",
+            result.errors,
+            if result.errors > 0 {
+                LabelKind::Failure
+            } else {
+                LabelKind::Muted
+            },
+            use_color,
+        ),
+    ]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use agentsync::SyncResult;
     use std::collections::HashSet;
+
+    fn render_apply_summary(dry_run: bool, result: &SyncResult) -> Vec<String> {
+        render_apply_summary_with_color(dry_run, result, false)
+    }
+
+    #[test]
+    fn apply_summary_preserves_exact_plain_contract() {
+        assert_eq!(
+            render_apply_summary(
+                false,
+                &SyncResult {
+                    created: 2,
+                    updated: 1,
+                    skipped: 3,
+                    removed: 0,
+                    errors: 1
+                }
+            ),
+            vec![
+                "✗ Sync completed with errors".to_string(),
+                "  Created: 2".to_string(),
+                "  Updated: 1".to_string(),
+                "  Skipped: 3".to_string(),
+                "  Removed: 0".to_string(),
+                "  Errors: 1".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn renderers_preserve_color_and_plain_paths() {
+        let result = SyncResult {
+            removed: 3,
+            ..Default::default()
+        };
+        assert_eq!(
+            render_clean_phase_with_color(true, false),
+            vec![
+                "➤ Clean".to_string(),
+                "  Previewing managed symlink removals".to_string()
+            ]
+        );
+        force_color();
+        assert!(
+            render_apply_summary_with_color(false, &result, true)
+                .iter()
+                .all(|line| line.contains("\x1b["))
+        );
+        assert!(
+            render_apply_summary_with_color(false, &result, false)
+                .iter()
+                .all(|line| !line.contains("\x1b["))
+        );
+    }
+
+    #[test]
+    fn init_footer_and_print_lines_contract_is_available_at_output_boundary() {
+        assert!(init_next_steps_lines(true).is_none());
+        assert_eq!(init_next_steps_lines(false).unwrap().len(), 3);
+    }
 
     /// Force the `colored` crate to emit ANSI codes even when stdout is not a TTY
     /// (e.g., inside `cargo test` which pipes stdout).

--- a/tests/mcp_documentation.rs
+++ b/tests/mcp_documentation.rs
@@ -1,0 +1,98 @@
+use agentsync::McpAgent;
+
+const START_MARKER: &str = "<!-- agentsync:mcp:start -->";
+const END_MARKER: &str = "<!-- agentsync:mcp:end -->";
+
+fn canonical_fragment() -> String {
+    let rows = canonical_rows().join("\n");
+
+    format!("{START_MARKER}\n{rows}\n{END_MARKER}")
+}
+
+fn canonical_rows() -> Vec<String> {
+    McpAgent::all()
+        .iter()
+        .map(|agent| {
+            let doc = agent.documentation();
+            let notes = doc.notes.strip_prefix("Global; ").unwrap_or(doc.notes);
+            let global = if doc.global { "; Global" } else { "" };
+            format!(
+                "- **{}** — `{}` (agent id: `{}`) — {}{}; {}",
+                doc.name, doc.destination, doc.id, doc.format, global, notes
+            )
+        })
+        .collect()
+}
+
+fn governed_fragment(content: &str) -> &str {
+    assert_eq!(
+        content.matches(START_MARKER).count(),
+        1,
+        "invalid start markers"
+    );
+    assert_eq!(
+        content.matches(END_MARKER).count(),
+        1,
+        "invalid end markers"
+    );
+    let start = content.find(START_MARKER).unwrap();
+    let end = content.find(END_MARKER).unwrap() + END_MARKER.len();
+    assert!(start < end, "end marker must follow start marker");
+    &content[start..end]
+}
+
+#[test]
+fn native_mcp_registry_has_complete_unique_metadata() {
+    let docs: Vec<_> = McpAgent::all()
+        .iter()
+        .map(McpAgent::documentation)
+        .collect();
+    assert_eq!(docs.len(), 8);
+    let mut ids: Vec<_> = docs.iter().map(|doc| doc.id).collect();
+    ids.sort_unstable();
+    ids.dedup();
+    assert_eq!(ids.len(), docs.len());
+    assert!(docs.iter().all(|doc| !doc.id.is_empty()
+        && !doc.name.is_empty()
+        && !doc.destination.is_empty()
+        && !doc.format.is_empty()));
+    let claude = docs.iter().find(|doc| doc.id == "claude-desktop").unwrap();
+    assert!(claude.global);
+    assert!(claude.destination.contains("Global"));
+    assert!(
+        docs.iter()
+            .any(|doc| doc.id == "copilot" && doc.destination == ".vscode/mcp.json")
+    );
+    assert!(
+        docs.iter()
+            .any(|doc| doc.id == "vscode" && doc.destination == ".vscode/mcp.json")
+    );
+}
+
+#[test]
+fn governed_documentation_contains_canonical_fragment() {
+    let files = [
+        include_str!("../README.md"),
+        include_str!("../npm/agentsync/README.md"),
+        include_str!("../website/docs/src/content/docs/guides/mcp.mdx"),
+        include_str!("../openspec/specs/mcp-generation/spec.md"),
+    ];
+    let expected = canonical_fragment();
+    for content in files {
+        assert_eq!(governed_fragment(content), expected);
+
+        let outside = content.replace(&expected, "");
+        let rows = canonical_rows();
+        for line in outside.lines() {
+            assert!(
+                !rows.iter().any(|row| line == row),
+                "canonical native MCP rows must only appear in the governed fragment: {line}"
+            );
+
+            assert!(
+                !line.starts_with("- **") || !line.contains("(agent id: "),
+                "native MCP rows must not appear outside the governed fragment: {line}"
+            );
+        }
+    }
+}

--- a/tests/mcp_documentation.rs
+++ b/tests/mcp_documentation.rs
@@ -24,7 +24,8 @@ fn canonical_rows() -> Vec<String> {
         .collect()
 }
 
-fn governed_fragment(content: &str) -> &str {
+fn governed_fragment(content: &str) -> String {
+    let content = content.replace("\r\n", "\n");
     assert_eq!(
         content.matches(START_MARKER).count(),
         1,
@@ -38,7 +39,7 @@ fn governed_fragment(content: &str) -> &str {
     let start = content.find(START_MARKER).unwrap();
     let end = content.find(END_MARKER).unwrap() + END_MARKER.len();
     assert!(start < end, "end marker must follow start marker");
-    &content[start..end]
+    content[start..end].to_string()
 }
 
 #[test]
@@ -79,9 +80,11 @@ fn governed_documentation_contains_canonical_fragment() {
     ];
     let expected = canonical_fragment();
     for content in files {
-        assert_eq!(governed_fragment(content), expected);
+        let fragment = governed_fragment(content);
+        assert_eq!(fragment, expected);
 
-        let outside = content.replace(&expected, "");
+        let normalized = content.replace("\r\n", "\n");
+        let outside = normalized.replace(&expected, "");
         let rows = canonical_rows();
         for line in outside.lines() {
             assert!(

--- a/tests/mcp_documentation.rs
+++ b/tests/mcp_documentation.rs
@@ -56,7 +56,8 @@ fn native_mcp_registry_has_complete_unique_metadata() {
     assert!(docs.iter().all(|doc| !doc.id.is_empty()
         && !doc.name.is_empty()
         && !doc.destination.is_empty()
-        && !doc.format.is_empty()));
+        && !doc.format.is_empty()
+        && !doc.notes.is_empty()));
     let claude = docs.iter().find(|doc| doc.id == "claude-desktop").unwrap();
     assert!(claude.global);
     assert!(claude.destination.contains("Global"));

--- a/website/docs/src/content/docs/guides/mcp.mdx
+++ b/website/docs/src/content/docs/guides/mcp.mdx
@@ -23,6 +23,17 @@ merge_strategy = "merge"
 - **`merge` (Default)**: AgentSync will read the existing agent-specific config file, add the servers defined in your TOML, and preserve existing servers that are not in the TOML. If a conflict occurs (same server name), the TOML configuration wins.
 - **`overwrite`**: AgentSync will completely replace the agent-specific config file with the servers defined in your TOML.
 
+<!-- agentsync:mcp:start -->
+- **Claude Code** — `.mcp.json` (agent id: `claude`) — JSON; Standard format
+- **Claude Desktop** — `Global OS-dependent config` (agent id: `claude-desktop`) — JSON; Global; disabled by default
+- **GitHub Copilot** — `.vscode/mcp.json` (agent id: `copilot`) — JSON; Shared with VS Code
+- **OpenAI Codex CLI** — `.codex/config.toml` (agent id: `codex`) — TOML; Maps headers to http_headers
+- **Gemini CLI** — `.gemini/settings.json` (agent id: `gemini`) — JSON; Adds trust: true
+- **VS Code** — `.vscode/mcp.json` (agent id: `vscode`) — JSON; Shared with GitHub Copilot
+- **Cursor** — `.cursor/mcp.json` (agent id: `cursor`) — JSON; Standard format
+- **OpenCode** — `opencode.json` (agent id: `opencode`) — JSON; Standard format
+<!-- agentsync:mcp:end -->
+
 ## Defining Servers
 
 Define your servers under `[mcp_servers.<name>]`:

--- a/website/docs/src/content/docs/guides/mcp.mdx
+++ b/website/docs/src/content/docs/guides/mcp.mdx
@@ -59,21 +59,6 @@ env = { "DEBUG" = "true" }
 - **`type`**: (Optional) The transport type (e.g., `stdio`, `http`, `sse`).
 - **`disabled`**: (Optional) Set to `true` to temporarily disable a server without removing it.
 
-## Supported Agents
-
-AgentSync automatically knows where to place the MCP configuration for these assistants:
-
-| Assistant | Destination File | Notes |
-| :--- | :--- | :--- |
-| **Claude Code** | `.mcp.json` | Standard format |
-| **Claude Desktop** | Global config (OS-dependent; see [below](#global-agents)) | Preserves non-MCP settings; disabled by default |
-| **GitHub Copilot** | `.vscode/mcp.json` | Shared with VS Code |
-| **OpenAI Codex CLI** | `.codex/config.toml` | TOML format (`[mcp_servers.<name>]`); AgentSync maps `headers` to `http_headers` |
-| **Gemini CLI** | `.gemini/settings.json` | Automatically adds `"trust": true` |
-| **VS Code** | `.vscode/mcp.json` | For VS Code extensions |
-| **Cursor** | `.cursor/mcp.json` | Standard format |
-| **OpenCode** | `opencode.json` | |
-
 ## Global Agents
 
 Some agents store their MCP configuration in a global (user-level) location rather than in the project directory. AgentSync calls these **global agents**.


### PR DESCRIPTION
## Summary
- extract CLI presentation/rendering helpers from `src/main.rs` into `src/output.rs` without changing output contracts
- add canonical typed metadata for native MCP agents, including Claude Desktop
- validate exact MCP documentation fragments in CI and remove stale duplicate documentation

## Issues
- Closes #494
- Closes #500

## Verification
- `cargo test --all-features`
- `cargo test --test mcp_documentation`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`

## SDD
- Proposal, specification, design, tasks, verification, and archive artifacts are included.
- Verification status: PASS WITH WARNINGS; no critical issues remain.
