### PR TITLE
feat(output): add structured diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1523,6 +1523,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2762,12 +2771,16 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "serde",
  "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2747,17 +2747,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "nu-ansi-term",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ dirs = "6"
 reqwest = { version = "0.13.3", features = ["json", "gzip", "stream", "blocking"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "fs"] }
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["json"] }
 futures-util = "0.3"
 lazy_static = "1.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ dirs = "6"
 reqwest = { version = "0.13.3", features = ["json", "gzip", "stream", "blocking"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "fs"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["json"] }
+tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 futures-util = "0.3"
 lazy_static = "1.4"
 

--- a/openspec/changes/archive/2026-08-03-structured-diagnostics/design.md
+++ b/openspec/changes/archive/2026-08-03-structured-diagnostics/design.md
@@ -4,7 +4,7 @@
 
 Replace `tracing_subscriber::fmt::init()` (main.rs:154) with an explicit `init_logging()` builder that always writes to `io::stderr` and switches between human/JSON format via global clap flags `--log-format`/`--log-level`. Instrument 8 operation points with `info_span!` + `.in_scope()`, migrate diagnostic `println!` to `info!`/`debug!`, enrich existing error events with structured fields, and add a `redact_url` helper. Functional stdout (human + per-command `--json`) is untouched; this fixes the latent bug where any WARN+ event during `--json` corrupts the machine-readable contract.
 
-    main() ──> Cli::parse() ──> init_logging(format, level) ──> subscriber → stderr
+    main() ──> run() ──> Cli::parse() ──> init_logging(format, level) ──> subscriber → stderr
       │
       ├── span root {operation} ──> dispatch handler
       │        └── span per agent {agent_id, operation, outcome}
@@ -18,7 +18,7 @@ Replace `tracing_subscriber::fmt::init()` (main.rs:154) with an explicit `init_l
 |---|----------|--------|----------|--------|
 | 1 | Where init lives | (a) main.rs inline (b) output.rs (c) **new `src/logging.rs`** | (a) bloats 450-line main (b) mixes formatting with subscriber setup (c) single-responsibility, unit-testable | **(c)** new `logging.rs`: `LogFormat`, `init_logging()`, `redact_url()` |
 | 2 | Flag shape | (a) **global args on `Cli`** (b) per-command (c) env-only | (a) one definition, readable before dispatch (b) repetitive (c) issue asks explicit flag | **(a)** `#[arg(long, global = true)]` on `struct Cli` (main.rs:43-54) |
-| 3 | Filter source | (a) flag only (b) **flag OR `RUST_LOG`** (c) EnvFilter directives | (a) drops existing RUST_LOG support (b) keeps it, no new feature (c) needs `env-filter` feature + more surface | **(b)** `--log-level` wins; else parse `RUST_LOG` as single LevelFilter; default INFO. Advanced directives out of scope |
+| 3 | Filter source | (a) flag only (b) **flag OR `RUST_LOG`** (c) EnvFilter directives | (a) drops existing RUST_LOG support (b) loses target-aware filtering (c) minimal feature and preserves subscriber semantics | **(c)** `--log-level` wins; otherwise `RUST_LOG` is parsed as an EnvFilter directive set; invalid input falls back to INFO. |
 | 4 | Spans | (a) `info_span!`+`.in_scope()` (b) `#[instrument]` | (a) no new direct dep, explicit control, no enter/exit leak (b) tracing-attributes proc-macro dep | **(a)** |
 | 5 | Error context | (a) **enrich fields only** (b) rewrite message | (a) human text identical, anyhow chain to stderr unchanged (b) breaks existing messages | **(a)** add `agent_id`/`target`/`path`/`config_path` fields |
 | 6 | Redaction | (a) **`redact_url` manual** (b) `url` crate | (a) zero new deps, strips userinfo+query (b) robust parse but new dep | **(a)** manual strip: `user:pass@` up to `@`, drop `?`-query |
@@ -32,7 +32,7 @@ Replace `tracing_subscriber::fmt::init()` (main.rs:154) with an explicit `init_l
 
 | File:lines | Span / Change |
 |-----------|----------------|
-| `main.rs` (dispatch 158-215) | Root span per subcommand: `operation = "apply\|clean\|init\|status\|doctor\|skill"`, `outcome` recorded at end |
+| `main.rs` (dispatch) | Root span per subcommand: `operation = "apply\|clean\|init\|status\|doctor\|skill"`, `outcome` recorded at end; runner renders errors through tracing and exits after span closure |
 | `main.rs:274-278` | `println!` "Using config" → `info!(config_path, "Using config")` |
 | `main.rs:381` | `error!(%e, ...)` → add `agent_id = agent.name()`, `config_path` |
 | `linker/apply.rs:43-109` | Span per agent: `operation="sync", agent_id`; `outcome` ok/skipped/error |
@@ -43,7 +43,7 @@ Replace `tracing_subscriber::fmt::init()` (main.rs:154) with an explicit `init_l
 | `linker/clean.rs:13-197` | Span per removed path: `operation="remove", path, outcome` |
 | `mcp.rs:1497-1522` (`generate_all`) | Span per agent: `operation="mcp", agent_id, outcome`; error (1518) add `config_path` |
 | `commands/skill.rs` (`run_install` 1015, `run_suggest` 785-899) | Span `operation="skill_install\|skill_suggest", skill_id, outcome`; reuse `{error,code,remediation}` envelope fields |
-| `update_check.rs:137` | Keep `eprintln!` (already stderr; not tracing to avoid JSON noise) |
+| `update_check.rs` | Update notices are emitted through tracing, keeping JSON diagnostics parseable. |
 
 ## Interfaces / Contracts
 
@@ -53,7 +53,7 @@ pub enum LogFormat { Human, Json }                       // FromStr from "--log-
 pub fn init_logging(format: LogFormat, level: Option<LevelFilter>); // .with_writer(io::stderr) always;
                                                             // .json() iff Json; filter = level
                                                             // .or_else(RUST_LOG).unwrap_or(INFO)
-pub fn resolve_level_filter(flag: Option<LevelFilter>, rust_log: Option<&str>) -> LevelFilter; // pure, testable
+pub fn resolve_level_filter(flag: Option<LevelFilter>, rust_log: Option<&str>) -> EnvFilter; // pure, testable
 pub fn redact_url(url: &str) -> String;                  // strip userinfo + query
 ```
 JSON event (stderr, one line per event):

--- a/openspec/changes/archive/2026-08-03-structured-diagnostics/design.md
+++ b/openspec/changes/archive/2026-08-03-structured-diagnostics/design.md
@@ -1,0 +1,83 @@
+# Design: Structured Diagnostics & Machine-Readable Logging
+
+## Technical Approach
+
+Replace `tracing_subscriber::fmt::init()` (main.rs:154) with an explicit `init_logging()` builder that always writes to `io::stderr` and switches between human/JSON format via global clap flags `--log-format`/`--log-level`. Instrument 8 operation points with `info_span!` + `.in_scope()`, migrate diagnostic `println!` to `info!`/`debug!`, enrich existing error events with structured fields, and add a `redact_url` helper. Functional stdout (human + per-command `--json`) is untouched; this fixes the latent bug where any WARN+ event during `--json` corrupts the machine-readable contract.
+
+    main() ──> Cli::parse() ──> init_logging(format, level) ──> subscriber → stderr
+      │
+      ├── span root {operation} ──> dispatch handler
+      │        └── span per agent {agent_id, operation, outcome}
+      │              └── span per target {target, path, outcome}
+      ├── error! enriched fields ──> stderr JSON event (envelope unchanged)
+      └── println!/render_* ──> stdout (functional output, intact)
+
+## Architecture Decisions
+
+| # | Decision | Option | Tradeoff | Choice |
+|---|----------|--------|----------|--------|
+| 1 | Where init lives | (a) main.rs inline (b) output.rs (c) **new `src/logging.rs`** | (a) bloats 450-line main (b) mixes formatting with subscriber setup (c) single-responsibility, unit-testable | **(c)** new `logging.rs`: `LogFormat`, `init_logging()`, `redact_url()` |
+| 2 | Flag shape | (a) **global args on `Cli`** (b) per-command (c) env-only | (a) one definition, readable before dispatch (b) repetitive (c) issue asks explicit flag | **(a)** `#[arg(long, global = true)]` on `struct Cli` (main.rs:43-54) |
+| 3 | Filter source | (a) flag only (b) **flag OR `RUST_LOG`** (c) EnvFilter directives | (a) drops existing RUST_LOG support (b) keeps it, no new feature (c) needs `env-filter` feature + more surface | **(b)** `--log-level` wins; else parse `RUST_LOG` as single LevelFilter; default INFO. Advanced directives out of scope |
+| 4 | Spans | (a) `info_span!`+`.in_scope()` (b) `#[instrument]` | (a) no new direct dep, explicit control, no enter/exit leak (b) tracing-attributes proc-macro dep | **(a)** |
+| 5 | Error context | (a) **enrich fields only** (b) rewrite message | (a) human text identical, anyhow chain to stderr unchanged (b) breaks existing messages | **(a)** add `agent_id`/`target`/`path`/`config_path` fields |
+| 6 | Redaction | (a) **`redact_url` manual** (b) `url` crate | (a) zero new deps, strips userinfo+query (b) robust parse but new dep | **(a)** manual strip: `user:pass@` up to `@`, drop `?`-query |
+| 7 | Span tests | (a) **black-box stderr tests** (b) `tracing-test` dev-dep | (a) contract-level, zero new deps (b) in-process capture, adds dep | **(a)** run binary, assert stderr JSON lines |
+
+## Span Convention
+
+`info_span!("agentsync", operation, outcome, agent_id, target, path, skill_id, config_path)` — only fields relevant to scope. Levels: INFO spans (command/agent/target outcome), DEBUG per-file detail (create/update/skip), WARN/ERROR failures. Close with `span.record("outcome", ...)` before `.in_scope()` returns. No per-file INFO spans (noise).
+
+## Instrumentation Points
+
+| File:lines | Span / Change |
+|-----------|----------------|
+| `main.rs` (dispatch 158-215) | Root span per subcommand: `operation = "apply\|clean\|init\|status\|doctor\|skill"`, `outcome` recorded at end |
+| `main.rs:274-278` | `println!` "Using config" → `info!(config_path, "Using config")` |
+| `main.rs:381` | `error!(%e, ...)` → add `agent_id = agent.name()`, `config_path` |
+| `linker/apply.rs:43-109` | Span per agent: `operation="sync", agent_id`; `outcome` ok/skipped/error |
+| `linker/apply.rs:47,60,72` | verbose skips → `debug!(agent_id, reason)` |
+| `linker/apply.rs:91-108` | Span per target: `target, path`; `outcome` created/updated/skipped/error |
+| `linker/apply.rs:93` | verbose "Processing target" → `debug!(target)` |
+| `linker/apply.rs:104` | `error!` → add `agent_id`, `path` (target destination) |
+| `linker/clean.rs:13-197` | Span per removed path: `operation="remove", path, outcome` |
+| `mcp.rs:1497-1522` (`generate_all`) | Span per agent: `operation="mcp", agent_id, outcome`; error (1518) add `config_path` |
+| `commands/skill.rs` (`run_install` 1015, `run_suggest` 785-899) | Span `operation="skill_install\|skill_suggest", skill_id, outcome`; reuse `{error,code,remediation}` envelope fields |
+| `update_check.rs:137` | Keep `eprintln!` (already stderr; not tracing to avoid JSON noise) |
+
+## Interfaces / Contracts
+
+```rust
+// src/logging.rs
+pub enum LogFormat { Human, Json }                       // FromStr from "--log-format"
+pub fn init_logging(format: LogFormat, level: Option<LevelFilter>); // .with_writer(io::stderr) always;
+                                                            // .json() iff Json; filter = level
+                                                            // .or_else(RUST_LOG).unwrap_or(INFO)
+pub fn resolve_level_filter(flag: Option<LevelFilter>, rust_log: Option<&str>) -> LevelFilter; // pure, testable
+pub fn redact_url(url: &str) -> String;                  // strip userinfo + query
+```
+JSON event (stderr, one line per event):
+```json
+{"timestamp":"...","level":"INFO","fields":{"operation":"sync","agent_id":"claude","outcome":"ok"},"target":"agentsync::linker::apply"}
+```
+**Rule**: MCP `env`/`headers` (may hold `Authorization: Bearer …`) are NEVER logged as fields; URLs pass through `redact_url`.
+
+## Testing Strategy
+
+| Layer | What | Approach |
+|-------|------|----------|
+| Unit (`logging.rs`) | `redact_url` (userinfo, query, plain), `resolve_level_filter`, `LogFormat` parse | pure fn tests |
+| Unit (main.rs) | Global flags parse: `agentsync --log-format json apply` | existing `Cli::parse` test module |
+| Integration `tests/test_logging.rs` (new) | `apply --log-format json` on fixture → every stderr line parses as JSON with `operation`/`outcome`; stdout human output intact; `--log-level error` suppresses INFO | black-box run + `serde_json` per stderr line |
+| Contract (`tests/contracts/`) | **Regression for latent bug**: induce WARN (e.g. MCP restricted-permission path) with `--json` → stdout still parses as one JSON doc, WARN appears only in stderr | extend `test_install_output.rs` / `test_skill_suggest_output.rs` asserts |
+| Existing | stdout human/JSON contracts | unchanged — verify no breakage |
+
+## Migration / Rollout
+
+No data migration. Single reversible PR; rollback = restore `fmt::init()` at main.rs:154 and drop flags/spans. Writer→stderr is the critical one-liner; everything else is isolated additions.
+
+## Open Questions
+
+- [ ] Add `env-filter` feature later for target-specific directives? (out of scope now)
+- [ ] Should `--log-level` appear in `--help` docs section ordering (auto by clap)?
+- [ ] Keep `doctor`/`status` functional stdout as-is (exit codes out of scope per proposal)?

--- a/openspec/changes/archive/2026-08-03-structured-diagnostics/exploration.md
+++ b/openspec/changes/archive/2026-08-03-structured-diagnostics/exploration.md
@@ -1,0 +1,290 @@
+# Exploration: structured diagnostics and machine-readable logging (issue #499)
+
+Change name (proposed): `structured-diagnostics` — `feat(output): add structured diagnostics and machine-readable logging`.
+
+> Investigación realizada el 2026-08-03 sobre el repo en `main` (HEAD `017f71d`). Todos los
+> números de línea son del código actual en disco. No se modificó ningún archivo de código.
+
+---
+
+## 1. Salida actual del CLI
+
+La salida está **solo parcialmente centralizada**. Existe `src/output.rs` (735 líneas) con
+helpers de formato, pero la mayoría de los puntos de emisión son `println!` directos repartidos por
+todo el crate.
+
+### API pública de `src/output.rs`
+
+- `LabelKind` enum (líneas 5-13): `Info | Warning | Success | Failure | Muted`.
+- `OutputMode` enum (17-20): `Json | Human { use_color }` — ya existe el concepto de "formato",
+  pero **solo lo usan `status` y `skill`**.
+- `HumanFormatter` (27-108):
+  - `format_label(symbol, label, kind)` (37) — "✔ installed".
+  - `format_heading(heading)` (43) — bold cuando hay color.
+  - `format_muted` (53), `format_key_value(label, value)` (63), `format_summary_line` (74),
+    `format_hint` (81) — `#[allow(dead_code)]` en 52, 62, 73, 80 (casi todo está muerto salvo
+    format_label/format_heading).
+  - `style_by_kind` (90-107) — mapeo ANSI por LabelKind.
+- `detect_output_mode(json, stdout_is_tty, no_color, clicolor, term)` (116-131) — función pura:
+  `json` tiene prioridad absoluta; color solo si stdout es TTY y no hay overrides.
+- `output_mode(json)` (134-142) — wrapper que lee el entorno real.
+- `human_use_color()` (144-149), `print_lines(&[String])` (151-155, **println! a stdout**),
+  `print_header()` (157-167, banner), `init_next_steps_lines(wizard)` (169-178).
+- Renderers que devuelven `Vec<String>` (el patrón "render" separa formato de emisión):
+  `render_dry_run_notice` (188), `render_clean_phase_with_color` (196),
+  `render_sync_phase_with_color` (208), `render_apply_summary_with_color` (229),
+  `render_clean_summary_with_color` (278), `render_gitignore_phase_with_color` (319),
+  `render_mcp_phase` (333), `render_mcp_summary_with_color` (345).
+
+### Puntos de emisión directa (`println!`) que NO pasan por output.rs
+
+- `src/main.rs`: 230, 240, 244, 248, 251, 274-278 (verbose "Using config"), 285, 295, 327, 338,
+  348, 368, 405, 414.
+- `src/linker/apply.rs`: 40 (dry-run), 47, 60, 72 (skips verbose), 88 (header agente), 93
+  (processing target verbose), 264, 282.
+- `src/linker/clean.rs`: 16, 60, 65, 94, 99, 152, 157, 179, 192, 197.
+- `src/linker/mod.rs`: 206, 214 (dirs creados).
+- `src/linker/discovery.rs`: 103, 118, 132, 224, 263.
+- `src/linker/symlinks.rs`: 27, 67, 95, 116, 123, 134, 148, 161.
+- `src/init.rs`: ~40 `println!` (351-401 en `init()`, 1506-2246 en wizard).
+- `src/mcp.rs`: 1384, 1391, 1407, 1414, 1454.
+- `src/commands/doctor.rs`: todo el comando (19-265).
+- `src/commands/skill.rs`: 71 (line reporter), 745, 772, 776, 819 (JSON), 823, 835, 841, 965
+  (JSON error), 973, 1061 (JSON install), 1087 (JSON error), 1095.
+
+**Conclusión**: el sistema de "formato" existe pero es per-command (`status --json`,
+`skill ... --json`, `devinstall --json`). `apply/clean/init/doctor` no tienen `--json` ni
+`OutputMode`; imprimen humano directo a stdout.
+
+---
+
+## 2. Logging actual
+
+- Inicialización: `src/main.rs:152-155`:
+  ```rust
+  fn main() -> Result<()> {
+      tracing_subscriber::fmt::init();
+  ```
+- **HALLAZGO CRÍTICO**: el writer por defecto de `fmt::init()` es **STDOUT** (verificado en el
+  código fuente de tracing-subscriber 0.3.23, `src/fmt/fmt_layer.rs:749` → `make_writer: io::stdout`,
+  y `fmt_layer.rs:68` → `W = fn() -> io::Stdout`). Es decir, **hoy TODOS los eventos tracing van a
+  stdout**. Cualquier `warn!`/`error!` que dispare durante un comando `--json` corrompe el contrato
+  machine-readable. Es un bug latente: los tests de contrato pasan porque los paths felices no
+  emiten WARN+.
+- `RUST_LOG` **sí funciona** aunque no esté el feature `env-filter`: `fmt::try_init()`
+  (fmt/mod.rs:1200-1246) construye un filtro `Targets` desde `RUST_LOG` cuando `env-filter` está
+  deshabilitado; default `INFO` cuando no está seteado (fmt/mod.rs:349 `DEFAULT_MAX_LEVEL =
+  LevelFilter::INFO`). El comentario de main.rs:153 ("Respects RUST_LOG env var") es correcto a
+  grandes rasgos, pero **no se pueden usar directivas de EnvFilter** (span fields, etc.) ni el
+  formato `.json()` porque el feature `json` de tracing-subscriber **no está habilitado**
+  (Cargo.toml:58 `tracing-subscriber = "0.3"` sin features; Cargo.lock confirma 0.3.23 con solo
+  nu-ansi-term/sharded-slab/smallvec/thread_local/tracing-core/tracing-log).
+- **No hay spans en ningún lado**: grep de `info_span|debug_span|error_span|warn_span|.enter()` =
+  0 resultados en todo el repo.
+- Los 15 call sites de macros tracing:
+  - `src/mcp.rs:1468` `warn!(error, path, "Failed to remediate restricted permissions...")`,
+    `src/mcp.rs:1518` `error!(agent, error, "Error generating agent config")`.
+  - `src/init.rs:124,130,138` `warn!(path/error, "User config template...")`.
+  - `src/main.rs:381` `error!(%e, "Error syncing MCP configs")`.
+  - `src/linker/apply.rs:104` `error!(target, error, "Error processing target")`.
+  - `src/linker/discovery.rs:231` `debug!(error, path, "WalkDir entry skipped...")`.
+  - `src/commands/skill.rs:708` `warn!`, `1028` `debug!("install")`, `1055` `warn!`,
+    `1235` `info!(original, converted, "Converted GitHub URL to ZIP format")`,
+    `1254`/`1268` `warn!(skill_id, provider_skill_id, "Failed to resolve...")`.
+  - `src/skills/uninstall.rs:83` `warn!`.
+- `eprintln!` existe en un solo lugar: `src/update_check.rs:137` (aviso de versión nueva → stderr).
+  Es el patrón correcto de referencia.
+- **`println!` que deberían ser logs** (info de diagnóstico/verbose en stdout):
+  - `src/main.rs:274-278` ("Using config: ..." solo con `-v`).
+  - `src/linker/apply.rs:47,60,72,93` (skips y "Processing target" solo con `verbose`).
+  - `src/linker/discovery.rs:103-263` (entradas saltadas en nested-glob).
+  - `src/commands/doctor.rs` (líneas de diagnóstico humano — hoy son salida funcional).
+
+---
+
+## 3. Comandos y operaciones principales (puntos de instrumentación)
+
+| Comando | Handler | Implementación | Operaciones que merecen span |
+|---|---|---|---|
+| `apply` | main.rs:181-197 → `handle_apply` (267) | `linker.sync` (apply.rs:28-112), `process_target` (115-160), `create_symlink` (symlinks.rs), `clean` (clean.rs), gitignore (main.rs:336), MCP (`handle_apply_mcp` 361 → `sync_mcp` → `generate_all` mcp.rs:1483) | sync por agente/target, clean, gitignore, mcp; campos `agent_id`, `target`, `path`, `operation`, `outcome` |
+| `clean` | main.rs:198-203 → `handle_clean` (388) | `linker.clean` (clean.rs:13-197) | remover symlinks por destino (`path`) |
+| `init` | main.rs:174-180 → `handle_init` (220) | `init::init` (init.rs:341-405), `init_wizard` (≈2006+), `init_wizard_experimental_tui` (1492) | crear dirs/config/AGENTS.md |
+| `status` | main.rs:164-168 → `run_status` (status.rs:139) | `collect_status_entries` (71-137), validación por entrada | validación por agente/target/entrada |
+| `doctor` | main.rs:169-173 → `run_doctor` (doctor.rs:267) | `check_source_directory` (19), `check_target_sources` (37), `check_destination_conflicts` (103), `check_mcp_servers` (141), `check_gitignore` (178), `check_unmanaged_skills` (258) | cada check |
+| `skill install/update/uninstall/suggest/registry` | main.rs:159-163 → `run_skill` (skill.rs:754) | `run_install` (1015), `run_update`, `run_uninstall`, `run_suggest` (785), `run_suggest_install` (846), `run_registry_command` (768) | install/update/uninstall por `skill_id`; resolve/install phases |
+
+**Puntos naturales para spans** (loop anidado agente→target ya existente):
+- `src/linker/apply.rs:43-109` — bucle de agentes: span por `agent_name` (campos `agent_id`,
+  `operation = "sync"`).
+- `src/linker/apply.rs:91-108` — bucle de targets: span con `target`, `path` (destino), `outcome`
+  (ok/error/skipped/created/updated).
+- `src/linker/apply.rs:115-160` (`process_target`) — `operation` por SyncType
+  (symlink / symlink-contents / nested-glob / module-map).
+- `src/linker/clean.rs:13-197` — span por `path`/`operation = "remove"`.
+- `src/mcp.rs:1497-1522` (`generate_all`) — span por `agent`.
+- `src/commands/skill.rs` — `run_install` (1015) y fases resolve/install de
+  `run_suggest_install` (846-899).
+
+---
+
+## 4. Errores
+
+- Fronteras: `anyhow::Result` en main.rs y comandos; `.context()` puntual
+  (main.rs:29, apply.rs:144-149). `thiserror` solo en skills:
+  `SkillInstallError` (skills/install.rs:16-33, variantes Io/Network/ZipArchive/Registry/
+  PathTraversal/Validation/Other), más `update.rs`/`uninstall.rs`.
+- `main() -> Result<()>` (main.rs:152): el `Termination` de std imprime el chain de anyhow a
+  **stderr** (formato "Error: ...: ...").
+- **Contexto que se pierde** (lo que la issue quiere mejorar):
+  - apply.rs:103-106: el error de un target se loguea solo con `target` + `%e`; **falta
+    `agent_id` y `path`**.
+  - main.rs:380-383: error de MCP solo con `%e`; **falta `agent`/`config_path`**.
+  - `doctor` **traga errores**: doctor.rs:280-282 y 290-293 imprimen y `return Ok(())` — exit
+    code siempre 0 aunque haya fallos de parseo. Sin JSON ni estructura.
+  - `status --json` con problemas: imprime el array JSON y `std::process::exit(1)` (status.rs:154)
+    — no emite un objeto de error estructurado.
+  - Los errores de skill SÍ tienen envelope estructurado: `handle_suggest_error`
+    (skill.rs:936-978) produce `{"error","code","remediation"}`; igual en run_install
+    (1082-1087), update (732-735), uninstall (1175, 1209-1212). Se imprime a stdout **y** se
+    propaga Err → el chain de anyhow va a stderr. Este es el patrón existente a reutilizar.
+
+---
+
+## 5. El `--json` actual
+
+- `status`: `StatusArgs { json: bool }` (status.rs:13-17), `#[command(flatten)]` en
+  main.rs:73-75; dispatch `run_status(args.json, project_root)` (main.rs:167); salida
+  `serde_json::to_string_pretty(&entries)` (status.rs:152); structs serializables
+  `StatusEntry`/`StatusIssue`/`StatusChildEntry`/`DestinationKind`/`StatusIssueKind`
+  (status.rs:19-69, kebab-case); exit 1 si `problems > 0` (154).
+- `skill suggest --json`: `print_suggest_output` (skill.rs:833-844) →
+  `serde_json::to_string(&response.to_json_response())`; install: `run_suggest_inner`
+  (818-820) imprime `SuggestInstallJsonResponse`; success install: `render_skill_success_json`
+  (566-581); errores: envelope `{error, code, remediation}` (960-965, 1082-1087, 732-735).
+- `devinstall --json` (main.rs:204-215) → `run_install`.
+- **No hay `--json` global**: el flag es per-command. `apply/clean/init/doctor` no lo tienen.
+- Docs: `website/docs/src/content/docs/reference/cli.mdx` documenta `--json` para status (321:
+  "Output machine-readable JSON (pretty-printed)... Useful for CI"), skill install/suggest/update.
+  `cli-tui-compatibility.md:11-14` codifica el contrato: *"When --json is set: stdout must contain
+  machine-readable JSON only. Human headings, colors, spinners, progress frames, and hints must not
+  be mixed into stdout."*
+
+---
+
+## 6. Contratos y tests
+
+- `tests/contracts/test_install_output.rs` (94 líneas): corre el binario y **parsea TODO el
+  stdout como JSON** (27-28, 71-72). `install_json_contract` exige campos
+  id/status/name/description/files/manifest_hash/installed_at; `install_json_error_contract`
+  exige `error`/`code`/`remediation` con `code != "unknown"` y exit no-success.
+- `tests/contracts/test_skill_suggest_output.rs` (397 líneas, 9 tests): `serde_json::from_slice(&output.stdout)` (30, 71, 100, 155, 204, 291); test clave
+  `..._has_no_progress_preamble` (213-274) y `..._has_no_human_progress_lines` (307-334) que
+  afirman stdout empieza con `{`, termina con `}`, sin "Installing ", sin `\r`, sin `⠋`, sin
+  ANSI; error estructurado `interactive_tty_required` (291-304, 332-334).
+- `tests/test_status_cli.rs`: afirma líneas humanas en stdout ("OK:", "Hint:",
+  "Status: All good") (58-67).
+- **Ningún test afirma contenido de stderr** (solo lo usan como diagnóstico en el mensaje de
+  fallo: 34 ocurrencias de `stderr` en tests, todas en asserts de error). → Mover logs a stderr
+  **no rompe ningún test existente**, siempre que stdout siga limpio.
+- Otros: `tests/all_tests.rs` (harness con módulos integration::*, unit::*), `tests/e2e/`
+  (Docker, `RUN_E2E=1`), `tests/security_repro/`, `tests/manual/`.
+- `src/output.rs` tiene 30+ tests unitarios de formato exacto (plain y ANSI) — p.ej.
+  `apply_summary_preserves_exact_plain_contract` (376-398).
+
+---
+
+## 7. Secrets
+
+- **No se encontró logging de tokens/API keys** en src. Los 15 call sites de tracing loguean solo
+  paths, errores y skill_ids.
+- Áreas sensibles que NO deben loguearse: MCP `env`/`headers` (pueden contener credenciales:
+  config.rs:1241 test `Authorization = "Bearer token123"`, mcp.rs:2785 test), `command`/`args` de
+  MCP con secretos embebidos. `set_restricted_permissions` (mcp.rs:1157, 1467-1468) protege los
+  permisos del archivo y el warn loguea solo `path` — correcto.
+- `doctor` imprime el command de MCP (doctor.rs:150-173) — nombre del binario, no sensible.
+- `try_convert_github_url` normaliza URLs y el log de skill.rs:1235 registra la URL convertida; el
+  test de skill.rs:1559 confirma que `?token=` se maneja (query descartado). Al añadir spans, el
+  campo `url` debe loguearse siempre sin query ni credenciales.
+- **Recomendación**: un helper de redacción (`redact_url`, nunca loguear `env`/`headers` de MCP)
+  y una regla explícita en el spec: los campos `path`/`url` se loguean solo tras sanitización.
+
+---
+
+## 8. init.rs y wizard
+
+- Wizard estándar: `dialoguer` (Confirm/MultiSelect/Select) en init.rs:2006-2071 y en
+  skill.rs:1003-1007. **Verificado en el fuente de dialoguer-0.12.0**: los prompts se renderizan a
+  **stderr** (`src/prompts/confirm.rs:102` "The dialog is rendered on stderr", `:108`
+  `self.interact_on(&Term::stderr())`).
+- Las líneas de progreso/estado del wizard van a **stdout** vía `println!` (init.rs:1506-2246).
+- TUI experimental: ratatui+crossterm pantalla completa (init.rs:1474-1520, 3947-3963); requiere
+  stdin y stdout TTY, si no, baila con mensaje (3962-3963).
+- **Implicación para logs a stderr**: dialoguer (prompts interactivos) y tracing (logs) compartirían
+  stderr → riesgo de intercalado durante wizard/suggest interactivo. En CI no hay prompts
+  interactivos (`ensure_interactive_install_supported` skill.rs:980-988 exige TTY; el wizard
+  estándar en no-TTY fallaría igual). Mitigación sugerida: logs por defecto solo WARN+ durante
+  fases interactivas, o aceptar el solapamiento porque prompts y logs comparten stderr solo en
+  TTY (caso interactivo, donde el usuario ve ambos).
+
+---
+
+## Recomendaciones preliminares (opciones de diseño)
+
+### A. Separar `--log-format json` del `--json` funcional
+
+1. **Flags globales en `Cli` (recomendado)**: añadir en `struct Cli` (main.rs:51-54) args globales
+   `--log-format <human|json>` (default `human`) y opcional `--log-level <trace|debug|info|warn|error>`
+   o reutilizar `RUST_LOG`. Clap permite args globales que se leen en `main()` antes del dispatch
+   del subcomando. El `--json` funcional queda intacto por comando.
+2. **Flag per-comando** `--log-format` en cada subcomando: repetitivo, inconsistente, más trabajo.
+3. **Solo env var** `AGENTSYNC_LOG_FORMAT` (+ `RUST_LOG`): cero flags nuevos, pero la issue pide un
+   flag explícito y es menos descubrible.
+4. (Complementario a cualquiera) Habilitar feature `json` de tracing-subscriber en Cargo.toml:58 →
+   `tracing-subscriber = { version = "0.3", features = ["json"] }` y construir el subscriber con
+   `fmt().json().with_writer(io::stderr).with_env_filter(...)` cuando `--log-format json`, y
+   `fmt().with_writer(io::stderr)` en el caso human. `serde_json` ya está en el árbol.
+
+### B. Qué spans/campos instrumentar y dónde
+
+- Niveles: `INFO` para span de comando + outcome por agente/target; `DEBUG` para detalles por
+  archivo (create/update/skip); `WARN/ERROR` para fallos. Campos fijos: `operation`, `outcome`,
+  `agent_id`, `target`, `path`, `skill_id` según el contexto.
+- Puntos: `main.rs` (span raíz por subcomando, `operation = "apply|clean|init|status|doctor|skill"`),
+  `linker/apply.rs:43-109` (agente+target), `apply.rs:115-160` (SyncType), `linker/clean.rs`
+  (path), `mcp.rs:1497-1522` (agent), `commands/skill.rs` `run_install`/`run_update`/`run_uninstall`
+  (skill_id, phases resolve/install). Usar `tracing::info_span!` + `.in_scope()` (evita añadir
+  `tracing-attributes` como dep directa, aunque ya está en el árbol como transitiva de tracing).
+- No instrumentar el inner loop de creación de symlinks con spans anidados por archivo a INFO
+  (ruido); usar `debug!`.
+
+### C. Garantizar logs→stderr y output→stdout
+
+- **Cambio #1 (crítico)**: reemplazar `tracing_subscriber::fmt::init()` (main.rs:154) por un
+  builder con `.with_writer(io::stderr)`. Hoy los logs van a stdout (bug latente).
+- Mantener `println!`/`print_lines` (output.rs:151) para salida funcional; migrar los `println!`
+  de diagnóstico/verbose (main.rs:274-278, apply.rs:47/60/72/93, discovery.rs) a `tracing::info!`/
+  `debug!` para que pasen a stderr automáticamente.
+- `update_check` ya usa `eprintln!` (update_check.rs:137) — patrón de referencia.
+- En modo `--log-format json`, cada evento es una línea JSON en stderr; la salida funcional
+  (humana o `--json`) sigue en stdout.
+
+### D. Riesgos de romper contratos
+
+- **ALTO (latente, hoy)**: cualquier evento WARN+ durante un comando `--json` escribe en stdout y
+  rompe `serde_json::from_slice(&output.stdout)` de los contracts. El fix (stderr) **elimina** este
+  riesgo; no lo introduce. Riesgo nuevo: implementar `--log-format json` con writer a stdout por
+  error → rompería todo. El spec debe exigir `with_writer(io::stderr)` en ambos formatos.
+- **MEDIO**: dialoguer renderiza prompts a stderr; logs a stderr se intercalarían en wizard/suggest
+  interactivos. Mitigar con default WARN+ en fases interactivas o aceptarlo (solo ocurre en TTY).
+- **MEDIO**: doctor siempre devuelve exit 0 (traga errores) y status usa `process::exit(1)` —
+  si el cambio introduce "outcome" por comando, decidir si se tocan exit codes (fuera de scope de
+  la issue salvo que el spec lo pida).
+- **BAJO**: tests de stdout humano exacto (test_status_cli.rs, output.rs unit tests) no se ven
+  afectados si no se cambia la salida funcional.
+- **BAJO**: el envelope de error `{error, code, remediation}` de skill ya es contrato (contracts
+  tests) — no cambiar su forma al añadir logs.
+
+### Ready for proposal
+Sí. La exploración confirma que el cambio es factible con bajo riesgo: la pieza crítica es un
+one-liner (writer→stderr) + flags globales + spans en 4-6 puntos. Se recomienda que sdd-propose
+use el nombre de cambio `structured-diagnostics`.

--- a/openspec/changes/archive/2026-08-03-structured-diagnostics/proposal.md
+++ b/openspec/changes/archive/2026-08-03-structured-diagnostics/proposal.md
@@ -1,0 +1,70 @@
+# Proposal: Structured Diagnostics & Machine-Readable Logging
+
+## Intent
+
+AgentSync carece de observabilidad estructurada. `tracing_subscriber::fmt::init()` (src/main.rs:154) escribe logs a **STDOUT** — **bug latente**: cualquier `warn!`/`error!` durante `--json` corrompe el contrato machine-readable; los contract tests pasan solo porque los happy paths no emiten WARN+. Sin spans, sin feature `json` (Cargo.toml:58), `apply/clean/init/doctor` con `println!` directo. Issue #499: logs a stderr, output funcional en stdout, JSON estable, sin secretos, CI-usable.
+
+## Scope
+
+### In Scope
+- Subscriber con `.with_writer(io::stderr)` (fix del bug latente).
+- Flags globales `--log-format <human|json>` + `--log-level` opcional; feature `json` de tracing-subscriber.
+- Spans en apply/clean/init/status/doctor/skill/mcp con campos `operation`, `outcome`, `agent_id`, `target`, `path`, `skill_id`; verbose `println!`→`info!`/`debug!`.
+- Contexto de error (apply.rs:103-106, main.rs:380-383) con `agent_id`/`path`.
+- Redacción: nunca loguear MCP `env`/`headers` ni URLs con credenciales.
+- Tests: asserts de stderr nuevos; contracts de stdout intactos.
+
+### Out of Scope
+- Exit codes (doctor exit 0, status exit 1).
+- Unificar la emisión de todo el output funcional (refactor mayor).
+- Envelope `{error, code, remediation}` de skill — ya es contrato.
+- Spans INFO por archivo (ruido; se usa `debug!`).
+- Interleaving de prompts dialoguer con logs en stderr (se acepta, solo TTY).
+
+## Capabilities
+
+### New Capabilities
+- `cli-diagnostics`: spans con campos, flag `--log-format human|json`, logs→stderr, redacción, CI-usability.
+
+### Modified Capabilities
+- `cli-output`: nuevo requisito — logs MUST ir a stderr y stdout MUST contener solo salida funcional; contrato JSON intacto.
+
+## Approach
+
+Reemplazar `fmt::init()` (main.rs:154) por builder: `fmt().with_writer(io::stderr)` o `.json().with_writer(io::stderr)`, filtrado por `--log-level`/`RUST_LOG`. Flags globales en `struct Cli` leídos en `main()` antes del dispatch; `--json` funcional intacto. `info_span!` + `.in_scope()` en 6-8 puntos. `serde_json` ya está en el árbol.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `src/main.rs` | Modified | Subscriber→stderr, flags, span raíz |
+| `Cargo.toml` | Modified | Feature `json` |
+| `src/linker/apply.rs`, `clean.rs` | Modified | Spans, contexto de error |
+| `src/mcp.rs` | Modified | Span por agent, redacción |
+| `src/commands/skill.rs`, `doctor.rs` | Modified | Spans por operación |
+| `src/output.rs` | Modified | Verbose→logs |
+| `tests/contracts/` | Modified | Asserts de stderr |
+| `website/docs/.../cli.mdx` | Modified | Documentar `--log-format` |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| `--log-format json` a stdout rompe contratos | Med | Spec exige `with_writer(io::stderr)` en ambos formatos + tests |
+| Interleaving prompt/log en stderr | Med | Default WARN+ en fases interactivas; solo TTY |
+| Romper tests de stdout humano | Low | Salida funcional intacta |
+
+## Rollback Plan
+
+Revertir main.rs:154 a `fmt::init()` y quitar flags + spans. La pieza crítica es un one-liner (writer→stderr) sin impacto en salida funcional ni exit codes; resto son adiciones aisladas en un PR único reversible.
+
+## Dependencies
+
+- tracing-subscriber feature `json` (Cargo.toml). `tracing` y `serde_json` ya presentes.
+
+## Success Criteria
+
+- [ ] Ningún evento tracing en stdout durante `--json` (test con WARN inducido); contract tests pasan
+- [ ] `apply --log-format json 2>logs.json` → JSON parseable en stderr; `cargo test` + clippy limpios
+- [ ] MCP `env`/`headers` y URLs con credenciales ausentes de logs
+- [ ] `--log-format` documentado en cli.mdx

--- a/openspec/changes/archive/2026-08-03-structured-diagnostics/specs/cli-diagnostics/spec.md
+++ b/openspec/changes/archive/2026-08-03-structured-diagnostics/specs/cli-diagnostics/spec.md
@@ -1,0 +1,116 @@
+# CLI Diagnostics Specification
+
+## Purpose
+
+Structured diagnostics: events to stderr (human/JSON), global log flags, spans with context,
+enriched error context, no secrets, CI-parseable. Fixes logs corrupting machine-readable stdout.
+
+## Requirements
+
+### Requirement: Global Logging Flags
+
+The CLI MUST accept global flags `--log-format <human|json>` (default `human`) and
+`--log-level <trace|debug|info|warn|error>` on every subcommand. The functional per-command `--json`
+flag MUST remain independent of `--log-format`.
+
+#### Scenario: Default human format
+
+- GIVEN no `--log-format` is provided
+- WHEN any command runs
+- THEN events SHALL render human-readable on stderr
+
+### Requirement: JSON Event Shape
+
+Events MUST go to stderr in both formats and every command mode. With `--log-format json`, each
+event MUST be a single-line JSON object with at least `timestamp`, `level`, `target`, and `fields`
+(incl. `message`), plus `span` inside a span, so stderr is line-parseable; JSON MUST NOT contain
+ANSI escapes.
+
+#### Scenario: Span fields appear in JSON events
+
+- GIVEN an INFO event logged inside an apply span with `agent_id` and `target` fields
+- WHEN rendered with `--log-format json`
+- THEN the JSON object SHALL include `span` with those field values
+
+### Requirement: Spans Around Core Operations
+
+The CLI MUST instrument `apply`, `clean`, `mcp`, and `skill` with spans carrying `operation`,
+record `outcome` (ok|created|updated|removed|skipped|error) on the span, and include `agent_id`,
+`target`, `path`, `skill_id` on agent/target spans where applicable.
+
+#### Scenario: Apply target span carries context
+
+- GIVEN `agentsync apply` syncs agent `claude` target `agents`
+- WHEN the sync runs with `--log-format json`
+- THEN span events SHALL include `operation` and `agent_id`; target events SHALL include `target`
+  and `path`
+
+#### Scenario: Skill install span carries skill_id
+
+- GIVEN `agentsync skill install some-skill` runs
+- WHEN the operation runs
+- THEN the span SHALL include `operation` and `skill_id`
+
+#### Scenario: Failed target records error outcome
+
+- GIVEN an apply target fails during processing
+- WHEN the span closes
+- THEN the span SHALL record `outcome = "error"`
+
+### Requirement: Error Context in Critical Failures
+
+Apply target failure logs MUST include the target's `agent_id` and `path`. MCP sync failure logs
+MUST include the agent and its config path.
+
+#### Scenario: Target failure logs agent and path
+
+- GIVEN a target fails during apply
+- WHEN the error event is emitted
+- THEN it MUST include `agent_id` and `path`
+
+#### Scenario: MCP sync failure logs agent and config path
+
+- GIVEN MCP config generation fails for an agent
+- WHEN the error event is emitted
+- THEN it MUST include the agent and its config path
+
+### Requirement: Secrets Are Never Logged
+
+The CLI MUST NOT log MCP `env` or HTTP `headers` at any level. URLs MUST be logged redacted —
+credentials, query strings, and tokens stripped before emission; `path`/`url` SHALL be sanitized.
+
+#### Scenario: MCP env with bearer token is not logged
+
+- GIVEN an MCP config has `env` with a bearer token
+- WHEN MCP config generation runs at any log level
+- THEN no log event SHALL contain the token value or the `env` block
+
+#### Scenario: URL token query is redacted
+
+- GIVEN a skill URL contains a `?token=...` query parameter
+- WHEN the URL is logged
+- THEN the event SHALL show the URL without query or credentials
+
+### Requirement: CI-Friendly Logging
+
+Logging MUST respect `RUST_LOG`; `--log-level` MUST override it. Diagnostics MUST be deterministic
+(stable field names, one event per line). Human events SHOULD NOT emit ANSI when stderr is not a
+TTY.
+
+#### Scenario: RUST_LOG raises verbosity
+
+- GIVEN `RUST_LOG=debug` and no `--log-level`
+- WHEN a command runs
+- THEN DEBUG events SHALL appear on stderr
+
+#### Scenario: --log-level overrides RUST_LOG
+
+- GIVEN `RUST_LOG=debug` and `--log-level warn`
+- WHEN a command runs
+- THEN only WARN and ERROR events SHALL appear
+
+#### Scenario: Piped stderr has no ANSI in human mode
+
+- GIVEN stderr is a pipe with `--log-format human`
+- WHEN a command runs
+- THEN stderr SHALL contain no ANSI escape sequences

--- a/openspec/changes/archive/2026-08-03-structured-diagnostics/specs/cli-output/spec.md
+++ b/openspec/changes/archive/2026-08-03-structured-diagnostics/specs/cli-output/spec.md
@@ -1,0 +1,34 @@
+# Delta for CLI Output
+
+## ADDED Requirements
+
+### Requirement: Diagnostic Logs and Functional Output Are Stream-Separated
+
+The CLI MUST write all tracing log events to stderr and MUST write only functional output to
+stdout. Functional output is the command's human-readable result or its `--json` machine-readable
+result.
+
+The CLI MUST NOT write any tracing event to stdout in any mode. The stdout JSON contract MUST remain
+fully parseable: a command run with its functional `--json` flag MUST produce stdout that parses as
+JSON without discarding any content.
+
+#### Scenario: WARN event does not corrupt --json stdout
+
+- GIVEN `agentsync skill suggest --json` emits a WARN event during execution
+- WHEN the command completes
+- THEN stdout MUST parse as a single JSON value
+- AND the WARN event MUST appear only on stderr
+
+#### Scenario: Human output stays on stdout unchanged
+
+- GIVEN `agentsync apply` runs with a color-capable TTY
+- WHEN the operation emits human output
+- THEN stdout MUST retain the existing labels, ordering, spacing, and ANSI coloring
+- AND no tracing event MAY be interleaved into stdout
+
+#### Scenario: Functional --json and log-format json stay separate
+
+- GIVEN `agentsync status --log-format json --json` runs
+- WHEN the command completes
+- THEN stdout MUST contain only the functional status array
+- AND stderr MUST contain only JSON log events

--- a/openspec/changes/archive/2026-08-03-structured-diagnostics/state.yaml
+++ b/openspec/changes/archive/2026-08-03-structured-diagnostics/state.yaml
@@ -1,0 +1,5 @@
+change: structured-diagnostics
+current_phase: archive
+completed: [explore, propose, spec, design, tasks, apply, verify, archive]
+next: none
+updated: 2026-08-03

--- a/openspec/changes/archive/2026-08-03-structured-diagnostics/tasks.md
+++ b/openspec/changes/archive/2026-08-03-structured-diagnostics/tasks.md
@@ -1,0 +1,63 @@
+# Tasks: Structured Diagnostics (#499)
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | ~550-650 |
+| 400-line budget risk | High |
+| Chained PRs recommended | Yes |
+| Suggested split | PR 1 → PR 2 |
+| Delivery strategy | ask-on-risk |
+| Chain strategy | pending |
+
+Decision needed before apply: Yes
+Chained PRs recommended: Yes
+Chain strategy: DECIDED — size-exception aprobada por el usuario (opción B): un solo PR con todo el alcance (~550-650 líneas). Aprobación explícita del dueño del repo.
+400-line budget risk: High (mitigado por size-exception)
+
+### Suggested Work Units
+
+| Unit | Goal | Likely PR | Notes |
+|------|------|-----------|-------|
+| 1 | Logging infra: `logging.rs`, flags, stderr fix | PR 1 | base=trunk; alone fixes latent bug |
+| 2 | Spans, verbose migration, error ctx, contracts, docs | PR 2 | depends on PR 1 |
+
+## Phase 1: Logging Infra (PR 1)
+
+- [x] 1.1 RED: unit test `LogFormat` FromStr (human/json/invalid)
+- [x] 1.2 GREEN: `src/logging.rs` — `enum LogFormat` + FromStr
+- [x] 1.3 RED: unit test `resolve_level_filter` (flag > RUST_LOG > INFO)
+- [x] 1.4 GREEN: implementar `resolve_level_filter`
+- [x] 1.5 RED: unit test `redact_url` (userinfo, query, plana)
+- [x] 1.6 GREEN: implementar `redact_url`
+- [x] 1.7 GREEN: `Cargo.toml:58` — feature `json` de tracing-subscriber
+- [x] 1.8 RED: test parse flags — `--log-format json apply`, default human (mod tests main.rs)
+- [x] 1.9 GREEN: flags globales `--log-format`/`--log-level` en `struct Cli` (main.rs:51-54)
+- [x] 1.10 GREEN: `init_logging(format, level)` — `.with_writer(io::stderr)` siempre, `.json()` condicional; reemplazar `fmt::init()` (main.rs:152-154)
+- [x] 1.11 RED: black-box `tests/test_logging.rs` — `apply` sin flags: stderr humano, stdout sin tracing (bug latente)
+- [x] 1.12 GREEN: validar 1.11 (stderr fix)
+
+## Phase 2: Instrumentación (PR 2)
+
+- [x] 2.1 RED: `tests/test_logging.rs` — `apply --log-format json`: span raíz con `operation`
+- [x] 2.2 GREEN: span raíz por subcomando (main.rs dispatch 158-215), record `outcome`
+- [x] 2.3 RED: `tests/test_logging.rs` — skips visibles con `--log-level debug`
+- [x] 2.4 GREEN: migrar `println!` diagnóstico → `info!`/`debug!` (main.rs:274-278, apply.rs:47/60/72/93)
+- [x] 2.5 RED: `tests/test_logging.rs` — span agente→target con `agent_id`/`target`/`path`/`outcome`
+- [x] 2.6 GREEN: spans apply.rs (43-109 agente, 91-108 target)
+- [x] 2.7 GREEN: error context apply.rs:104 — añadir `agent_id`+`path` al `error!`
+- [x] 2.8 GREEN: span clean.rs (13-197) — `operation="remove"`, `path`, `outcome`
+- [x] 2.9 RED: `tests/test_logging.rs` — span mcp `operation="mcp"`; sin `env`/`headers` en eventos
+- [x] 2.10 GREEN: span mcp.rs generate_all (1497-1522) + error 1518 `config_path` + `redact_url`
+- [x] 2.11 RED: `tests/test_logging.rs` — span skill install con `skill_id`
+- [x] 2.12 GREEN: spans skill.rs install/update/uninstall/suggest (1015, 785-899)
+- [x] 2.13 GREEN: error context main.rs:381 — añadir `agent_id`+`config_path`
+
+## Phase 3: Contratos, Docs, Verificación
+
+- [x] 3.1 RED: contract regression — WARN inducido (MCP restricted) con `--json`: stdout 1 JSON, WARN en stderr (tests/contracts/)
+- [x] 3.2 RED: contract — `status --log-format json --json`: stdout array, stderr logs
+- [x] 3.3 GREEN: fijar 3.1-3.2 con asserts de stderr en contracts
+- [x] 3.4 Docs: `website/docs/src/content/docs/reference/cli.mdx` — documentar `--log-format`/`--log-level`
+- [x] 3.5 Verificación global: `cargo fmt --check`, clippy `-D warnings`, `cargo test --all-features`, contracts, `tests/test_logging.rs`

--- a/openspec/changes/archive/2026-08-03-structured-diagnostics/verify-report.md
+++ b/openspec/changes/archive/2026-08-03-structured-diagnostics/verify-report.md
@@ -1,0 +1,101 @@
+# Verification Report: structured-diagnostics
+
+## Verdict
+
+**PASS WITH WARNINGS**
+
+The requested final verification passed. The CRITICAL runtime gaps are covered by deterministic
+black-box tests, including the `skill suggest` WARN path, clean spans, apply/MCP error outcomes,
+log precedence, stream separation, and redaction. The repository still cannot provide independent
+timestamped evidence of historical test-first ordering, and some JSON event-shape assertions remain
+partial.
+
+## Change and completeness
+
+| Area | Result | Evidence |
+|---|---|---|
+| Proposal/design/spec/tasks read | PASS | All requested OpenSpec artifacts read. |
+| Implementation tasks | PASS (claimed) | `tasks.md` marks all implementation tasks complete; source diff contains the corresponding files. |
+| Working tree attribution | INFO | The tree contains unrelated changes, including `.agents/skills/registry.json`, `tests/test_module_map_cli.rs`, `src/linker/mod.rs`, and an untracked `.agents/skills/test-skill/`; these were not attributed to this change except where overlapping tests are explicitly referenced. |
+| Review budget | INFO | Diff reports 530 insertions / 223 deletions; tasks document the approved size-exception. |
+
+## Runtime evidence
+
+| Command | Result |
+|---|---|
+| `cargo fmt --all -- --check` | PASS |
+| `cargo clippy --all-targets --all-features -- -D warnings` | PASS |
+| `cargo test --all-features` | PASS — 540 library, 167 binary, 107 all-tests, and all other reported suites passed; 4 tests were ignored by existing gates. |
+| `cargo test --test test_logging -- --nocapture` | PASS — 12 logging tests passed. |
+| Focused logging/contracts tests | PASS — logging, skill-output, and module-map coverage passed within the full suite. |
+| `git diff --check` | PASS |
+
+## Spec compliance matrix
+
+| Requirement / scenario | Implementation evidence | Passing covering test | Result |
+|---|---|---|---|
+| Global `--log-format`/`--log-level`, independent from `--json` | `src/main.rs:43-66`, `src/logging.rs:18-36` | CLI parser unit tests; status/skill separation tests | PASS |
+| Default human diagnostics on stderr | `src/logging.rs:93-102` | `warn_event_routes_to_stderr_not_stdout_and_stays_plain_when_piped` | PASS |
+| JSON line events with span context | `src/logging.rs:95-102` | `apply_json_emits_root_span_with_operation`, agent/target span test | PASS for exercised paths |
+| Apply spans and outcomes | `src/linker/apply.rs:43-141` | `apply_json_emits_agent_and_target_spans` | PASS |
+| Clean spans and outcomes | `src/linker/clean.rs:67-101` | `clean_json_emits_removed_span_with_operation_and_path` | PASS for removed path; error path remains environment-dependent |
+| MCP spans and failure context | `src/mcp.rs:1497-1545`, `src/main.rs:360-384` | `apply_json_mcp_failure_emits_agent_and_config_path`, MCP span/secrets test | PASS |
+| Skill spans and `skill_id` | `src/commands/skill.rs:798-817,1032-1044,1190-1202,1277-1289` | `skill_install_json_emits_span_with_skill_id` | PASS for install; update/uninstall/suggest untested |
+| Error outcomes | Apply/MCP/skill record error outcomes in source | `apply_json_failed_target_emits_error_outcome_with_context`, `apply_json_mcp_failure_emits_agent_and_config_path` | PASS for target and MCP |
+| No MCP `env`/`headers`, URL redaction | `src/logging.rs:63-83`, redacted skill URL log; no env/header logging found in changed paths | `apply_json_mcp_span_never_leaks_env_headers_or_url` | PASS for exercised apply fixture |
+| `RUST_LOG` and flag precedence | `resolve_level_filter` and `init_logging` | `rust_log_debug_emits_debug_and_log_level_warn_overrides_it` | PASS |
+| Piped human stderr has no ANSI | `src/logging.rs:105-111` | `warn_event_routes_to_stderr_not_stdout_and_stays_plain_when_piped` | PASS |
+| Functional stdout remains parseable/intact | Subscriber writer is stderr; contract tests | skill suggest and status JSON contract tests; apply human stdout test | PASS for covered commands |
+| WARN regression on `skill suggest --json` | `tests/test_logging.rs:605-628` induces invalid recommendation metadata and checks stdout JSON plus stderr WARN | `skill_suggest_json_warn_stays_on_stderr_and_stdout_remains_parseable` | PASS |
+| Functional `status --log-format json --json` separation | Global flags are independent from functional JSON; status contract remains covered by existing status CLI tests and full suite | Source inspection; no dedicated black-box stderr-content assertion | PASS WITH WARNING (partial coverage) |
+
+## TDD evidence
+
+The task checklist records RED/GREEN ordering, and the repository contains regression/unit tests.
+However, no commit history, test-first trace, or other timestamped evidence was available that
+proves each listed test was failing before its production change. This is therefore not inventing
+compliance: the temporal TDD claim remains unproven.
+
+## Issues
+
+### CRITICAL
+
+None — all confirmed CRITICAL gaps now have deterministic runtime coverage.
+
+### HIGH
+
+None — all confirmed HIGH gaps now have deterministic runtime coverage.
+
+### MEDIUM
+
+| Finding | Judge A | Judge B | Severity | Status |
+|---|---|---|---|---|
+| JSON event-shape requirement is asserted only indirectly; tests do not require every emitted event to contain `timestamp`, `level`, `target`, `fields.message`, and no ANSI. | ✅ | ❌ | MEDIUM | Suspect / partial coverage |
+| TDD temporal ordering is documented in tasks but not independently evidenced. | ✅ | ✅ | MEDIUM | Confirmed — evidence gap |
+
+### WARNING (final verification)
+
+| Finding | Judge A | Judge B | Severity | Status |
+|---|---|---|---|---|
+| Dedicated `status --log-format json --json` black-box test is absent; separation is verified by implementation and adjacent contracts rather than a focused runtime assertion. | ✅ | ✅ | WARNING | Confirmed |
+
+### LOW
+
+None.
+
+## Design coherence
+
+| Decision | Assessment |
+|---|---|
+| Dedicated logging module and stderr writer | Coherent with design; implemented. |
+| Global flags independent from functional JSON | Coherent and implemented. |
+| Span-close JSON events | Coherent and implemented for JSON format. |
+| Preserve functional output | Coherent; covered paths remained parseable. |
+
+## Recommendation
+
+No CRITICAL follow-up remains. Archive is recommended. Keep the explicit TDD evidence limitation:
+repository history does not prove temporal RED-before-GREEN ordering. JSON event-shape and status
+stream-separation assertions are partial but do not block this verdict. Clean removal is covered;
+a separate clean failure fixture was not added because the current safe-unlink path is difficult to
+fail deterministically without changing production behavior.

--- a/openspec/changes/archive/2026-08-03-structured-diagnostics/verify-report.md
+++ b/openspec/changes/archive/2026-08-03-structured-diagnostics/verify-report.md
@@ -4,9 +4,10 @@
 
 **PASS WITH WARNINGS**
 
-The requested final verification passed. The CRITICAL runtime gaps are covered by deterministic
-black-box tests, including the `skill suggest` WARN path, clean spans, apply/MCP error outcomes,
-log precedence, stream separation, and redaction. The repository still cannot provide independent
+The requested review follow-up is implemented with deterministic black-box coverage for failing
+`apply --log-format json` and failing `status --log-format json --json`: functional stdout remains
+parseable, stderr is newline-delimited JSON, root spans close with `outcome=error`, and the process
+exits nonzero. The repository still cannot provide independent
 timestamped evidence of historical test-first ordering, and some JSON event-shape assertions remain
 partial.
 
@@ -47,7 +48,8 @@ partial.
 | Piped human stderr has no ANSI | `src/logging.rs:105-111` | `warn_event_routes_to_stderr_not_stdout_and_stays_plain_when_piped` | PASS |
 | Functional stdout remains parseable/intact | Subscriber writer is stderr; contract tests | skill suggest and status JSON contract tests; apply human stdout test | PASS for covered commands |
 | WARN regression on `skill suggest --json` | `tests/test_logging.rs:605-628` induces invalid recommendation metadata and checks stdout JSON plus stderr WARN | `skill_suggest_json_warn_stays_on_stderr_and_stdout_remains_parseable` | PASS |
-| Functional `status --log-format json --json` separation | Global flags are independent from functional JSON; status contract remains covered by existing status CLI tests and full suite | Source inspection; no dedicated black-box stderr-content assertion | PASS WITH WARNING (partial coverage) |
+| Functional `status --log-format json --json` separation | `src/commands/status.rs:151-157` returns an error after printing JSON; top-level runner logs it through tracing | `status_json_failure_exits_nonzero_with_parseable_stdout_and_json_diagnostics` | PASS |
+| Top-level failure rendering | `src/main.rs:174-274, 384-389` closes root span, logs error, and exits nonzero; apply aggregates errors | `apply_json_failure_exits_nonzero_and_keeps_error_protocol_on_stderr`, `status_json_failure_exits_nonzero_with_parseable_stdout_and_json_diagnostics` | PASS |
 
 ## TDD evidence
 
@@ -94,8 +96,7 @@ None.
 
 ## Recommendation
 
-No CRITICAL follow-up remains. Archive is recommended. Keep the explicit TDD evidence limitation:
-repository history does not prove temporal RED-before-GREEN ordering. JSON event-shape and status
-stream-separation assertions are partial but do not block this verdict. Clean removal is covered;
+No CRITICAL follow-up remains. Archive is ready after the mandatory full validation commands pass.
+Keep the explicit TDD evidence limitation: repository history does not prove temporal RED-before-GREEN ordering. JSON event-shape assertions are partial. Clean removal is covered;
 a separate clean failure fixture was not added because the current safe-unlink path is difficult to
 fail deterministically without changing production behavior.

--- a/openspec/specs/cli-diagnostics/spec.md
+++ b/openspec/specs/cli-diagnostics/spec.md
@@ -1,0 +1,115 @@
+# CLI Diagnostics Specification
+
+## Purpose
+
+Structured diagnostics: events to stderr (human/JSON), global log flags, spans with context,
+enriched error context, no secrets, CI-parseable. Fixes logs corrupting machine-readable stdout.
+
+## Requirements
+
+### Requirement: Global Logging Flags
+
+The CLI MUST accept global flags `--log-format <human|json>` (default `human`) and
+`--log-level <trace|debug|info|warn|error>` on every subcommand. The functional per-command `--json`
+flag MUST remain independent of `--log-format`.
+
+#### Scenario: Default human format
+
+- GIVEN no `--log-format` is provided
+- WHEN any command runs
+- THEN events SHALL render human-readable on stderr
+
+### Requirement: JSON Event Shape
+
+Events MUST go to stderr in both formats and every command mode. With `--log-format json`, each
+event MUST be a single-line JSON object with at least `timestamp`, `level`, `target`, and `fields`
+(incl. `message`), plus `span` inside a span, so stderr is line-parseable; JSON MUST NOT contain
+ANSI escapes.
+
+#### Scenario: Span fields appear in JSON events
+
+- GIVEN an INFO event logged inside an apply span with `agent_id` and `target` fields
+- WHEN rendered with `--log-format json`
+- THEN the JSON object SHALL include `span` with those field values
+
+### Requirement: Spans Around Core Operations
+
+The CLI MUST instrument `apply`, `clean`, `mcp`, and `skill` with spans carrying `operation`,
+record `outcome` (ok|created|updated|removed|skipped|error) on the span, and include `agent_id`,
+target, `path`, `skill_id` on agent/target spans where applicable.
+
+#### Scenario: Apply target span carries context
+
+- GIVEN `agentsync apply` syncs agent `claude` target `agents`
+- WHEN the sync runs with `--log-format json`
+- THEN span events SHALL include `operation` and `agent_id`; target events SHALL include `target`
+  and `path`
+
+#### Scenario: Skill install span carries skill_id
+
+- GIVEN `agentsync skill install some-skill` runs
+- WHEN the operation runs
+- THEN the span SHALL include `operation` and `skill_id`
+
+#### Scenario: Failed target records error outcome
+
+- GIVEN a target fails during processing
+- WHEN the span closes
+- THEN the span SHALL record `outcome = "error"`
+
+### Requirement: Error Context in Critical Failures
+
+Apply target failure logs MUST include the target's `agent_id` and `path`. MCP sync failure logs
+MUST include the agent and its config path.
+
+#### Scenario: Target failure logs agent and path
+
+- GIVEN a target fails during apply
+- WHEN the error event is emitted
+- THEN it MUST include `agent_id` and `path`
+
+#### Scenario: MCP sync failure logs agent and config path
+
+- GIVEN MCP config generation fails for an agent
+- WHEN the error event is emitted
+- THEN it MUST include the agent and its config path
+
+### Requirement: Secrets Are Never Logged
+
+The CLI MUST NOT log MCP `env` or HTTP `headers` at any level. URLs MUST be logged redacted —
+credentials, query strings, and tokens stripped before emission; `path`/`url` SHALL be sanitized.
+
+#### Scenario: MCP env with bearer token is not logged
+
+- GIVEN an MCP config has `env` with a bearer token
+- WHEN MCP config generation runs at any log level
+- THEN no log event SHALL contain the token value or the `env` block
+
+#### Scenario: URL token query is redacted
+
+- GIVEN a skill URL contains a `?token=...` query parameter
+- WHEN the URL is logged
+- THEN the event SHALL show the URL without query or credentials
+
+### Requirement: CI-Friendly Logging
+
+Logging MUST respect `RUST_LOG`; `--log-level` MUST override it. Diagnostics MUST be deterministic
+(stable field names, one event per line). Human events SHOULD NOT emit ANSI when stderr is not a TTY.
+
+#### Scenario: RUST_LOG raises verbosity
+
+- GIVEN `RUST_LOG=debug` and no `--log-level`
+- WHEN a command runs
+- THEN DEBUG events SHALL appear on stderr
+
+#### Scenario: --log-level overrides RUST_LOG
+
+- GIVEN `RUST_LOG=debug` and `--log-level warn`
+- WHEN a command runs
+- THEN only WARN and ERROR events SHALL appear
+
+#### Scenario: Piped stderr has no ANSI in human mode
+
+- GIVEN stderr is a pipe with `--log-format human`
+- WHEN a command runs
+- THEN stderr SHALL contain no ANSI escape sequences

--- a/openspec/specs/cli-output/spec.md
+++ b/openspec/specs/cli-output/spec.md
@@ -41,3 +41,34 @@ owned by its command module and unchanged.
 - GIVEN `agentsync status --json` produces a status array
 - WHEN the output implementation is reorganized
 - THEN its JSON shape and non-zero problem exit behavior MUST remain unchanged
+
+### Requirement: Diagnostic Logs and Functional Output Are Stream-Separated
+
+The CLI MUST write all tracing log events to stderr and MUST write only functional output to
+stdout. Functional output is the command's human-readable result or its `--json` machine-readable
+result.
+
+The CLI MUST NOT write any tracing event to stdout in any mode. The stdout JSON contract MUST remain
+fully parseable: a command run with its functional `--json` flag MUST produce stdout that parses as
+JSON without discarding any content.
+
+#### Scenario: WARN event does not corrupt --json stdout
+
+- GIVEN `agentsync skill suggest --json` emits a WARN event during execution
+- WHEN the command completes
+- THEN stdout MUST parse as a single JSON value
+- AND the WARN event MUST appear only on stderr
+
+#### Scenario: Human output stays on stdout unchanged
+
+- GIVEN `agentsync apply` runs with a color-capable TTY
+- WHEN the operation emits human output
+- THEN stdout MUST retain the existing labels, ordering, spacing, and ANSI coloring
+- AND no tracing event MAY be interleaved into stdout
+
+#### Scenario: Functional --json and log-format json stay separate
+
+- GIVEN `agentsync status --log-format json --json` runs
+- WHEN the command completes
+- THEN stdout MUST contain only the functional status array
+- AND stderr MUST contain only JSON log events

--- a/src/commands/skill.rs
+++ b/src/commands/skill.rs
@@ -666,6 +666,19 @@ pub struct SkillSuggestArgs {
 }
 
 pub fn run_update(args: SkillUpdateArgs, project_root: PathBuf) -> Result<()> {
+    let span = tracing::info_span!(
+        "agentsync",
+        operation = "skill_update",
+        skill_id = %args.skill_id,
+        outcome = tracing::field::Empty
+    );
+    let _enter = span.enter();
+    let result = run_update_inner(args, project_root);
+    span.record("outcome", if result.is_ok() { "ok" } else { "error" });
+    result
+}
+
+fn run_update_inner(args: SkillUpdateArgs, project_root: PathBuf) -> Result<()> {
     let target_root = project_root.join(".agents").join("skills");
     std::fs::create_dir_all(&target_root)?;
 
@@ -783,13 +796,19 @@ fn run_registry_command(command: SkillRegistryCommand) -> Result<()> {
 }
 
 pub fn run_suggest(args: SkillSuggestArgs, project_root: PathBuf) -> Result<()> {
-    let service = SuggestionService;
-    let result = run_suggest_inner(&args, &project_root, &service);
-
-    match result {
+    let span = tracing::info_span!(
+        "agentsync",
+        operation = "skill_suggest",
+        outcome = tracing::field::Empty
+    );
+    let _enter = span.enter();
+    let result = run_suggest_inner(&args, &project_root, &SuggestionService);
+    let result = match result {
         Ok(()) => Ok(()),
         Err(error) => handle_suggest_error(&args, error),
-    }
+    };
+    span.record("outcome", if result.is_ok() { "ok" } else { "error" });
+    result
 }
 
 fn run_suggest_inner(
@@ -1013,6 +1032,19 @@ fn prompt_for_recommended_skills(
 }
 
 pub fn run_install(args: SkillInstallArgs, project_root: PathBuf) -> Result<()> {
+    let span = tracing::info_span!(
+        "agentsync",
+        operation = "skill_install",
+        skill_id = %args.skill_id,
+        outcome = tracing::field::Empty
+    );
+    let _enter = span.enter();
+    let result = run_install_inner(args, project_root);
+    span.record("outcome", if result.is_ok() { "ok" } else { "error" });
+    result
+}
+
+fn run_install_inner(args: SkillInstallArgs, project_root: PathBuf) -> Result<()> {
     let target_root = project_root.join(".agents").join("skills");
     std::fs::create_dir_all(&target_root)?;
 
@@ -1158,6 +1190,19 @@ impl Provider for SuggestInstallProvider {
 }
 
 pub fn run_uninstall(args: SkillUninstallArgs, project_root: PathBuf) -> Result<()> {
+    let span = tracing::info_span!(
+        "agentsync",
+        operation = "skill_uninstall",
+        skill_id = %args.skill_id,
+        outcome = tracing::field::Empty
+    );
+    let _enter = span.enter();
+    let result = run_uninstall_inner(args, project_root);
+    span.record("outcome", if result.is_ok() { "ok" } else { "error" });
+    result
+}
+
+fn run_uninstall_inner(args: SkillUninstallArgs, project_root: PathBuf) -> Result<()> {
     let target_root = project_root.join(".agents").join("skills");
 
     let skill_id = &args.skill_id;
@@ -1232,7 +1277,11 @@ fn resolve_source(skill_id: &str, source_arg: Option<String>) -> Result<String> 
     if let Some(s) = source_arg {
         // Check if it's a GitHub URL that needs conversion to ZIP format
         if let Some(github_url) = try_convert_github_url(&s) {
-            tracing::info!(original = %s, converted = %github_url, "Converted GitHub URL to ZIP format");
+            tracing::info!(
+                original = %agentsync::logging::redact_url(&s),
+                converted = %agentsync::logging::redact_url(&github_url),
+                "Converted GitHub URL to ZIP format"
+            );
             return Ok(github_url);
         }
         return Ok(s);

--- a/src/commands/skill.rs
+++ b/src/commands/skill.rs
@@ -18,6 +18,21 @@ use std::thread::{self, JoinHandle};
 use std::time::Duration;
 use tracing::error;
 
+fn with_skill_span<F>(operation: &'static str, skill_id: Option<&str>, f: F) -> Result<()>
+where
+    F: FnOnce() -> Result<()>,
+{
+    let span = match skill_id {
+        Some(id) => {
+            tracing::info_span!("agentsync", operation, skill_id = %id, outcome = tracing::field::Empty)
+        }
+        None => tracing::info_span!("agentsync", operation, outcome = tracing::field::Empty),
+    };
+    let result = span.in_scope(f);
+    span.record("outcome", if result.is_ok() { "ok" } else { "error" });
+    result
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SuggestInstallOutputMode {
     Json,
@@ -666,16 +681,10 @@ pub struct SkillSuggestArgs {
 }
 
 pub fn run_update(args: SkillUpdateArgs, project_root: PathBuf) -> Result<()> {
-    let span = tracing::info_span!(
-        "agentsync",
-        operation = "skill_update",
-        skill_id = %args.skill_id,
-        outcome = tracing::field::Empty
-    );
-    let _enter = span.enter();
-    let result = run_update_inner(args, project_root);
-    span.record("outcome", if result.is_ok() { "ok" } else { "error" });
-    result
+    let skill_id = args.skill_id.clone();
+    with_skill_span("skill_update", Some(&skill_id), || {
+        run_update_inner(args, project_root)
+    })
 }
 
 fn run_update_inner(args: SkillUpdateArgs, project_root: PathBuf) -> Result<()> {
@@ -796,19 +805,12 @@ fn run_registry_command(command: SkillRegistryCommand) -> Result<()> {
 }
 
 pub fn run_suggest(args: SkillSuggestArgs, project_root: PathBuf) -> Result<()> {
-    let span = tracing::info_span!(
-        "agentsync",
-        operation = "skill_suggest",
-        outcome = tracing::field::Empty
-    );
-    let _enter = span.enter();
-    let result = run_suggest_inner(&args, &project_root, &SuggestionService);
-    let result = match result {
-        Ok(()) => Ok(()),
-        Err(error) => handle_suggest_error(&args, error),
-    };
-    span.record("outcome", if result.is_ok() { "ok" } else { "error" });
-    result
+    with_skill_span("skill_suggest", None, || {
+        match run_suggest_inner(&args, &project_root, &SuggestionService) {
+            Ok(()) => Ok(()),
+            Err(error) => handle_suggest_error(&args, error),
+        }
+    })
 }
 
 fn run_suggest_inner(
@@ -1032,16 +1034,10 @@ fn prompt_for_recommended_skills(
 }
 
 pub fn run_install(args: SkillInstallArgs, project_root: PathBuf) -> Result<()> {
-    let span = tracing::info_span!(
-        "agentsync",
-        operation = "skill_install",
-        skill_id = %args.skill_id,
-        outcome = tracing::field::Empty
-    );
-    let _enter = span.enter();
-    let result = run_install_inner(args, project_root);
-    span.record("outcome", if result.is_ok() { "ok" } else { "error" });
-    result
+    let skill_id = args.skill_id.clone();
+    with_skill_span("skill_install", Some(&skill_id), || {
+        run_install_inner(args, project_root)
+    })
 }
 
 fn run_install_inner(args: SkillInstallArgs, project_root: PathBuf) -> Result<()> {
@@ -1059,7 +1055,7 @@ fn run_install_inner(args: SkillInstallArgs, project_root: PathBuf) -> Result<()
     // Unified logic: install from archive, URL, or local directory
     tracing::debug!(
         skill_id = %skill_id,
-        source = %source,
+        source = %agentsync::logging::redact_url(&source),
         target_root = %target_root.display(),
         "install"
     );
@@ -1190,16 +1186,10 @@ impl Provider for SuggestInstallProvider {
 }
 
 pub fn run_uninstall(args: SkillUninstallArgs, project_root: PathBuf) -> Result<()> {
-    let span = tracing::info_span!(
-        "agentsync",
-        operation = "skill_uninstall",
-        skill_id = %args.skill_id,
-        outcome = tracing::field::Empty
-    );
-    let _enter = span.enter();
-    let result = run_uninstall_inner(args, project_root);
-    span.record("outcome", if result.is_ok() { "ok" } else { "error" });
-    result
+    let skill_id = args.skill_id.clone();
+    with_skill_span("skill_uninstall", Some(&skill_id), || {
+        run_uninstall_inner(args, project_root)
+    })
 }
 
 fn run_uninstall_inner(args: SkillUninstallArgs, project_root: PathBuf) -> Result<()> {

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -150,10 +150,11 @@ pub fn run_status(json: bool, project_root: PathBuf) -> Result<()> {
 
     if json {
         println!("{}", serde_json::to_string_pretty(&entries)?);
-        if problems > 0 {
-            std::process::exit(1);
-        }
-        return Ok(());
+        return if problems > 0 {
+            Err(anyhow::anyhow!("status found {problems} problem(s)"))
+        } else {
+            Ok(())
+        };
     }
 
     let use_color = match crate::output::output_mode(json) {
@@ -176,7 +177,7 @@ pub fn run_status(json: bool, project_root: PathBuf) -> Result<()> {
 
     if problems > 0 {
         println!("\n{}", render_status_summary(problems, &formatter));
-        std::process::exit(1);
+        return Err(anyhow::anyhow!("status found {problems} problem(s)"));
     }
 
     println!("\n{}", render_status_summary(0, &formatter));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod config;
 pub mod gitignore;
 pub mod init;
 pub mod linker;
+pub mod logging;
 pub mod mcp;
 pub mod skills;
 pub mod skills_layout;

--- a/src/linker/apply.rs
+++ b/src/linker/apply.rs
@@ -41,11 +41,18 @@ impl Linker {
         }
 
         for (agent_name, agent_config) in &self.config.agents {
+            let agent_span = tracing::info_span!(
+                "agentsync",
+                operation = "sync",
+                agent_id = %agent_name,
+                outcome = tracing::field::Empty
+            );
+            let _agent_enter = agent_span.enter();
+
             // Skip disabled agents
             if !agent_config.enabled {
-                if options.verbose {
-                    println!("  {} Skipping disabled agent: {}", "○".yellow(), agent_name);
-                }
+                tracing::debug!(reason = "disabled", "Skipping agent");
+                agent_span.record("outcome", "skipped");
                 continue;
             }
 
@@ -56,9 +63,8 @@ impl Linker {
                     .iter()
                     .any(|f| crate::agent_ids::sync_filter_matches(agent_name, f))
                 {
-                    if options.verbose {
-                        println!("  {} Skipping filtered agent: {}", "○".yellow(), agent_name);
-                    }
+                    tracing::debug!(reason = "filtered", "Skipping agent");
+                    agent_span.record("outcome", "skipped");
                     continue;
                 }
             } else if !self.config.default_agents.is_empty()
@@ -68,13 +74,8 @@ impl Linker {
                     .iter()
                     .any(|f| crate::agent_ids::sync_filter_matches(agent_name, f))
             {
-                if options.verbose {
-                    println!(
-                        "  {} Skipping agent (not in default_agents): {}",
-                        "○".yellow(),
-                        agent_name
-                    );
-                }
+                tracing::debug!(reason = "not in default_agents", "Skipping agent");
+                agent_span.record("outcome", "skipped");
                 continue;
             }
             // If neither --agents nor default_agents, process all enabled agents
@@ -87,11 +88,23 @@ impl Linker {
             };
             println!("\n{}{}", agent_name.bold(), desc.dimmed());
 
+            let mut agent_errors = 0usize;
+            let mut agent_created = 0usize;
+            let mut agent_updated = 0usize;
+
             // Process each target
             for (target_name, target_config) in &agent_config.targets {
-                if options.verbose {
-                    println!("  Processing target: {}", target_name.dimmed());
-                }
+                let target_span = tracing::info_span!(
+                    "agentsync",
+                    operation = "sync",
+                    agent_id = %agent_name,
+                    target = %target_name,
+                    path = %target_config.destination,
+                    outcome = tracing::field::Empty
+                );
+                let _target_enter = target_span.enter();
+
+                tracing::debug!(target = %target_name, "Processing target");
 
                 match self.process_target(agent_name, target_config, options) {
                     Ok(target_result) => {
@@ -99,13 +112,43 @@ impl Linker {
                         result.updated += target_result.updated;
                         result.skipped += target_result.skipped;
                         result.errors += target_result.errors;
+                        agent_errors += target_result.errors;
+                        agent_created += target_result.created;
+                        agent_updated += target_result.updated;
+                        let outcome = if target_result.errors > 0 {
+                            "error"
+                        } else if target_result.created > 0 {
+                            "created"
+                        } else if target_result.updated > 0 {
+                            "updated"
+                        } else {
+                            "skipped"
+                        };
+                        target_span.record("outcome", outcome);
                     }
                     Err(e) => {
-                        tracing::error!(target = %target_name, error = %e, "Error processing target");
+                        tracing::error!(
+                            agent_id = %agent_name,
+                            target = %target_name,
+                            path = %target_config.destination,
+                            error = %e,
+                            "Error processing target"
+                        );
+                        target_span.record("outcome", "error");
                         result.errors += 1;
+                        agent_errors += 1;
                     }
                 }
             }
+
+            let agent_outcome = if agent_errors > 0 {
+                "error"
+            } else if agent_created + agent_updated > 0 {
+                "ok"
+            } else {
+                "skipped"
+            };
+            agent_span.record("outcome", agent_outcome);
         }
 
         Ok(result)

--- a/src/linker/clean.rs
+++ b/src/linker/clean.rs
@@ -83,15 +83,15 @@ impl Linker {
         } else {
             if let Err(e) = self.revalidate_unlink_path(dest) {
                 span.record("outcome", "error");
-                return Err(e).with_context(|| {
-                    format!("Failed to remove managed symlink: {}", dest.display())
-                });
+                result.errors += 1;
+                tracing::error!(error = %e, path = %dest.display(), "Failed to revalidate managed symlink removal");
+                return Ok(());
             }
             if let Err(e) = symlinks::remove_symlink(dest) {
                 span.record("outcome", "error");
-                return Err(e).with_context(|| {
-                    format!("Failed to remove managed symlink: {}", dest.display())
-                });
+                result.errors += 1;
+                tracing::error!(error = %e, path = %dest.display(), "Failed to remove managed symlink");
+                return Ok(());
             }
             self.invalidate_path_cache();
             println!("  {} Removed: {}", "✔".green(), dest.display());

--- a/src/linker/clean.rs
+++ b/src/linker/clean.rs
@@ -3,6 +3,7 @@
 use anyhow::{Context, Result};
 use colored::Colorize;
 use std::fs;
+use std::path::Path;
 
 use crate::config::SyncType;
 
@@ -56,16 +57,47 @@ impl Linker {
             Err(_) => return Ok(()),
         };
         if dest.is_symlink() {
-            if options.dry_run {
-                println!("  {} Would remove: {}", "→".cyan(), dest.display());
-            } else {
-                self.revalidate_unlink_path(&dest)?;
-                symlinks::remove_symlink(&dest)?;
-                self.invalidate_path_cache();
-                println!("  {} Removed: {}", "✔".green(), dest.display());
-            }
-            result.removed += 1;
+            self.remove_managed_symlink(&dest, options.dry_run, result)?;
         }
+        Ok(())
+    }
+
+    /// Remove a single managed symlink, emitting a per-path span
+    /// (`operation="remove"`, `path`, `outcome`) around the decision.
+    fn remove_managed_symlink(
+        &self,
+        dest: &Path,
+        dry_run: bool,
+        result: &mut SyncResult,
+    ) -> Result<()> {
+        let span = tracing::info_span!(
+            "agentsync",
+            operation = "remove",
+            path = %dest.display(),
+            outcome = tracing::field::Empty
+        );
+        let _enter = span.enter();
+        if dry_run {
+            println!("  {} Would remove: {}", "→".cyan(), dest.display());
+            span.record("outcome", "would_remove");
+        } else {
+            if let Err(e) = self.revalidate_unlink_path(dest) {
+                span.record("outcome", "error");
+                return Err(e).with_context(|| {
+                    format!("Failed to remove managed symlink: {}", dest.display())
+                });
+            }
+            if let Err(e) = symlinks::remove_symlink(dest) {
+                span.record("outcome", "error");
+                return Err(e).with_context(|| {
+                    format!("Failed to remove managed symlink: {}", dest.display())
+                });
+            }
+            self.invalidate_path_cache();
+            println!("  {} Removed: {}", "✔".green(), dest.display());
+            span.record("outcome", "removed");
+        }
+        result.removed += 1;
         Ok(())
     }
 
@@ -90,15 +122,7 @@ impl Linker {
                 entry.with_context(|| format!("Failed to read entry in: {}", dest.display()))?;
             let entry_path = entry.path();
             if entry_path.is_symlink() {
-                if options.dry_run {
-                    println!("  {} Would remove: {}", "→".cyan(), entry_path.display());
-                } else {
-                    self.revalidate_unlink_path(&entry_path)?;
-                    symlinks::remove_symlink(&entry_path)?;
-                    self.invalidate_path_cache();
-                    println!("  {} Removed: {}", "✔".green(), entry_path.display());
-                }
-                result.removed += 1;
+                self.remove_managed_symlink(&entry_path, options.dry_run, result)?;
             }
         }
         // Try to remove the directory if empty
@@ -148,15 +172,7 @@ impl Linker {
                 Err(_) => continue,
             };
             if dest.is_symlink() {
-                if options.dry_run {
-                    println!("  {} Would remove: {}", "→".cyan(), dest.display());
-                } else {
-                    self.revalidate_unlink_path(&dest)?;
-                    symlinks::remove_symlink(&dest)?;
-                    self.invalidate_path_cache();
-                    println!("  {} Removed: {}", "✔".green(), dest.display());
-                }
-                result.removed += 1;
+                self.remove_managed_symlink(&dest, options.dry_run, result)?;
             }
         }
         Ok(())
@@ -188,15 +204,7 @@ impl Linker {
             };
 
             if dest.is_symlink() {
-                if options.dry_run {
-                    println!("  {} Would remove: {}", "→".cyan(), dest.display());
-                } else {
-                    self.revalidate_unlink_path(&dest)?;
-                    symlinks::remove_symlink(&dest)?;
-                    self.invalidate_path_cache();
-                    println!("  {} Removed: {}", "✔".green(), dest.display());
-                }
-                result.removed += 1;
+                self.remove_managed_symlink(&dest, options.dry_run, result)?;
             }
         }
         Ok(())

--- a/src/linker/mod.rs
+++ b/src/linker/mod.rs
@@ -120,6 +120,11 @@ impl Linker {
         &self.config
     }
 
+    /// Get the path of the loaded `agentsync.toml` config file.
+    pub fn config_path(&self) -> &Path {
+        &self.config_path
+    }
+
     /// Drop discovery caches after filesystem mutations that can affect later
     /// nested-glob walks. Symlink mutations do NOT require this as NestedGlob
     /// discovery uses follow_links(false).

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -10,7 +10,7 @@ use std::io;
 use std::io::IsTerminal;
 use std::str::FromStr;
 
-use tracing_subscriber::filter::LevelFilter;
+use tracing_subscriber::filter::{EnvFilter, LevelFilter};
 use tracing_subscriber::fmt::format::FmtSpan;
 
 /// Log event rendering format, selected via the global `--log-format` flag.
@@ -50,14 +50,16 @@ impl fmt::Display for LogFormat {
 ///
 /// `rust_log` is passed in explicitly (rather than read via `std::env`) so the
 /// precedence logic stays pure and unit-testable without racing on process env.
-pub fn resolve_level_filter(flag: Option<LevelFilter>, rust_log: Option<&str>) -> LevelFilter {
+pub fn resolve_level_filter(flag: Option<LevelFilter>, rust_log: Option<&str>) -> EnvFilter {
     if let Some(level) = flag {
-        return level;
+        return EnvFilter::new(level.to_string());
     }
-    if let Ok(Some(level)) = rust_log.map(str::parse).transpose() {
-        return level;
+    if let Some(directives) = rust_log
+        && let Ok(filter) = EnvFilter::try_new(directives)
+    {
+        return filter;
     }
-    LevelFilter::INFO
+    EnvFilter::new("info")
 }
 
 /// Strip credentials and query strings from a URL for safe inclusion in log events.
@@ -71,13 +73,13 @@ pub fn redact_url(url: &str) -> String {
         // Only strip userinfo when it is preceded by a scheme (`://`), so plain
         // "user@host" emails / usernames in paths are not mangled.
         let prefix = &redacted[..at];
-        if prefix.contains("://")
-            && let Some(scheme_end) = prefix.rfind("://")
-        {
+        if let Some(scheme_end) = prefix.rfind("://") {
             redacted.replace_range(scheme_end + 3..at + 1, "");
+        } else if url.starts_with("//") {
+            redacted.replace_range(2..at + 1, "");
         }
     }
-    if let Some(query_start) = redacted.find('?') {
+    if let Some(query_start) = redacted.find(['?', '#']) {
         redacted.truncate(query_start);
     }
     redacted
@@ -91,14 +93,19 @@ pub fn redact_url(url: &str) -> String {
 /// `json` format additionally emits span-close events so span fields (agent id,
 /// target, outcome) are observable by machine consumers.
 pub fn init_logging(format: LogFormat, level: Option<LevelFilter>) {
-    let level = resolve_level_filter(level, std::env::var("RUST_LOG").ok().as_deref());
-    let builder = tracing_subscriber::fmt()
-        .with_writer(io::stderr)
-        .with_ansi(use_ansi())
-        .with_max_level(level);
+    let filter = resolve_level_filter(level, std::env::var("RUST_LOG").ok().as_deref());
     match format {
-        LogFormat::Human => builder.init(),
-        LogFormat::Json => builder.json().with_span_events(FmtSpan::CLOSE).init(),
+        LogFormat::Human => tracing_subscriber::fmt()
+            .with_writer(io::stderr)
+            .with_ansi(use_ansi())
+            .with_env_filter(filter)
+            .init(),
+        LogFormat::Json => tracing_subscriber::fmt()
+            .json()
+            .with_writer(io::stderr)
+            .with_span_events(FmtSpan::CLOSE)
+            .with_env_filter(filter)
+            .init(),
     }
 }
 
@@ -159,33 +166,47 @@ mod tests {
 
     #[test]
     fn resolve_level_filter_flag_beats_rust_log() {
-        assert_eq!(
-            resolve_level_filter(Some(LevelFilter::DEBUG), Some("info")),
-            LevelFilter::DEBUG
+        assert!(
+            resolve_level_filter(Some(LevelFilter::DEBUG), Some("info"))
+                .to_string()
+                .contains("debug")
         );
     }
 
     #[test]
     fn resolve_level_filter_rust_log_when_no_flag() {
-        assert_eq!(resolve_level_filter(None, Some("warn")), LevelFilter::WARN);
+        assert!(
+            resolve_level_filter(None, Some("warn"))
+                .to_string()
+                .contains("warn")
+        );
     }
 
     #[test]
     fn resolve_level_filter_rust_log_off() {
-        assert_eq!(resolve_level_filter(None, Some("off")), LevelFilter::OFF);
+        assert!(
+            resolve_level_filter(None, Some("off"))
+                .to_string()
+                .contains("off")
+        );
     }
 
     #[test]
-    fn resolve_level_filter_invalid_rust_log_falls_back_to_info() {
-        assert_eq!(
-            resolve_level_filter(None, Some("garbage-level")),
-            LevelFilter::INFO
+    fn resolve_level_filter_preserves_target_directives() {
+        assert!(
+            resolve_level_filter(None, Some("agentsync::linker=debug"))
+                .to_string()
+                .contains("agentsync::linker=debug")
         );
     }
 
     #[test]
     fn resolve_level_filter_defaults_to_info() {
-        assert_eq!(resolve_level_filter(None, None), LevelFilter::INFO);
+        assert!(
+            resolve_level_filter(None, None)
+                .to_string()
+                .contains("info")
+        );
     }
 
     #[test]
@@ -223,5 +244,17 @@ mod tests {
     #[test]
     fn redact_url_handles_url_without_scheme() {
         assert_eq!(redact_url("example.com/path"), "example.com/path");
+    }
+
+    #[test]
+    fn redact_url_strips_scheme_relative_credentials_and_preserves_fragment() {
+        assert_eq!(
+            redact_url("//user:pass@example.com/path?token=x#frag"),
+            "//example.com/path"
+        );
+        assert_eq!(
+            redact_url("https://example.com/path#token"),
+            "https://example.com/path"
+        );
     }
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,227 @@
+//! Structured diagnostics: subscriber setup, log format parsing, and URL redaction.
+//!
+//! See `openspec/changes/structured-diagnostics/` for the full design. This module
+//! owns how AgentSync writes structured log events: always to stderr (never stdout),
+//! in human or JSON format, at a level resolved from `--log-level` > `RUST_LOG` >
+//! default `INFO`.
+
+use std::fmt;
+use std::io;
+use std::io::IsTerminal;
+use std::str::FromStr;
+
+use tracing_subscriber::filter::LevelFilter;
+use tracing_subscriber::fmt::format::FmtSpan;
+
+/// Log event rendering format, selected via the global `--log-format` flag.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogFormat {
+    /// Human-readable, ANSI-colored lines (default).
+    Human,
+    /// Newline-delimited JSON events, stable for machine consumers.
+    Json,
+}
+
+impl FromStr for LogFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "human" => Ok(LogFormat::Human),
+            "json" => Ok(LogFormat::Json),
+            _ => Err(format!(
+                "invalid log format '{s}' (expected 'human' or 'json')"
+            )),
+        }
+    }
+}
+
+impl fmt::Display for LogFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LogFormat::Human => f.write_str("human"),
+            LogFormat::Json => f.write_str("json"),
+        }
+    }
+}
+
+/// Resolve the subscriber filter level by precedence:
+/// explicit `--log-level` flag > `RUST_LOG` env var > default `INFO`.
+///
+/// `rust_log` is passed in explicitly (rather than read via `std::env`) so the
+/// precedence logic stays pure and unit-testable without racing on process env.
+pub fn resolve_level_filter(flag: Option<LevelFilter>, rust_log: Option<&str>) -> LevelFilter {
+    if let Some(level) = flag {
+        return level;
+    }
+    if let Ok(Some(level)) = rust_log.map(str::parse).transpose() {
+        return level;
+    }
+    LevelFilter::INFO
+}
+
+/// Strip credentials and query strings from a URL for safe inclusion in log events.
+///
+/// Removes `user:pass@` userinfo (up to and including the `@`) and drops anything
+/// after `?` (query params may hold tokens). URLs without a scheme are returned
+/// unchanged.
+pub fn redact_url(url: &str) -> String {
+    let mut redacted = url.to_string();
+    if let Some(at) = redacted.find('@') {
+        // Only strip userinfo when it is preceded by a scheme (`://`), so plain
+        // "user@host" emails / usernames in paths are not mangled.
+        let prefix = &redacted[..at];
+        if prefix.contains("://")
+            && let Some(scheme_end) = prefix.rfind("://")
+        {
+            redacted.replace_range(scheme_end + 3..at + 1, "");
+        }
+    }
+    if let Some(query_start) = redacted.find('?') {
+        redacted.truncate(query_start);
+    }
+    redacted
+}
+
+/// Install the global tracing subscriber.
+///
+/// Log events ALWAYS go to stderr so functional stdout (human output and the
+/// machine-readable `--json` contracts) stays clean — this is the core fix for
+/// issue #499. The filter level is resolved via [`resolve_level_filter`], and
+/// `json` format additionally emits span-close events so span fields (agent id,
+/// target, outcome) are observable by machine consumers.
+pub fn init_logging(format: LogFormat, level: Option<LevelFilter>) {
+    let level = resolve_level_filter(level, std::env::var("RUST_LOG").ok().as_deref());
+    let builder = tracing_subscriber::fmt()
+        .with_writer(io::stderr)
+        .with_ansi(use_ansi())
+        .with_max_level(level);
+    match format {
+        LogFormat::Human => builder.init(),
+        LogFormat::Json => builder.json().with_span_events(FmtSpan::CLOSE).init(),
+    }
+}
+
+/// Whether human-format events may use ANSI escape codes.
+///
+/// Enabled only when stderr is a terminal (piped stderr stays plain, keeping
+/// logs machine-parseable) and `NO_COLOR` is unset or empty.
+fn use_ansi() -> bool {
+    io::stderr().is_terminal() && std::env::var("NO_COLOR").map_or(true, |v| v.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+
+    #[test]
+    fn log_format_from_str_human() {
+        assert_eq!(LogFormat::from_str("human").unwrap(), LogFormat::Human);
+    }
+
+    #[test]
+    fn log_format_from_str_json() {
+        assert_eq!(LogFormat::from_str("json").unwrap(), LogFormat::Json);
+    }
+
+    #[test]
+    fn log_format_from_str_case_insensitive() {
+        assert_eq!(LogFormat::from_str("JSON").unwrap(), LogFormat::Json);
+        assert_eq!(LogFormat::from_str("Human").unwrap(), LogFormat::Human);
+    }
+
+    #[test]
+    fn log_format_from_str_whitespace_trimmed() {
+        assert_eq!(LogFormat::from_str("  json ").unwrap(), LogFormat::Json);
+    }
+
+    #[test]
+    fn log_format_from_str_invalid_rejected() {
+        let err = LogFormat::from_str("xml").unwrap_err();
+        assert!(err.contains("invalid log format"), "got: {err}");
+        assert!(err.contains("'xml'"), "got: {err}");
+        assert!(err.contains("human"), "got: {err}");
+        assert!(err.contains("json"), "got: {err}");
+    }
+
+    #[test]
+    fn log_format_from_str_empty_rejected() {
+        assert!(LogFormat::from_str("").is_err());
+    }
+
+    #[test]
+    fn log_format_display_roundtrip() {
+        assert_eq!(LogFormat::Human.to_string(), "human");
+        assert_eq!(LogFormat::Json.to_string(), "json");
+    }
+
+    #[test]
+    fn resolve_level_filter_flag_beats_rust_log() {
+        assert_eq!(
+            resolve_level_filter(Some(LevelFilter::DEBUG), Some("info")),
+            LevelFilter::DEBUG
+        );
+    }
+
+    #[test]
+    fn resolve_level_filter_rust_log_when_no_flag() {
+        assert_eq!(resolve_level_filter(None, Some("warn")), LevelFilter::WARN);
+    }
+
+    #[test]
+    fn resolve_level_filter_rust_log_off() {
+        assert_eq!(resolve_level_filter(None, Some("off")), LevelFilter::OFF);
+    }
+
+    #[test]
+    fn resolve_level_filter_invalid_rust_log_falls_back_to_info() {
+        assert_eq!(
+            resolve_level_filter(None, Some("garbage-level")),
+            LevelFilter::INFO
+        );
+    }
+
+    #[test]
+    fn resolve_level_filter_defaults_to_info() {
+        assert_eq!(resolve_level_filter(None, None), LevelFilter::INFO);
+    }
+
+    #[test]
+    fn redact_url_strips_userinfo() {
+        assert_eq!(
+            redact_url("https://user:secret@example.com/mcp"),
+            "https://example.com/mcp"
+        );
+    }
+
+    #[test]
+    fn redact_url_strips_query_but_keeps_path() {
+        assert_eq!(
+            redact_url("https://example.com/stream?token=abc123"),
+            "https://example.com/stream"
+        );
+    }
+
+    #[test]
+    fn redact_url_strips_both_userinfo_and_query() {
+        assert_eq!(
+            redact_url("https://user:pw@example.com/path?key=value"),
+            "https://example.com/path"
+        );
+    }
+
+    #[test]
+    fn redact_url_leaves_plain_url_untouched() {
+        assert_eq!(
+            redact_url("https://example.com/health"),
+            "https://example.com/health"
+        );
+    }
+
+    #[test]
+    fn redact_url_handles_url_without_scheme() {
+        assert_eq!(redact_url("example.com/path"), "example.com/path");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,31 +171,37 @@ enum Commands {
     },
 }
 
-fn main() -> Result<()> {
+fn main() {
+    if run().is_err() {
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
     // Initialize tracing subscriber for structured logging. Respects RUST_LOG env var.
     let cli = Cli::parse();
     agentsync::logging::init_logging(cli.log_format, cli.log_level);
     agentsync::update_check::spawn();
 
-    match cli.command {
+    let result = match cli.command {
         Commands::Skill { cmd, project_root } => run_in_root_span("skill", || {
             let root =
                 current_project_root(project_root, || env::current_dir().map_err(Into::into))?;
             run_skill(cmd, root)?;
             Ok(())
-        })?,
+        }),
         Commands::Status { args, project_root } => run_in_root_span("status", || {
             let project_root =
                 current_project_root(project_root, || env::current_dir().map_err(Into::into))?;
             run_status(args.json, project_root)?;
             Ok(())
-        })?,
+        }),
         Commands::Doctor { project_root } => run_in_root_span("doctor", || {
             let project_root =
                 current_project_root(project_root, || env::current_dir().map_err(Into::into))?;
             run_doctor(project_root)?;
             Ok(())
-        })?,
+        }),
         Commands::Init {
             path,
             force,
@@ -205,7 +211,7 @@ fn main() -> Result<()> {
         } => run_in_root_span("init", || {
             handle_init(path, force, wizard, experimental_tui, template)?;
             Ok(())
-        })?,
+        }),
         Commands::Apply {
             path,
             config,
@@ -225,7 +231,7 @@ fn main() -> Result<()> {
                 no_gitignore,
             })?;
             Ok(())
-        })?,
+        }),
         Commands::Clean {
             path,
             config,
@@ -234,7 +240,7 @@ fn main() -> Result<()> {
         } => run_in_root_span("clean", || {
             handle_clean(path, config, dry_run, verbose)?;
             Ok(())
-        })?,
+        }),
         Commands::DevInstall { skill_id, json } => run_in_root_span("skill", || {
             let project_root =
                 current_project_root(None, || env::current_dir().map_err(Into::into))?;
@@ -247,9 +253,12 @@ fn main() -> Result<()> {
             };
             run_install(args, project_root)?;
             Ok(())
-        })?,
+        }),
+    };
+    if let Err(error) = &result {
+        tracing::error!(error = %error, "Command failed");
     }
-    Ok(())
+    result
 }
 
 /// Run `f` inside a root span named `agentsync` that records `outcome`
@@ -319,7 +328,7 @@ fn handle_apply(args: ApplyArgs) -> Result<()> {
         None => Config::find_config(&start_dir)?,
     };
     if args.verbose {
-        tracing::info!(config_path = %config_path.display(), "Using config");
+        tracing::debug!(config_path = %config_path.display(), "Using config");
     }
     let config = Config::load(&config_path)?;
     let linker = Linker::new(config, config_path);
@@ -374,6 +383,12 @@ fn handle_apply(args: ApplyArgs) -> Result<()> {
         &result,
         use_color,
     ));
+    if result.errors > 0 {
+        return Err(anyhow::anyhow!(
+            "apply completed with {} error(s)",
+            result.errors
+        ));
+    }
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,9 @@ use colored::Colorize;
 use std::env;
 use std::path::PathBuf;
 
+use agentsync::logging::LogFormat;
 use agentsync::{Linker, SyncOptions, SyncResult, config::Config, gitignore, init};
+use tracing_subscriber::filter::LevelFilter;
 mod commands;
 mod output;
 use commands::doctor::run_doctor;
@@ -38,7 +40,7 @@ fn merge_clean_result_into_apply_result(result: &mut SyncResult, clean_result: &
     result.errors += clean_result.errors;
 }
 
-// tracing_subscriber is used to initialize logging in main
+// Logging is initialized in main via agentsync::logging::init_logging (stderr, human/json).
 
 #[derive(Parser)]
 #[command(name = "agentsync")]
@@ -51,6 +53,26 @@ fn merge_clean_result_into_apply_result(result: &mut SyncResult, clean_result: &
 struct Cli {
     #[command(subcommand)]
     command: Commands,
+
+    /// Log event format: human (default) or json (newline-delimited JSON to stderr)
+    #[arg(long, global = true, value_parser = parse_log_format, default_value = "human")]
+    log_format: LogFormat,
+
+    /// Minimum log level: trace, debug, info, warn, error, off (defaults to RUST_LOG or info)
+    #[arg(long, global = true, value_parser = parse_log_level)]
+    log_level: Option<LevelFilter>,
+}
+
+fn parse_log_format(s: &str) -> Result<LogFormat, String> {
+    s.parse()
+}
+
+fn parse_log_level(s: &str) -> Result<LevelFilter, String> {
+    s.parse().map_err(|_| {
+        format!(
+            "invalid log level '{s}' (expected 'trace', 'debug', 'info', 'warn', 'error', or 'off')"
+        )
+    })
 }
 
 #[derive(Subcommand)]
@@ -151,33 +173,39 @@ enum Commands {
 
 fn main() -> Result<()> {
     // Initialize tracing subscriber for structured logging. Respects RUST_LOG env var.
-    tracing_subscriber::fmt::init();
-    agentsync::update_check::spawn();
     let cli = Cli::parse();
+    agentsync::logging::init_logging(cli.log_format, cli.log_level);
+    agentsync::update_check::spawn();
 
     match cli.command {
-        Commands::Skill { cmd, project_root } => {
+        Commands::Skill { cmd, project_root } => run_in_root_span("skill", || {
             let root =
                 current_project_root(project_root, || env::current_dir().map_err(Into::into))?;
             run_skill(cmd, root)?;
-        }
-        Commands::Status { args, project_root } => {
+            Ok(())
+        })?,
+        Commands::Status { args, project_root } => run_in_root_span("status", || {
             let project_root =
                 current_project_root(project_root, || env::current_dir().map_err(Into::into))?;
             run_status(args.json, project_root)?;
-        }
-        Commands::Doctor { project_root } => {
+            Ok(())
+        })?,
+        Commands::Doctor { project_root } => run_in_root_span("doctor", || {
             let project_root =
                 current_project_root(project_root, || env::current_dir().map_err(Into::into))?;
             run_doctor(project_root)?;
-        }
+            Ok(())
+        })?,
         Commands::Init {
             path,
             force,
             wizard,
             experimental_tui,
             template,
-        } => handle_init(path, force, wizard, experimental_tui, template)?,
+        } => run_in_root_span("init", || {
+            handle_init(path, force, wizard, experimental_tui, template)?;
+            Ok(())
+        })?,
         Commands::Apply {
             path,
             config,
@@ -186,22 +214,28 @@ fn main() -> Result<()> {
             verbose,
             agents,
             no_gitignore,
-        } => handle_apply(ApplyArgs {
-            path,
-            config,
-            clean,
-            dry_run,
-            verbose,
-            agents,
-            no_gitignore,
+        } => run_in_root_span("apply", || {
+            handle_apply(ApplyArgs {
+                path,
+                config,
+                clean,
+                dry_run,
+                verbose,
+                agents,
+                no_gitignore,
+            })?;
+            Ok(())
         })?,
         Commands::Clean {
             path,
             config,
             dry_run,
             verbose,
-        } => handle_clean(path, config, dry_run, verbose)?,
-        Commands::DevInstall { skill_id, json } => {
+        } => run_in_root_span("clean", || {
+            handle_clean(path, config, dry_run, verbose)?;
+            Ok(())
+        })?,
+        Commands::DevInstall { skill_id, json } => run_in_root_span("skill", || {
             let project_root =
                 current_project_root(None, || env::current_dir().map_err(Into::into))?;
             use commands::skill::SkillInstallArgs;
@@ -212,9 +246,22 @@ fn main() -> Result<()> {
                 json,
             };
             run_install(args, project_root)?;
-        }
+            Ok(())
+        })?,
     }
     Ok(())
+}
+
+/// Run `f` inside a root span named `agentsync` that records `outcome`
+/// (ok/error) once it completes, so span-close JSON events expose the result.
+fn run_in_root_span<F>(operation: &'static str, f: F) -> Result<()>
+where
+    F: FnOnce() -> Result<()>,
+{
+    let span = tracing::info_span!("agentsync", operation, outcome = tracing::field::Empty);
+    let result = span.in_scope(f);
+    span.record("outcome", if result.is_ok() { "ok" } else { "error" });
+    result
 }
 
 fn handle_init(
@@ -272,10 +319,7 @@ fn handle_apply(args: ApplyArgs) -> Result<()> {
         None => Config::find_config(&start_dir)?,
     };
     if args.verbose {
-        println!(
-            "Using config: {}\n",
-            config_path.display().to_string().dimmed()
-        );
+        tracing::info!(config_path = %config_path.display(), "Using config");
     }
     let config = Config::load(&config_path)?;
     let linker = Linker::new(config, config_path);
@@ -378,7 +422,11 @@ fn handle_apply_mcp(
             }
         }
         Err(e) => {
-            tracing::error!(%e, "Error syncing MCP configs");
+            tracing::error!(
+                config_path = %linker.config_path().display(),
+                error = %e,
+                "Error syncing MCP configs"
+            );
             result.errors += 1;
         }
     }
@@ -420,7 +468,7 @@ fn handle_clean(
 
 #[cfg(test)]
 mod tests {
-    use super::{Cli, Commands, current_project_root};
+    use super::{Cli, Commands, LogFormat, current_project_root};
     use crate::output::{
         init_next_steps_lines, render_apply_summary_with_color, render_clean_phase_with_color,
         render_clean_summary_with_color, render_gitignore_phase_with_color,
@@ -428,6 +476,7 @@ mod tests {
     };
     use agentsync::{SyncResult, mcp::McpSyncResult};
     use clap::Parser;
+    use tracing_subscriber::filter::LevelFilter;
 
     fn render_apply_summary(dry_run: bool, result: &SyncResult) -> Vec<String> {
         render_apply_summary_with_color(dry_run, result, false)
@@ -665,5 +714,45 @@ mod tests {
         let rendered = standard.join("\n");
         assert!(rendered.contains("Edit .agents/AGENTS.md"));
         assert!(rendered.contains("Run agentsync apply"));
+    }
+
+    #[test]
+    fn cli_log_format_parses_json_after_subcommand() {
+        let cli = Cli::try_parse_from(["agentsync", "apply", "--log-format", "json"])
+            .expect("global --log-format should parse after the subcommand");
+        assert_eq!(cli.log_format, LogFormat::Json);
+    }
+
+    #[test]
+    fn cli_log_format_parses_json_before_subcommand() {
+        let cli = Cli::try_parse_from(["agentsync", "--log-format", "json", "status"])
+            .expect("global --log-format should parse before the subcommand");
+        assert_eq!(cli.log_format, LogFormat::Json);
+    }
+
+    #[test]
+    fn cli_log_format_defaults_to_human() {
+        let cli = Cli::try_parse_from(["agentsync", "status"])
+            .expect("status should parse without --log-format");
+        assert_eq!(cli.log_format, LogFormat::Human);
+    }
+
+    #[test]
+    fn cli_log_level_parses() {
+        let cli = Cli::try_parse_from(["agentsync", "apply", "--log-level", "debug"])
+            .expect("--log-level debug should parse");
+        assert_eq!(cli.log_level, Some(LevelFilter::DEBUG));
+    }
+
+    #[test]
+    fn cli_log_level_defaults_to_none() {
+        let cli = Cli::try_parse_from(["agentsync", "status"])
+            .expect("status should parse without --log-level");
+        assert_eq!(cli.log_level, None);
+    }
+
+    #[test]
+    fn cli_rejects_invalid_log_format() {
+        assert!(Cli::try_parse_from(["agentsync", "status", "--log-format", "xml"]).is_err());
     }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1495,11 +1495,19 @@ impl McpGenerator {
         }
 
         for agent in enabled_agents {
+            let span = tracing::info_span!(
+                "agentsync",
+                operation = "mcp",
+                agent_id = %agent.id(),
+                outcome = tracing::field::Empty
+            );
+            let _enter = span.enter();
+
             let path = match agent.resolved_config_path(project_root) {
                 Some(p) => p,
                 None => continue,
             };
-            if !handled_paths.insert(path) {
+            if !handled_paths.insert(path.clone()) {
                 continue;
             }
 
@@ -1513,9 +1521,25 @@ impl McpGenerator {
                     total_result.created += result.created;
                     total_result.updated += result.updated;
                     total_result.skipped += result.skipped;
+                    let outcome = if result.errors > 0 {
+                        "error"
+                    } else if result.created > 0 {
+                        "created"
+                    } else if result.updated > 0 {
+                        "updated"
+                    } else {
+                        "skipped"
+                    };
+                    span.record("outcome", outcome);
                 }
                 Err(e) => {
-                    tracing::error!(agent = %agent.name(), error = %e, "Error generating agent config");
+                    tracing::error!(
+                        agent = %agent.name(),
+                        config_path = %path.display(),
+                        error = %e,
+                        "Error generating agent config"
+                    );
+                    span.record("outcome", "error");
                     total_result.errors += 1;
                 }
             }

--- a/src/skills/provider.rs
+++ b/src/skills/provider.rs
@@ -366,6 +366,7 @@ impl Provider for SkillsShProvider {
         // Deterministic subprocess hook for the CLI contract test that verifies
         // catalog fallback warnings stay on stderr. It is inert unless explicitly
         // enabled by a test environment.
+        #[cfg(debug_assertions)]
         if std::env::var_os("AGENTSYNC_TEST_INVALID_RECOMMENDATION_CATALOG").is_some() {
             anyhow::bail!("invalid recommendation catalog test fixture")
         }

--- a/src/skills/provider.rs
+++ b/src/skills/provider.rs
@@ -361,6 +361,16 @@ impl Provider for SkillsShProvider {
         // Fallback: use skills.sh search API for simple IDs (e.g., "rust-async-patterns")
         self.resolve_via_search(id)
     }
+
+    fn recommendation_catalog(&self) -> Result<Option<ProviderCatalogMetadata>> {
+        // Deterministic subprocess hook for the CLI contract test that verifies
+        // catalog fallback warnings stay on stderr. It is inert unless explicitly
+        // enabled by a test environment.
+        if std::env::var_os("AGENTSYNC_TEST_INVALID_RECOMMENDATION_CATALOG").is_some() {
+            anyhow::bail!("invalid recommendation catalog test fixture")
+        }
+        Ok(None)
+    }
 }
 
 #[cfg(test)]

--- a/src/update_check.rs
+++ b/src/update_check.rs
@@ -3,10 +3,10 @@ use std::path::PathBuf;
 use std::thread;
 
 use anyhow::Context;
-use colored::Colorize;
 use is_terminal::IsTerminal;
 use semver::Version;
 use serde::{Deserialize, Serialize};
+use tracing::info;
 
 const CACHE_TTL_SECS: i64 = 24 * 60 * 60;
 const CRATES_IO_URL: &str = "https://crates.io/api/v1/crates/agentsync";
@@ -134,16 +134,10 @@ fn check_and_notify() {
         notified_for_version: Some(newest_version.clone()),
     };
 
-    eprintln!(
-        "{} {}",
-        "💡".yellow().bold(),
-        format!(
-            "A new version of agentsync is available: {} (you have {}). Run cargo install agentsync to update.",
-            newest_version.yellow().bold(),
-            env!("CARGO_PKG_VERSION").dimmed()
-        )
-        .yellow()
-        .bold()
+    info!(
+        latest_version = %newest_version,
+        current_version = env!("CARGO_PKG_VERSION"),
+        "A new version of agentsync is available; run cargo install agentsync to update"
     );
 
     let _ = cache.save(&new_cache);

--- a/tests/contracts/test_skill_suggest_output.rs
+++ b/tests/contracts/test_skill_suggest_output.rs
@@ -53,6 +53,35 @@ fn skill_suggest_json_contract_includes_required_fields() {
 }
 
 #[test]
+fn skill_suggest_json_keeps_diagnostics_out_of_stdout() {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+
+    fs::write(root.join("Cargo.toml"), "[package]\nname='demo'\n").unwrap();
+
+    let output = Command::new(agentsync_bin())
+        .current_dir(root)
+        .args(["skill", "suggest", "--json", "--log-format", "json"])
+        .output()
+        .expect("failed to run agentsync skill suggest --json");
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let _: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .expect("functional skill suggest JSON must remain the only stdout document");
+    for line in String::from_utf8_lossy(&output.stderr).lines() {
+        assert!(
+            serde_json::from_str::<serde_json::Value>(line).is_ok(),
+            "JSON log format must emit one JSON event per stderr line: {line}"
+        );
+    }
+}
+
+#[test]
 fn skill_suggest_json_contract_is_well_formed_when_empty() {
     let temp_dir = TempDir::new().unwrap();
 

--- a/tests/test_logging.rs
+++ b/tests/test_logging.rs
@@ -1,3 +1,4 @@
+#![cfg(unix)]
 //! Black-box tests for structured diagnostics (#499).
 //!
 //! Core contract: log events ALWAYS go to stderr; functional stdout (human
@@ -9,12 +10,10 @@ use std::process::{Command, Output};
 
 use tempfile::TempDir;
 
-#[cfg(unix)]
 fn agentsync_bin() -> &'static str {
     env!("CARGO_BIN_EXE_agentsync")
 }
 
-#[cfg(unix)]
 fn run_agentsync(project_root: &Path, args: &[&str]) -> Output {
     Command::new(agentsync_bin())
         .current_dir(project_root)
@@ -117,7 +116,6 @@ fn has_field_with_suffix(event: &serde_json::Value, key: &str, suffix: &str) -> 
 }
 
 #[test]
-#[cfg(unix)]
 fn apply_default_logs_are_human_and_never_on_stdout() {
     let temp_dir = TempDir::new().unwrap();
     let project_root = temp_dir.path();
@@ -535,9 +533,8 @@ fn apply_json_failed_target_emits_error_outcome_with_context() {
 
     let output = run_agentsync(root, &["apply", "--log-format", "json"]);
     assert!(
-        output.status.success(),
-        "apply should report target errors in its summary: {}",
-        String::from_utf8_lossy(&output.stderr)
+        !output.status.success(),
+        "apply target errors must exit nonzero"
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     let events = json_events(&stderr);
@@ -580,7 +577,7 @@ fn apply_json_mcp_failure_emits_agent_and_config_path() {
     let output = run_agentsync(root, &["apply", "--log-format", "json"]);
     assert!(
         output.status.success(),
-        "apply should preserve its existing summary behavior: {}",
+        "MCP generation preserves apply summary behavior: {}",
         String::from_utf8_lossy(&output.stderr)
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -597,6 +594,94 @@ fn apply_json_mcp_failure_emits_agent_and_config_path() {
             has_field(event, "operation", "mcp") && has_field(event, "outcome", "error")
         }),
         "MCP error outcome missing: {stderr}"
+    );
+}
+
+#[test]
+fn apply_json_failure_exits_nonzero_and_keeps_error_protocol_on_stderr() {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+    let agents_dir = root.join(".agents");
+    fs::create_dir_all(&agents_dir).unwrap();
+    fs::write(agents_dir.join("AGENTS.md"), "# instructions\n").unwrap();
+    fs::write(
+        agents_dir.join("agentsync.toml"),
+        r#"
+        [agents.claude]
+        enabled = true
+        [agents.claude.targets.instructions]
+        source = "AGENTS.md"
+        destination = "/outside/CLAUDE.md"
+        type = "symlink"
+    "#,
+    )
+    .unwrap();
+
+    let output = run_agentsync(root, &["apply", "--log-format", "json"]);
+    assert!(!output.status.success(), "failed apply must exit nonzero");
+    assert_stdout_has_no_tracing(&String::from_utf8_lossy(&output.stdout));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let events = json_events(&stderr);
+    assert!(!events.is_empty(), "expected JSON error events: {stderr}");
+    assert!(
+        events.iter().any(|event| {
+            has_field(event, "operation", "apply") && has_field(event, "outcome", "error")
+        }),
+        "root apply error span missing: {stderr}"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| has_field(event, "outcome", "error")),
+        "target error event missing: {stderr}"
+    );
+    assert!(
+        stderr
+            .lines()
+            .all(|line| serde_json::from_str::<serde_json::Value>(line).is_ok()),
+        "stderr must contain only JSON events: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Error: "),
+        "plaintext top-level error leaked: {stderr}"
+    );
+}
+
+#[test]
+fn status_json_failure_exits_nonzero_with_parseable_stdout_and_json_diagnostics() {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+    write_apply_fixture(root);
+
+    let output = run_agentsync(root, &["status", "--log-format", "json", "--json"]);
+    assert!(!output.status.success(), "drifted status must exit nonzero");
+    let entries: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("status --json stdout must remain parseable");
+    assert!(
+        entries.as_array().is_some(),
+        "status output must be an array"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let events = json_events(&stderr);
+    assert!(
+        !events.is_empty(),
+        "expected JSON status diagnostics: {stderr}"
+    );
+    assert!(
+        events.iter().any(|event| {
+            has_field(event, "operation", "status") && has_field(event, "outcome", "error")
+        }),
+        "root status error span missing: {stderr}"
+    );
+    assert!(
+        stderr
+            .lines()
+            .all(|line| serde_json::from_str::<serde_json::Value>(line).is_ok()),
+        "stderr must contain only JSON events: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Error: "),
+        "plaintext top-level error leaked: {stderr}"
     );
 }
 

--- a/tests/test_logging.rs
+++ b/tests/test_logging.rs
@@ -1,0 +1,669 @@
+//! Black-box tests for structured diagnostics (#499).
+//!
+//! Core contract: log events ALWAYS go to stderr; functional stdout (human
+//! output and the `--json` contracts) is never polluted by tracing lines.
+
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use tempfile::TempDir;
+
+#[cfg(unix)]
+fn agentsync_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_agentsync")
+}
+
+#[cfg(unix)]
+fn run_agentsync(project_root: &Path, args: &[&str]) -> Output {
+    Command::new(agentsync_bin())
+        .current_dir(project_root)
+        .args(args)
+        .output()
+        .unwrap_or_else(|error| panic!("failed to run agentsync {:?}: {error}", args))
+}
+
+/// Write a minimal `.agents` fixture that `apply` can sync without network access.
+fn write_apply_fixture(root: &Path) {
+    let agents_dir = root.join(".agents");
+    fs::create_dir_all(&agents_dir).unwrap();
+    fs::write(agents_dir.join("AGENTS.md"), "# Agent instructions\n").unwrap();
+    fs::write(
+        agents_dir.join("agentsync.toml"),
+        r#"
+        [agents.claude]
+        enabled = true
+        [agents.claude.targets.instructions]
+        source = "AGENTS.md"
+        destination = "CLAUDE.md"
+        type = "symlink"
+    "#,
+    )
+    .unwrap();
+}
+
+/// Assert that `stdout` contains no tracing output: no ANSI escapes, no level
+/// markers, and no leading ISO timestamps.
+fn assert_stdout_has_no_tracing(stdout: &str) {
+    for line in stdout.lines() {
+        assert!(
+            !line.contains("\u{1b}["),
+            "stdout line contains a tracing ANSI escape: {line:?}"
+        );
+        for marker in [" INFO ", " WARN ", " ERROR ", " DEBUG ", " TRACE "] {
+            assert!(
+                !line.contains(marker),
+                "stdout line contains a tracing level marker: {line:?}"
+            );
+        }
+        let bytes = line.as_bytes();
+        let timestamp_headed =
+            bytes.len() >= 5 && bytes[..4].iter().all(u8::is_ascii_digit) && bytes[4] == b'-';
+        assert!(
+            !timestamp_headed,
+            "stdout line starts with a tracing timestamp: {line:?}"
+        );
+    }
+}
+
+/// Parse newline-delimited JSON log events from stderr.
+fn json_events(stderr: &str) -> Vec<serde_json::Value> {
+    stderr
+        .lines()
+        .filter(|line| line.starts_with('{'))
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .collect()
+}
+
+/// Collect every (key, value) pair from the `fields` object of an event and
+/// from the span objects (`span`/`spans`). Robust to how tracing-subscriber
+/// distributes span fields: nested under `span.fields` or flat on the span
+/// object (name/operation/outcome) depending on format version.
+fn span_field_pairs(event: &serde_json::Value) -> Vec<(String, serde_json::Value)> {
+    let mut pairs = Vec::new();
+    let mut collect = |obj: Option<&serde_json::Map<String, serde_json::Value>>| {
+        if let Some(fields) = obj {
+            for (key, value) in fields {
+                pairs.push((key.clone(), value.clone()));
+            }
+        }
+    };
+    collect(event.get("fields").and_then(serde_json::Value::as_object));
+    if let Some(span) = event.get("span").and_then(serde_json::Value::as_object) {
+        collect(span.get("fields").and_then(serde_json::Value::as_object));
+        collect(Some(span));
+    }
+    if let Some(spans) = event.get("spans").and_then(serde_json::Value::as_array) {
+        for span in spans {
+            let span = span.as_object().expect("span list entries are objects");
+            collect(span.get("fields").and_then(serde_json::Value::as_object));
+            collect(Some(span));
+        }
+    }
+    pairs
+}
+
+fn has_field(event: &serde_json::Value, key: &str, value: &str) -> bool {
+    span_field_pairs(event).contains(&(
+        key.to_string(),
+        serde_json::Value::String(value.to_string()),
+    ))
+}
+
+fn has_field_with_suffix(event: &serde_json::Value, key: &str, suffix: &str) -> bool {
+    span_field_pairs(event).iter().any(|(field, value)| {
+        field == key && value.as_str().is_some_and(|value| value.ends_with(suffix))
+    })
+}
+
+#[test]
+#[cfg(unix)]
+fn apply_default_logs_are_human_and_never_on_stdout() {
+    let temp_dir = TempDir::new().unwrap();
+    let project_root = temp_dir.path();
+    write_apply_fixture(project_root);
+
+    let output = run_agentsync(project_root, &["apply"]);
+    assert!(
+        output.status.success(),
+        "apply failed: status={:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // Functional stdout is intact (the latent #499 bug would mix tracing into it).
+    assert!(stdout.contains("Sync"), "stdout: {stdout}");
+    assert!(stdout.contains("claude"), "stdout: {stdout}");
+    assert_stdout_has_no_tracing(&stdout);
+
+    // stderr carries no functional output; a clean apply emits no events in
+    // the default human mode, so stderr stays empty.
+    assert!(
+        !stderr.contains("Sync"),
+        "functional text leaked to stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("claude"),
+        "functional text leaked to stderr: {stderr}"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn warn_event_routes_to_stderr_not_stdout_and_stays_plain_when_piped() {
+    let temp_dir = TempDir::new().unwrap();
+    let project_root = temp_dir.path();
+
+    // An invalid user config template at $XDG_CONFIG_HOME makes `init` emit a
+    // tracing WARN while still completing successfully.
+    let xdg_home = project_root.join("xdg");
+    let xdg_agentsync = xdg_home.join("agentsync");
+    fs::create_dir_all(&xdg_agentsync).unwrap();
+    fs::write(xdg_agentsync.join("config.toml"), "not = [valid toml").unwrap();
+
+    let output = Command::new(agentsync_bin())
+        .current_dir(project_root)
+        .env("XDG_CONFIG_HOME", &xdg_home)
+        .args(["init"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "init failed: status={:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // The WARN event is human-readable on stderr...
+    assert!(
+        stderr.contains("User config template is invalid TOML"),
+        "WARN missing from stderr: {stderr}"
+    );
+    // ...with no ANSI escapes when stderr is piped (spec scenario)...
+    assert!(
+        !stderr.contains("\u{1b}["),
+        "piped stderr must not contain ANSI escapes: {stderr:?}"
+    );
+    // ...and never leaks to stdout.
+    assert_stdout_has_no_tracing(&stdout);
+    assert!(
+        !stdout.contains("User config template is invalid TOML"),
+        "WARN leaked to stdout: {stdout}"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn apply_json_emits_root_span_with_operation() {
+    let temp_dir = TempDir::new().unwrap();
+    let project_root = temp_dir.path();
+    write_apply_fixture(project_root);
+
+    let output = run_agentsync(project_root, &["--log-format", "json", "apply"]);
+    assert!(
+        output.status.success(),
+        "apply failed: status={:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // JSON events are on stderr, never on stdout.
+    assert!(
+        !stdout.lines().any(|line| line.starts_with('{')),
+        "JSON log events leaked to stdout: {stdout}"
+    );
+    let events = json_events(&stderr);
+    assert!(
+        !events.is_empty(),
+        "no JSON log events on stderr for --log-format json: {stderr}"
+    );
+
+    // The root span for the subcommand carries operation=apply.
+    let has_root_span = events
+        .iter()
+        .any(|event| has_field(event, "operation", "apply"));
+    assert!(
+        has_root_span,
+        "no event carries a root span with operation=apply: {stderr}"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn apply_json_emits_agent_and_target_spans() {
+    let temp_dir = TempDir::new().unwrap();
+    let project_root = temp_dir.path();
+    write_apply_fixture(project_root);
+
+    let output = run_agentsync(project_root, &["apply", "--log-format", "json"]);
+    assert!(
+        output.status.success(),
+        "apply failed: status={:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let events = json_events(&stderr);
+    assert!(
+        events.len() >= 2,
+        "expected span-close events for agent and target: {stderr}"
+    );
+
+    // The per-agent span carries agent_id, the per-target span carries
+    // target and the configured destination path.
+    let has_agent_id = events
+        .iter()
+        .any(|event| has_field(event, "agent_id", "claude"));
+    assert!(has_agent_id, "no span carries agent_id=claude: {stderr}");
+    let has_target = events
+        .iter()
+        .any(|event| has_field(event, "target", "instructions"));
+    assert!(has_target, "no span carries target=instructions: {stderr}");
+    let has_path = events
+        .iter()
+        .any(|event| has_field(event, "path", "CLAUDE.md"));
+    assert!(has_path, "no span carries path=CLAUDE.md: {stderr}");
+
+    // A freshly-created symlink closes the target span with outcome=created.
+    let has_created_outcome = events
+        .iter()
+        .any(|event| has_field(event, "outcome", "created"));
+    assert!(
+        has_created_outcome,
+        "no span carries outcome=created: {stderr}"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn apply_json_mcp_span_never_leaks_env_headers_or_url() {
+    let temp_dir = TempDir::new().unwrap();
+    let project_root = temp_dir.path();
+
+    // MCP fixture with a remote server carrying a credential-style header, a
+    // server env map with a token, and a URL with userinfo + query — nothing
+    // may appear in log events.
+    let agents_dir = project_root.join(".agents");
+    fs::create_dir_all(&agents_dir).unwrap();
+    fs::write(agents_dir.join("AGENTS.md"), "# Agent instructions\n").unwrap();
+    fs::write(
+        agents_dir.join("agentsync.toml"),
+        r#"
+        [mcp]
+        enabled = true
+
+        [mcp_servers.remote]
+        url = "https://user:pass@example.com/mcp-stream?token=abc123"
+        type = "sse"
+        headers = { Authorization = "Bearer leak-check-token-42" }
+
+        [mcp_servers.filesystem]
+        command = "npx"
+        args = ["-y", "@modelcontextprotocol/server-filesystem", "."]
+        env = { API_TOKEN = "leak-check-token-42" }
+
+        [agents.claude]
+        enabled = true
+        [agents.claude.targets.instructions]
+        source = "AGENTS.md"
+        destination = "CLAUDE.md"
+        type = "symlink"
+    "#,
+    )
+    .unwrap();
+
+    let output = run_agentsync(project_root, &["apply", "--log-format", "json"]);
+    assert!(
+        output.status.success(),
+        "apply failed: status={:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let events = json_events(&stderr);
+    assert!(!events.is_empty(), "no JSON log events on stderr: {stderr}");
+
+    // The per-agent MCP generation emits a span with operation=mcp.
+    let has_mcp_span = events
+        .iter()
+        .any(|event| has_field(event, "operation", "mcp"));
+    assert!(has_mcp_span, "no span carries operation=mcp: {stderr}");
+
+    // env / headers values, Authorization headers, and URL userinfo+query are
+    // never emitted in log events.
+    for secret in [
+        "leak-check-token-42",
+        "Bearer ",
+        "user:pass",
+        "token=abc123",
+    ] {
+        assert!(
+            !stderr.contains(secret),
+            "secret leaked into stderr: {secret:?}\n{stderr}"
+        );
+    }
+}
+
+#[test]
+#[cfg(unix)]
+fn skill_install_json_emits_span_with_skill_id() {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+
+    // Offline local-dir skill install via --source.
+    let source_root = root.join("skill-sources");
+    fs::create_dir_all(source_root.join("test-skill")).unwrap();
+    fs::write(
+        source_root.join("test-skill").join("SKILL.md"),
+        "---\nname: test-skill\nversion: 1.0.0\n---\n# Test Skill\n",
+    )
+    .unwrap();
+
+    let output = Command::new(agentsync_bin())
+        .current_dir(root)
+        .args([
+            "skill",
+            "install",
+            "test-skill",
+            "--source",
+            source_root.join("test-skill").to_str().unwrap(),
+            "--json",
+            "--log-format",
+            "json",
+        ])
+        .output()
+        .unwrap_or_else(|error| panic!("failed to run agentsync skill install: {error}"));
+
+    assert!(
+        output.status.success(),
+        "skill install failed: status={:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let events = json_events(&stderr);
+    assert!(!events.is_empty(), "no JSON log events on stderr: {stderr}");
+
+    // The install emits a span with operation=skill_install and skill_id.
+    let has_install_span = events
+        .iter()
+        .any(|event| has_field(event, "operation", "skill_install"));
+    assert!(
+        has_install_span,
+        "no span carries operation=skill_install: {stderr}"
+    );
+    let has_skill_id = events
+        .iter()
+        .any(|event| has_field(event, "skill_id", "test-skill"));
+    assert!(
+        has_skill_id,
+        "no span carries skill_id=test-skill: {stderr}"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn apply_debug_level_shows_skips_on_stderr() {
+    let temp_dir = TempDir::new().unwrap();
+    let project_root = temp_dir.path();
+
+    // Two enabled agents; copilot is filtered out via --agents claude.
+    let agents_dir = project_root.join(".agents");
+    fs::create_dir_all(&agents_dir).unwrap();
+    fs::write(agents_dir.join("AGENTS.md"), "# Agent instructions\n").unwrap();
+    fs::write(
+        agents_dir.join("agentsync.toml"),
+        r#"
+        [agents.claude]
+        enabled = true
+        [agents.claude.targets.instructions]
+        source = "AGENTS.md"
+        destination = "CLAUDE.md"
+        type = "symlink"
+        [agents.copilot]
+        enabled = true
+        [agents.copilot.targets.instructions]
+        source = "AGENTS.md"
+        destination = ".github/copilot-instructions.md"
+        type = "symlink"
+    "#,
+    )
+    .unwrap();
+
+    let output = run_agentsync(
+        project_root,
+        &["apply", "--agents", "claude", "--log-level", "debug"],
+    );
+    assert!(
+        output.status.success(),
+        "apply failed: status={:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // The skip diagnostic moved off functional stdout...
+    assert!(
+        !stdout.contains("Skipping"),
+        "skip diagnostic still on stdout: {stdout}"
+    );
+    // ...and is visible on stderr at debug level, naming the skipped agent.
+    assert!(
+        stderr.contains("Skipping"),
+        "skip diagnostic not visible on stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("copilot"),
+        "skip diagnostic should name the skipped agent: {stderr}"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn clean_json_emits_removed_span_with_operation_and_path() {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+    write_apply_fixture(root);
+
+    let apply = run_agentsync(root, &["apply"]);
+    assert!(
+        apply.status.success(),
+        "apply failed: {}",
+        String::from_utf8_lossy(&apply.stderr)
+    );
+
+    let output = run_agentsync(root, &["clean", "--log-format", "json"]);
+    assert!(
+        output.status.success(),
+        "clean failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let events = json_events(&stderr);
+    assert!(
+        events.iter().any(|event| {
+            has_field(event, "operation", "remove")
+                && has_field_with_suffix(event, "path", "CLAUDE.md")
+                && has_field(event, "outcome", "removed")
+        }),
+        "removed clean span missing: {stderr}"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn apply_json_failed_target_emits_error_outcome_with_context() {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+    let agents_dir = root.join(".agents");
+    fs::create_dir_all(&agents_dir).unwrap();
+    fs::write(agents_dir.join("AGENTS.md"), "# instructions\n").unwrap();
+    fs::write(
+        agents_dir.join("agentsync.toml"),
+        r#"
+        [agents.claude]
+        enabled = true
+        [agents.claude.targets.instructions]
+        source = "AGENTS.md"
+        destination = "/outside/CLAUDE.md"
+        type = "symlink"
+    "#,
+    )
+    .unwrap();
+
+    let output = run_agentsync(root, &["apply", "--log-format", "json"]);
+    assert!(
+        output.status.success(),
+        "apply should report target errors in its summary: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let events = json_events(&stderr);
+    assert!(
+        events.iter().any(|event| {
+            has_field(event, "agent_id", "claude")
+                && has_field(event, "path", "/outside/CLAUDE.md")
+                && has_field(event, "outcome", "error")
+        }),
+        "failed target context/outcome missing: {stderr}"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn apply_json_mcp_failure_emits_agent_and_config_path() {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+    let agents_dir = root.join(".agents");
+    fs::create_dir_all(&agents_dir).unwrap();
+    fs::write(agents_dir.join("AGENTS.md"), "# instructions\n").unwrap();
+    fs::write(root.join(".mcp.json"), "not valid json").unwrap();
+    fs::write(
+        agents_dir.join("agentsync.toml"),
+        r#"
+        [mcp]
+        enabled = true
+        [mcp_servers.test]
+        command = "test-server"
+        [agents.claude]
+        enabled = true
+        [agents.claude.targets.instructions]
+        source = "AGENTS.md"
+        destination = "CLAUDE.md"
+        type = "symlink"
+    "#,
+    )
+    .unwrap();
+
+    let output = run_agentsync(root, &["apply", "--log-format", "json"]);
+    assert!(
+        output.status.success(),
+        "apply should preserve its existing summary behavior: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let events = json_events(&stderr);
+    assert!(
+        events.iter().any(|event| {
+            has_field(event, "agent", "Claude Code")
+                && has_field_with_suffix(event, "config_path", ".mcp.json")
+        }),
+        "MCP failure context missing: {stderr}"
+    );
+    assert!(
+        events.iter().any(|event| {
+            has_field(event, "operation", "mcp") && has_field(event, "outcome", "error")
+        }),
+        "MCP error outcome missing: {stderr}"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn skill_suggest_json_warn_stays_on_stderr_and_stdout_remains_parseable() {
+    let temp_dir = TempDir::new().unwrap();
+    let output = Command::new(agentsync_bin())
+        .current_dir(temp_dir.path())
+        .env("AGENTSYNC_TEST_INVALID_RECOMMENDATION_CATALOG", "1")
+        .args(["skill", "suggest", "--json"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "suggest failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let _: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .expect("skill suggest functional JSON must remain parseable");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Falling back to embedded recommendation catalog"),
+        "expected real fallback WARN: {stderr}"
+    );
+    assert!(!String::from_utf8_lossy(&output.stdout).contains("Falling back"));
+}
+
+#[test]
+#[cfg(unix)]
+fn rust_log_debug_emits_debug_and_log_level_warn_overrides_it() {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+    write_apply_fixture(root);
+
+    let debug = Command::new(agentsync_bin())
+        .current_dir(root)
+        .env("RUST_LOG", "debug")
+        .args(["apply", "--agents", "other", "--log-format", "json"])
+        .output()
+        .unwrap();
+    let debug_stderr = String::from_utf8_lossy(&debug.stderr);
+    assert!(
+        debug_stderr
+            .lines()
+            .any(|line| line.contains("Skipping agent")),
+        "RUST_LOG=debug did not emit debug event: {debug_stderr}"
+    );
+
+    let warn = Command::new(agentsync_bin())
+        .current_dir(root)
+        .env("RUST_LOG", "debug")
+        .args([
+            "apply",
+            "--agents",
+            "other",
+            "--log-level",
+            "warn",
+            "--log-format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    let warn_stderr = String::from_utf8_lossy(&warn.stderr);
+    assert!(
+        !warn_stderr.contains("Skipping agent"),
+        "--log-level warn did not override RUST_LOG=debug: {warn_stderr}"
+    );
+}

--- a/tests/test_module_map_cli.rs
+++ b/tests/test_module_map_cli.rs
@@ -123,20 +123,6 @@ fn test_module_map_cli_placeholder_happy_path() {
             .is_some_and(|source| source.ends_with(".agents/claude/api-context.md"))
     }));
 
-    let status_with_json_logs =
-        run_agentsync(project_root, &["status", "--log-format", "json", "--json"]);
-    assert_success(
-        &status_with_json_logs,
-        "agentsync status --log-format json --json",
-    );
-    let _: serde_json::Value = serde_json::from_slice(&status_with_json_logs.stdout)
-        .expect("status --json stdout must remain a JSON array");
-    for line in String::from_utf8_lossy(&status_with_json_logs.stderr).lines() {
-        assert!(
-            serde_json::from_str::<serde_json::Value>(line).is_ok(),
-            "status JSON logs must be line-parseable: {line}"
-        );
-    }
     assert!(entries.iter().any(|entry| {
         entry["expected_source"]
             .as_str()
@@ -163,4 +149,30 @@ fn test_module_map_cli_placeholder_happy_path() {
     );
     let clean_stdout = String::from_utf8_lossy(&clean.stdout);
     assert!(clean_stdout.contains("Removed: 2"), "{clean_stdout}");
+}
+
+#[test]
+#[cfg(unix)]
+fn test_module_map_status_json_logging_contract() {
+    let temp_dir = TempDir::new().unwrap();
+    let project_root = temp_dir.path();
+    write_module_map_fixture(project_root);
+
+    let apply = run_agentsync(project_root, &["apply"]);
+    assert_success(&apply, "agentsync apply");
+
+    let status_with_json_logs =
+        run_agentsync(project_root, &["status", "--log-format", "json", "--json"]);
+    assert_success(
+        &status_with_json_logs,
+        "agentsync status --log-format json --json",
+    );
+    let _: serde_json::Value = serde_json::from_slice(&status_with_json_logs.stdout)
+        .expect("status --json stdout must remain a JSON array");
+    for line in String::from_utf8_lossy(&status_with_json_logs.stderr).lines() {
+        assert!(
+            serde_json::from_str::<serde_json::Value>(line).is_ok(),
+            "status JSON logs must be line-parseable: {line}"
+        );
+    }
 }

--- a/tests/test_module_map_cli.rs
+++ b/tests/test_module_map_cli.rs
@@ -167,8 +167,9 @@ fn test_module_map_status_json_logging_contract() {
         &status_with_json_logs,
         "agentsync status --log-format json --json",
     );
-    let _: serde_json::Value = serde_json::from_slice(&status_with_json_logs.stdout)
+    let status: serde_json::Value = serde_json::from_slice(&status_with_json_logs.stdout)
         .expect("status --json stdout must remain a JSON array");
+    assert!(status.is_array(), "status --json stdout must be a JSON array");
     for line in String::from_utf8_lossy(&status_with_json_logs.stderr).lines() {
         assert!(
             serde_json::from_str::<serde_json::Value>(line).is_ok(),

--- a/tests/test_module_map_cli.rs
+++ b/tests/test_module_map_cli.rs
@@ -122,6 +122,21 @@ fn test_module_map_cli_placeholder_happy_path() {
             .as_str()
             .is_some_and(|source| source.ends_with(".agents/claude/api-context.md"))
     }));
+
+    let status_with_json_logs =
+        run_agentsync(project_root, &["status", "--log-format", "json", "--json"]);
+    assert_success(
+        &status_with_json_logs,
+        "agentsync status --log-format json --json",
+    );
+    let _: serde_json::Value = serde_json::from_slice(&status_with_json_logs.stdout)
+        .expect("status --json stdout must remain a JSON array");
+    for line in String::from_utf8_lossy(&status_with_json_logs.stderr).lines() {
+        assert!(
+            serde_json::from_str::<serde_json::Value>(line).is_ok(),
+            "status JSON logs must be line-parseable: {line}"
+        );
+    }
     assert!(entries.iter().any(|entry| {
         entry["expected_source"]
             .as_str()

--- a/tests/test_module_map_cli.rs
+++ b/tests/test_module_map_cli.rs
@@ -169,7 +169,10 @@ fn test_module_map_status_json_logging_contract() {
     );
     let status: serde_json::Value = serde_json::from_slice(&status_with_json_logs.stdout)
         .expect("status --json stdout must remain a JSON array");
-    assert!(status.is_array(), "status --json stdout must be a JSON array");
+    assert!(
+        status.is_array(),
+        "status --json stdout must be a JSON array"
+    );
     for line in String::from_utf8_lossy(&status_with_json_logs.stderr).lines() {
         assert!(
             serde_json::from_str::<serde_json::Value>(line).is_ok(),

--- a/website/docs/src/content/docs/reference/cli.mdx
+++ b/website/docs/src/content/docs/reference/cli.mdx
@@ -17,7 +17,8 @@ functional `--json` output parseable in CI.
 - `--log-format human|json`: Render human-readable diagnostics (default) or one JSON event per
   stderr line.
 - `--log-level trace|debug|info|warn|error|off`: Set the minimum diagnostic level. This overrides
-  `RUST_LOG`; when omitted, `RUST_LOG` is used when it contains a single level, otherwise `info`.
+  `RUST_LOG`; when omitted, `RUST_LOG` supports target-aware EnvFilter directives and falls back to
+  `info` when invalid.
 
 The logging flags are independent from command-specific `--json`:
 

--- a/website/docs/src/content/docs/reference/cli.mdx
+++ b/website/docs/src/content/docs/reference/cli.mdx
@@ -7,6 +7,27 @@ import CommandTabs from '../../../components/CommandTabs.astro';
 
 `agentsync` provides a straightforward set of commands to manage your AI agent configurations.
 
+## Logging and diagnostics
+
+Diagnostic logs are always written to stderr, while command results remain on stdout. This keeps
+functional `--json` output parseable in CI.
+
+**Global options** (available before or after a subcommand):
+
+- `--log-format human|json`: Render human-readable diagnostics (default) or one JSON event per
+  stderr line.
+- `--log-level trace|debug|info|warn|error|off`: Set the minimum diagnostic level. This overrides
+  `RUST_LOG`; when omitted, `RUST_LOG` is used when it contains a single level, otherwise `info`.
+
+The logging flags are independent from command-specific `--json`:
+
+```bash
+agentsync status --log-format json --json >status.json 2>diagnostics.jsonl
+```
+
+The status array is written to `status.json`; structured diagnostic events are written to
+`diagnostics.jsonl`.
+
 If you run AgentSync from Windows and need symlink prerequisites, WSL setup positioning, or recovery help, use the <a href="/guides/windows-symlink-setup/">Windows Symlink Setup guide</a>. The command reference below stays focused on CLI behavior.
 
 ## Commands


### PR DESCRIPTION
## Summary
- add structured diagnostics with human and JSON log formats
- route tracing diagnostics to stderr while preserving functional stdout/JSON contracts
- instrument apply, clean, MCP, and skill operations with contextual spans and redacted values
- add runtime coverage and document `--log-format` / `--log-level`

## Validation
- `cargo test --all-features`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`

## Notes
- Verification result: PASS WITH WARNINGS; no critical findings.
- The repository owner approved the size exception for this single PR.
- Unrelated pre-existing skill files remain uncommitted and are not included.

Fixes #499
