### PR TITLE
Fix dependabot auto merge workflow secrets context error

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,5 +11,4 @@ jobs:
     with:
       target: squash
       approve: true
-    secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}
+    secrets: inherit


### PR DESCRIPTION
Changes the secrets block in the dependabot-auto-merge workflow from mapping `token` explicitly to `secrets: inherit`. This prevents the GitHub Actions workflow parser error when the called reusable workflow references optional secrets that were not explicitly passed by the caller.

Fixes #527

---
*PR created automatically by Jules for task [9854180672088434778](https://jules.google.com/task/9854180672088434778) started by @yacosta738*