### PR TITLE
perf(linker): scope path_cache invalidation to mutated paths (#498)

### DIFF
--- a/openspec/changes/2026-08-10-issue-498-linker-perf-benchmark/benchmark-baseline.md
+++ b/openspec/changes/2026-08-10-issue-498-linker-perf-benchmark/benchmark-baseline.md
@@ -60,9 +60,22 @@ nested-glob          5000     5000    855.969ms    844.723ms    114.416ms     19
 
 ## Before / After (Phase B commits — filled by units 2–5)
 
+B1 (unit 2, PR 2): scoped `path_cache` invalidation — `invalidate_path(path)` (exact key +
+descendants) replaces full clears after every symlink mutation; full clear kept at `sync()` start.
+`path_cache` moved to `BTreeMap` so prefix removal is a contiguous range scan (O(log n + m)) rather
+than a per-mutation full-map scan (the initial `HashMap::retain` implementation measured O(N²) at
+N=5000 and was reverted). After numbers = mean of two clean 5-run captures on the same machine
+(load avg ~8–11 during capture).
+
 | Opt | Cell | Before (baseline) | After | Delta |
 |---|---|---|---|---|
-| B1 path_cache invalidation | (pending) | | | |
+| B1 path_cache invalidation | flat N=4 (small gate) | warm 0.606 ms; canonicalize 0.104 ms | warm 0.541 ms; canonicalize 0.067 ms | −10.7% warm — within noise band, no regression |
+| B1 path_cache invalidation | flat N=100 | warm 13.492 ms; canonicalize 3.562 ms | warm 10.058 ms; canonicalize 1.500 ms | −25.5% warm; −57.9% canonicalize |
+| B1 path_cache invalidation | flat N=1000 | warm 126.419 ms; canonicalize 27.145 ms | warm 103.526 ms; canonicalize 18.034 ms | −18.1% warm; −33.6% canonicalize |
+| B1 path_cache invalidation | flat N=5000 | warm 625.598 ms; canonicalize 134.239 ms | warm 528.703 ms; canonicalize 92.900 ms | −15.5% warm; −30.8% canonicalize |
+| B1 path_cache invalidation | nested-glob N=100 | warm 21.967 ms; canonicalize 4.152 ms | warm 19.397 ms; canonicalize 3.046 ms | −11.7% warm; −26.6% canonicalize |
+| B1 path_cache invalidation | nested-glob N=1000 | warm 160.244 ms; canonicalize 37.807 ms | warm 134.435 ms; canonicalize 24.671 ms | −16.1% warm; −34.7% canonicalize |
+| B1 path_cache invalidation | nested-glob N=5000 | warm 844.723 ms; canonicalize 199.190 ms | warm 699.955 ms; canonicalize 125.038 ms | −17.1% warm; −37.2% canonicalize |
 | B2 single existence probe | (pending) | | | |
 | B3 DirEntry reuse | (pending) | | | |
 | B4 sorted iteration + final metrics | (pending) | | | |

--- a/openspec/changes/2026-08-10-issue-498-linker-perf-benchmark/benchmark-baseline.md
+++ b/openspec/changes/2026-08-10-issue-498-linker-perf-benchmark/benchmark-baseline.md
@@ -58,6 +58,16 @@ nested-glob          5000     5000    855.969ms    844.723ms    114.416ms     19
 - **Small-repo gate** (flat, N=4): warm 0.6 ms, cold 0.9 ms — comfortably inside the 3–5 ms no-regression band with margin.
 - **Biggest cost center**: link creation (incl. canonicalize) — 80–90% of total on the 5000 cells, consistent with per-link `source.exists()` probe + `relative_path` canonicalization. These are the Phase B targets (B1/B2/B3).
 
+## B2 observation (unit 3, PR 3)
+
+B2 collapses the `dest.is_symlink()` + `dest.exists()` pair in `create_symlink` into a single
+`fs::symlink_metadata` lstat. It removes exactly one existence-class syscall per destination, but
+the bench cells use FRESH fixtures (every link is a `created`), so the measured win is small
+(−0.6% to −4.3% warm) — the optimization's larger effect shows on re-run scenarios where the
+destination already exists (two probes → one). No regression on the small gate (N=4: 0.541 →
+0.518 ms). Note: the nested-glob N=5000 `discovery` attribution (206.4 ms this capture vs 129.2 ms
+baseline) is run variance in the final-run walk span, unrelated to B2 (B2 does not touch discovery).
+
 ## Before / After (Phase B commits — filled by units 2–5)
 
 B1 (unit 2, PR 2): scoped `path_cache` invalidation — `invalidate_path(path)` (exact key +
@@ -76,7 +86,13 @@ N=5000 and was reverted). After numbers = mean of two clean 5-run captures on th
 | B1 path_cache invalidation | nested-glob N=100 | warm 21.967 ms; canonicalize 4.152 ms | warm 19.397 ms; canonicalize 3.046 ms | −11.7% warm; −26.6% canonicalize |
 | B1 path_cache invalidation | nested-glob N=1000 | warm 160.244 ms; canonicalize 37.807 ms | warm 134.435 ms; canonicalize 24.671 ms | −16.1% warm; −34.7% canonicalize |
 | B1 path_cache invalidation | nested-glob N=5000 | warm 844.723 ms; canonicalize 199.190 ms | warm 699.955 ms; canonicalize 125.038 ms | −17.1% warm; −37.2% canonicalize |
-| B2 single existence probe | (pending) | | | |
+| B2 single existence probe | flat N=4 (small gate) | warm 0.541 ms; canonicalize 0.067 ms | warm 0.518 ms; canonicalize 0.067 ms | −4.3% warm — within noise band, no regression |
+| B2 single existence probe | flat N=100 | warm 10.058 ms; canonicalize 1.500 ms | warm 9.960 ms; canonicalize 1.616 ms | −1.0% warm; canonicalize within noise |
+| B2 single existence probe | flat N=1000 | warm 103.526 ms; canonicalize 18.034 ms | warm 102.871 ms; canonicalize 17.430 ms | −0.6% warm; −3.3% canonicalize |
+| B2 single existence probe | flat N=5000 | warm 528.703 ms; canonicalize 92.900 ms | warm 520.139 ms; canonicalize 90.879 ms | −1.6% warm; −2.2% canonicalize |
+| B2 single existence probe | nested-glob N=100 | warm 19.397 ms; canonicalize 3.046 ms | warm 18.709 ms; canonicalize 3.041 ms | −3.5% warm |
+| B2 single existence probe | nested-glob N=1000 | warm 134.435 ms; canonicalize 24.671 ms | warm 132.077 ms; canonicalize 24.016 ms | −1.8% warm; −2.7% canonicalize |
+| B2 single existence probe | nested-glob N=5000 | warm 699.955 ms; canonicalize 125.038 ms | warm 675.811 ms; canonicalize 124.267 ms | −3.5% warm; −0.6% canonicalize |
 | B3 DirEntry reuse | (pending) | | | |
 | B4 sorted iteration + final metrics | (pending) | | | |
 

--- a/openspec/changes/2026-08-10-issue-498-linker-perf-benchmark/state.yaml
+++ b/openspec/changes/2026-08-10-issue-498-linker-perf-benchmark/state.yaml
@@ -22,6 +22,24 @@ apply_note: >-
   failed, fmt + clippy clean. Bench B1 row recorded in benchmark-baseline.md:
   flat-5000 warm 625.6 -> 528.7 ms (-15.5%), canonicalize 134.2 -> 92.9 ms
   (-30.8%); nested-glob-5000 warm 844.7 -> 700.0 ms (-17.1%); small gate N=4
-  within noise band. Remaining: tasks 3.2-3.4 (PRs 3-5), 4.1-4.2 (final).
-  Chain strategy in tasks.md still pending.
+  within noise band.
+
+  Phase B unit 3 (task 3.2, B2 single existence probe) implemented and
+  validated: create_symlink (symlinks.rs:47-77) now collapses dest.is_symlink()
+  + dest.exists() into ONE fs::symlink_metadata(dest) match (symlink -> existing
+  symlink incl. broken, Ok(_) -> .bak backup, NotFound -> created, other -> Err
+  propagated with context). Broken-symlink semantics preserved (lstat succeeds,
+  symlink path, never backup); counters/output/exit code unchanged. TDD: 6 unit
+  tests (nonexistent->created; regular->.bak backup; broken symlink->no backup;
+  valid symlink already-correct->skipped; valid symlink wrong-target->updated;
+  ELOOP dest in dry-run->Err). Note: 5 contract tests are behavior-preserving
+  characterization (green pre-change by design); the ELOOP probe-error test was
+  the genuine RED (current code silently reported created=1 for an unprobeable
+  dest). Gates: linker_security 11/11, full suite 895 passed 0 failed, fmt +
+  clippy clean. Bench B2 row recorded in benchmark-baseline.md: fresh-fixture
+  win is small as predicted (warm -0.6% to -4.3% across cells; flat-5000 warm
+  528.7 -> 520.1 ms; nested-glob-5000 700.0 -> 675.8 ms); small gate N=4
+  0.541 -> 0.518 ms, no regression; larger effect expected on re-run (existing
+  dest) scenarios. Remaining: tasks 3.3-3.4 (PRs 4-5), 4.1-4.2 (final). Chain
+  strategy in tasks.md still pending.
 updated: 2026-08-10

--- a/openspec/changes/2026-08-10-issue-498-linker-perf-benchmark/state.yaml
+++ b/openspec/changes/2026-08-10-issue-498-linker-perf-benchmark/state.yaml
@@ -10,6 +10,18 @@ next: apply
 apply_note: >-
   Phase A (work unit 1 of 5; tasks 1.1-1.5, 2.1-2.2) implemented and validated:
   dev-bench harness, timing sink, baseline captured in benchmark-baseline.md.
-  Phase B (tasks 3.1-3.4) and final bench/verification (4.1-4.2) are later
-  chained work units (PRs 2-5). Chain strategy in tasks.md still pending.
+
+  Phase B unit 2 (task 3.1, B1 scoped path_cache invalidation) implemented and
+  validated: Linker::invalidate_path(path) drops exact key + starts_with keys via
+  BTreeMap range scan (path_cache switched HashMap -> BTreeMap after the initial
+  HashMap::retain implementation regressed to O(N^2) at N=5000 and was reverted).
+  Full clears replaced at symlinks.rs:99,138,165 (dest + backup), clean.rs:96,
+  apply.rs:283; full clear kept at sync() start. TDD: 4 unit tests (sibling
+  from_dir reuse mid-run; cleared after 2nd sync(); exact+descendant drop;
+  sibling survives). Gates: linker_security 11/11, full suite 889 passed 0
+  failed, fmt + clippy clean. Bench B1 row recorded in benchmark-baseline.md:
+  flat-5000 warm 625.6 -> 528.7 ms (-15.5%), canonicalize 134.2 -> 92.9 ms
+  (-30.8%); nested-glob-5000 warm 844.7 -> 700.0 ms (-17.1%); small gate N=4
+  within noise band. Remaining: tasks 3.2-3.4 (PRs 3-5), 4.1-4.2 (final).
+  Chain strategy in tasks.md still pending.
 updated: 2026-08-10

--- a/openspec/changes/2026-08-10-issue-498-linker-perf-benchmark/tasks.md
+++ b/openspec/changes/2026-08-10-issue-498-linker-perf-benchmark/tasks.md
@@ -34,7 +34,7 @@ Changed lines est.: 800–1,150 · delivery: ask-on-risk.
 
 ## Phase 3: Implementation — Phase B optimizations (TDD, one commit each)
 
-- [ ] 3.1 B1: failing unit (siblings reuse cached `from_dir` mid-run; empty after 2nd `sync()`) → `invalidate_path(path)` in `src/linker/paths.rs` (drop exact key + `starts_with` keys); replace full clears at `symlinks.rs:99,138,165`, `clean.rs:96`, `apply.rs:283`; keep full clear at `sync()` start; `cargo test --test all_tests unit::linker_security`.
+- [x] 3.1 B1: failing unit (siblings reuse cached `from_dir` mid-run; empty after 2nd `sync()`) → `invalidate_path(path)` in `src/linker/paths.rs` (drop exact key + `starts_with` keys); replace full clears at `symlinks.rs:99,138,165`, `clean.rs:96`, `apply.rs:283`; keep full clear at `sync()` start; `cargo test --test all_tests unit::linker_security`.
 - [ ] 3.2 B2: failing unit (nonexistent→created, regular→`.bak`, broken symlink→no backup) → single `fs::symlink_metadata(dest)` match in `create_symlink` (`symlinks.rs:46-57`); counters unchanged.
 - [ ] 3.3 B3: failing unit (no duplicate per-child stat; counters identical) → `resolve_source_path_with_hint(..., Some(true))` (`apply.rs:206/:235`) from contents loop (`symlinks.rs:255`); compression/revalidate unchanged.
 - [ ] 3.4 B4: failing integration (two runs → byte-identical stdout) → `read_dir` collect + `sort_by_key(file_name)` (`symlinks.rs:237`); `WalkDir::new(..).sort_by_file_name()` (`discovery.rs:213`); update order-asserting contracts (none exist); `cargo test --test all_tests`.

--- a/openspec/changes/2026-08-10-issue-498-linker-perf-benchmark/tasks.md
+++ b/openspec/changes/2026-08-10-issue-498-linker-perf-benchmark/tasks.md
@@ -35,7 +35,7 @@ Changed lines est.: 800–1,150 · delivery: ask-on-risk.
 ## Phase 3: Implementation — Phase B optimizations (TDD, one commit each)
 
 - [x] 3.1 B1: failing unit (siblings reuse cached `from_dir` mid-run; empty after 2nd `sync()`) → `invalidate_path(path)` in `src/linker/paths.rs` (drop exact key + `starts_with` keys); replace full clears at `symlinks.rs:99,138,165`, `clean.rs:96`, `apply.rs:283`; keep full clear at `sync()` start; `cargo test --test all_tests unit::linker_security`.
-- [ ] 3.2 B2: failing unit (nonexistent→created, regular→`.bak`, broken symlink→no backup) → single `fs::symlink_metadata(dest)` match in `create_symlink` (`symlinks.rs:46-57`); counters unchanged.
+- [x] 3.2 B2: failing unit (nonexistent→created, regular→`.bak`, broken symlink→no backup) → single `fs::symlink_metadata(dest)` match in `create_symlink` (`symlinks.rs:46-57`); counters unchanged.
 - [ ] 3.3 B3: failing unit (no duplicate per-child stat; counters identical) → `resolve_source_path_with_hint(..., Some(true))` (`apply.rs:206/:235`) from contents loop (`symlinks.rs:255`); compression/revalidate unchanged.
 - [ ] 3.4 B4: failing integration (two runs → byte-identical stdout) → `read_dir` collect + `sort_by_key(file_name)` (`symlinks.rs:237`); `WalkDir::new(..).sort_by_file_name()` (`discovery.rs:213`); update order-asserting contracts (none exist); `cargo test --test all_tests`.
 

--- a/src/linker/apply.rs
+++ b/src/linker/apply.rs
@@ -282,7 +282,7 @@ impl Linker {
         }
         fs::write(dest, compressed.as_bytes())
             .with_context(|| format!("Failed to write compressed AGENTS.md: {}", dest.display()))?;
-        self.invalidate_path_cache();
+        self.invalidate_path(dest);
         self.invalidate_glob_cache();
 
         self.ensured_compressed

--- a/src/linker/clean.rs
+++ b/src/linker/clean.rs
@@ -93,7 +93,7 @@ impl Linker {
                 tracing::error!(error = %e, path = %dest.display(), "Failed to remove managed symlink");
                 return Ok(());
             }
-            self.invalidate_path_cache();
+            self.invalidate_path(dest);
             println!("  {} Removed: {}", "✔".green(), dest.display());
             span.record("outcome", "removed");
         }

--- a/src/linker/mod.rs
+++ b/src/linker/mod.rs
@@ -6,7 +6,7 @@
 use anyhow::{Context, Result};
 use colored::Colorize;
 use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
@@ -83,7 +83,10 @@ pub struct Linker {
     config_path: PathBuf,
     project_root: PathBuf,
     source_dir: PathBuf,
-    path_cache: RefCell<HashMap<PathBuf, Rc<PathBuf>>>,
+    /// Canonicalize cache. `BTreeMap` (sorted keys) so scoped invalidation can
+    /// remove a path prefix via a contiguous range scan in O(log n + m) instead
+    /// of scanning the whole map per mutation.
+    path_cache: RefCell<BTreeMap<PathBuf, Rc<PathBuf>>>,
     compression_cache: RefCell<HashMap<PathBuf, Rc<str>>>,
     /// Cache for NestedGlob discovery results: (search_root, pattern, excludes) -> [(full_path, rel_path)]
     glob_cache: RefCell<HashMap<NestedGlobKey, NestedGlobMatches>>,
@@ -107,7 +110,7 @@ impl Linker {
             config_path,
             project_root,
             source_dir,
-            path_cache: RefCell::new(HashMap::new()),
+            path_cache: RefCell::new(BTreeMap::new()),
             compression_cache: RefCell::new(HashMap::new()),
             glob_cache: RefCell::new(HashMap::new()),
             ensured_dirs: RefCell::new(HashSet::new()),

--- a/src/linker/paths.rs
+++ b/src/linker/paths.rs
@@ -9,11 +9,41 @@ use super::Linker;
 use super::timing::SpanKind;
 
 impl Linker {
-    /// Drop path canonicalization cache after filesystem mutations that can affect
-    /// destination safety checks in the same run.
+    /// Drop every path canonicalization cache entry. Called at the start of
+    /// each `sync()` so filesystem changes between runs are always reflected
+    /// (REQ-023: caches never survive across runs).
     // `pub(super)` is required by the root façade and future mutation siblings.
     pub(super) fn invalidate_path_cache(&self) {
         self.path_cache.borrow_mut().clear();
+    }
+
+    /// Drop the path canonicalization cache entries whose canonical identity
+    /// may have changed because of a filesystem mutation at `path`: the exact
+    /// key and every key at or below it (prefix-based, REQ-023 scoped
+    /// invalidation).
+    ///
+    /// Unlike [`Self::invalidate_path_cache`], unrelated paths stay cached —
+    /// e.g. a sibling destination's parent directory — so `canonicalize_cached`
+    /// keeps hitting for unchanged paths within the same run (SC-023b), while
+    /// any path mutated by create/update/backup/remove is re-canonicalized on
+    /// next use (SC-023c). `ensure_safe_path`/`revalidate_path` are unaffected:
+    /// they use `canonicalize_uncached`, which always bypasses the cache.
+    ///
+    /// The cache is a `BTreeMap`, so keys sharing `path` as a prefix sort
+    /// contiguously: a `range(path..)` scan with a `starts_with` filter removes
+    /// only the affected entries in O(log n + m) (m = matches, usually 0 for
+    /// leaf destinations) instead of scanning the whole map per mutation.
+    // `pub(super)` is required by the root façade and mutation siblings.
+    pub(super) fn invalidate_path(&self, path: &Path) {
+        let mut cache = self.path_cache.borrow_mut();
+        let to_remove: Vec<PathBuf> = cache
+            .range(path.to_path_buf()..)
+            .take_while(|(key, _)| key.starts_with(path))
+            .map(|(key, _)| key.clone())
+            .collect();
+        for key in to_remove {
+            cache.remove(&key);
+        }
     }
 
     fn canonicalize_uncached(&self, path: &Path) -> Result<PathBuf> {
@@ -537,5 +567,183 @@ mod tests {
 
         let rel_fresh = linker.relative_path(&dest, &source_link, false).unwrap();
         assert_eq!(rel_fresh, PathBuf::from("real-b.md"));
+    }
+
+    // ==========================================================================
+    // scoped invalidate_path (REQ-023, work unit B1)
+    // ==========================================================================
+
+    /// Build a linker with a `symlink-contents` target linking
+    /// `.agents/flat/` → `links/` (4 fixed children), mirroring the benchmark
+    /// flat fixture. Returns `(linker, links_dir)`.
+    fn make_contents_linker(project_root: &Path) -> (Linker, PathBuf) {
+        use crate::config::{AgentConfig, SyncType, TargetConfig};
+
+        let flat = project_root.join(".agents").join("flat");
+        fs::create_dir_all(&flat).unwrap();
+        for i in 0..4 {
+            fs::write(flat.join(format!("f{i:04}.md")), "FIXED\n").unwrap();
+        }
+
+        let mut targets = BTreeMap::new();
+        targets.insert(
+            "target".to_string(),
+            TargetConfig {
+                source: "flat".to_string(),
+                destination: "links".to_string(),
+                sync_type: SyncType::SymlinkContents,
+                pattern: None,
+                exclude: vec![],
+                mappings: vec![],
+            },
+        );
+        let agent_config = AgentConfig {
+            enabled: true,
+            description: String::new(),
+            targets,
+        };
+        let mut agents = BTreeMap::new();
+        agents.insert("test".to_string(), agent_config);
+
+        let config = Config {
+            source_dir: ".agents".to_string(),
+            compress_agents_md: false,
+            default_agents: vec![],
+            agents,
+            gitignore: Default::default(),
+            mcp: Default::default(),
+            mcp_servers: Default::default(),
+        };
+
+        let config_path = project_root.join("agentsync.toml");
+        fs::write(&config_path, "").unwrap();
+        let linker = Linker::new(config, config_path);
+        (linker, project_root.join("links"))
+    }
+
+    #[test]
+    fn invalidate_path_drops_exact_and_descendant_keys_only() {
+        let temp = TempDir::new().unwrap();
+        let linker = make_linker(temp.path());
+        let root = temp.path();
+
+        let dir = root.join("dir");
+        let dir_child = dir.join("child.md");
+        let sibling = root.join("sibling.md");
+
+        {
+            let mut cache = linker.path_cache.borrow_mut();
+            cache.insert(dir.clone(), Rc::new(dir.clone()));
+            cache.insert(dir_child.clone(), Rc::new(dir_child.clone()));
+            cache.insert(sibling.clone(), Rc::new(sibling.clone()));
+        }
+
+        linker.invalidate_path(&dir);
+
+        let cache = linker.path_cache.borrow();
+        assert!(!cache.contains_key(&dir), "exact key must be dropped");
+        assert!(
+            !cache.contains_key(&dir_child),
+            "descendant keys must be dropped"
+        );
+        assert!(
+            cache.contains_key(&sibling),
+            "unrelated keys must survive scoped invalidation"
+        );
+    }
+
+    #[test]
+    fn scoped_invalidation_keeps_sibling_from_dir_cached() {
+        let temp = TempDir::new().unwrap();
+        let linker = make_linker(temp.path());
+
+        let source = temp.path().join("source.md");
+        fs::write(&source, "x").unwrap();
+        let dest_dir = temp.path().join("links");
+        fs::create_dir_all(&dest_dir).unwrap();
+        let dest_a = dest_dir.join("a.md");
+        let dest_b = dest_dir.join("b.md");
+
+        // First link populates the cache for `links/` (from_dir) and `source.md`.
+        let rel_a = linker.relative_path(&dest_a, &source, false).unwrap();
+        assert_eq!(rel_a, PathBuf::from("../source.md"));
+
+        // Post-mutation scoped invalidation — exactly what create_symlink now does.
+        linker.invalidate_path(&dest_a);
+
+        // The unchanged from_dir and source entries MUST survive.
+        assert!(
+            linker.path_cache.borrow().contains_key(&dest_dir),
+            "from_dir must stay cached after mutating a child dest"
+        );
+        assert!(
+            linker.path_cache.borrow().contains_key(&source),
+            "source must stay cached after mutating a child dest"
+        );
+
+        // Second sibling reuses the surviving from_dir entry → same result.
+        let rel_b = linker.relative_path(&dest_b, &source, false).unwrap();
+        assert_eq!(rel_b, PathBuf::from("../source.md"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn sync_retains_path_cache_entries_within_run() {
+        let temp = TempDir::new().unwrap();
+        let (linker, links_dir) = make_contents_linker(temp.path());
+
+        let result = linker.sync(&super::super::SyncOptions::default()).unwrap();
+        assert_eq!(result.created, 4);
+
+        // The last create_symlink only invalidates its own dest key; the
+        // from_dir and source entries computed for it must survive the run.
+        let cache = linker.path_cache.borrow();
+        assert!(
+            !cache.is_empty(),
+            "scoped invalidation must leave cached entries within a run"
+        );
+        assert!(
+            cache.contains_key(&links_dir),
+            "from_dir must remain cached after the run's last mutation"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn sync_clears_path_cache_between_runs() {
+        let temp = TempDir::new().unwrap();
+        let (linker, links_dir) = make_contents_linker(temp.path());
+
+        let first_source = temp.path().join(".agents/flat/f0000.md");
+        let first_dest = links_dir.join("f0000.md");
+        let expected_target = PathBuf::from("../.agents/flat/f0000.md");
+
+        let result1 = linker.sync(&super::super::SyncOptions::default()).unwrap();
+        assert_eq!(result1.created, 4);
+        assert_eq!(fs::read_link(&first_dest).unwrap(), expected_target);
+
+        // Poison the cache with wrong canonical identities, simulating stale
+        // entries a previous run could have left behind.
+        {
+            let mut cache = linker.path_cache.borrow_mut();
+            cache.insert(
+                first_source.clone(),
+                Rc::new(PathBuf::from("/wrong/canonical/source")),
+            );
+            cache.insert(
+                links_dir.clone(),
+                Rc::new(PathBuf::from("/wrong/canonical/dir")),
+            );
+        }
+
+        // Run 2 must clear the cache at sync() start: the poison entries must
+        // never be served, so the links keep their correct targets.
+        let result2 = linker.sync(&super::super::SyncOptions::default()).unwrap();
+        assert_eq!(result2.created, 0, "second run must skip correct links");
+        assert_eq!(
+            fs::read_link(&first_dest).unwrap(),
+            expected_target,
+            "run 2 must not serve run 1's cache entries"
+        );
     }
 }

--- a/src/linker/symlinks.rs
+++ b/src/linker/symlinks.rs
@@ -78,7 +78,6 @@ impl Linker {
             #[cfg(unix)]
             std::os::unix::fs::symlink(&relative_source, dest)
                 .with_context(|| format!("Failed to create symlink: {}", dest.display()))?;
-
             #[cfg(windows)]
             {
                 if source.path.is_dir() {
@@ -98,7 +97,9 @@ impl Linker {
                 }
             }
 
-            self.invalidate_path_cache();
+            // Scoped invalidation: only the mutated dest's canonical identity
+            // can have changed; sibling/ancestor entries stay cached.
+            self.invalidate_path(dest);
 
             println!(
                 "  {} Linked: {} -> {}",
@@ -137,7 +138,7 @@ impl Linker {
         } else {
             self.revalidate_unlink_path(dest)?;
             remove_symlink(dest)?;
-            self.invalidate_path_cache();
+            self.invalidate_path(dest);
             if options.verbose {
                 println!(
                     "  {} Removed old symlink: {} (was -> {})",
@@ -164,7 +165,10 @@ impl Linker {
             self.revalidate_path(&backup)?;
             remove_existing_path(&backup)?;
             fs::rename(dest, &backup)?;
-            self.invalidate_path_cache();
+            // The rename moves `dest` (now absent) to `backup` (now present);
+            // both prefixes must be re-canonicalized on next use.
+            self.invalidate_path(dest);
+            self.invalidate_path(&backup);
             self.invalidate_glob_cache();
             println!(
                 "  {} Backed up: {} -> {}",

--- a/src/linker/symlinks.rs
+++ b/src/linker/symlinks.rs
@@ -44,23 +44,38 @@ impl Linker {
         let allow_missing = options.dry_run && !source.path.exists();
         let relative_source = self.relative_path(dest, &source.path, allow_missing)?;
 
-        // Handle existing destination
-        if dest.is_symlink() {
-            let action = self.handle_existing_symlink(dest, &relative_source, options)?;
-            match action {
-                ExistingSymlinkAction::AlreadyCorrect => {
-                    result.skipped += 1;
-                    return Ok(result);
-                }
-                ExistingSymlinkAction::Updated => {
-                    result.updated += 1;
+        // Handle existing destination with a SINGLE existence-class probe.
+        // `symlink_metadata` does not follow the final component: a broken
+        // symlink still lstat-succeeds with `is_symlink() == true`, so it
+        // takes the symlink path (never the backup path) — the same semantics
+        // the previous `dest.is_symlink()` + `dest.exists()` pair produced,
+        // but with one syscall instead of two. `NotFound` means the
+        // destination is fresh; any other probe error is propagated instead
+        // of silently claiming the destination was created.
+        match fs::symlink_metadata(dest) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                let action = self.handle_existing_symlink(dest, &relative_source, options)?;
+                match action {
+                    ExistingSymlinkAction::AlreadyCorrect => {
+                        result.skipped += 1;
+                        return Ok(result);
+                    }
+                    ExistingSymlinkAction::Updated => {
+                        result.updated += 1;
+                    }
                 }
             }
-        } else if dest.exists() {
-            self.backup_existing_destination(dest, options)?;
-            result.updated += 1;
-        } else {
-            result.created += 1;
+            Ok(_) => {
+                self.backup_existing_destination(dest, options)?;
+                result.updated += 1;
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                result.created += 1;
+            }
+            Err(err) => {
+                return Err(err)
+                    .with_context(|| format!("Failed to probe destination: {}", dest.display()));
+            }
         }
 
         // Create the symlink
@@ -311,7 +326,226 @@ pub(super) fn remove_symlink(path: &Path) -> std::io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::Config;
+    use std::collections::BTreeMap;
     use tempfile::TempDir;
+
+    // ==========================================================================
+    // test helpers
+    // ==========================================================================
+
+    /// Build a `Linker` rooted at `project_root` with an empty (unused) config,
+    /// mirroring the helper in `paths.rs` tests. `create_symlink` is called
+    /// directly with a `ResolvedSource`, so the config contents are irrelevant.
+    #[cfg(unix)]
+    fn make_linker(project_root: &Path) -> Linker {
+        let agents_dir = project_root.join(".agents");
+        fs::create_dir_all(&agents_dir).unwrap();
+        let config_path = agents_dir.join("agentsync.toml");
+
+        let config = Config {
+            source_dir: ".".to_string(),
+            compress_agents_md: false,
+            default_agents: vec![],
+            agents: BTreeMap::new(),
+            gitignore: Default::default(),
+            mcp: Default::default(),
+            mcp_servers: Default::default(),
+        };
+
+        Linker::new(config, config_path)
+    }
+
+    /// Standard fixture: a real source file and a destination whose parent
+    /// (the project root) already exists. Returns the `TempDir` FIRST so it
+    /// stays alive (and the tree stays on disk) for the whole test scope.
+    #[cfg(unix)]
+    fn make_single_link_fixture() -> (TempDir, Linker, PathBuf, PathBuf) {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path();
+        let linker = make_linker(root);
+
+        let source = root.join(".agents").join("source.md");
+        fs::write(&source, "# Source").unwrap();
+        let dest = root.join("dest.md");
+
+        (temp, linker, source, dest)
+    }
+
+    // ==========================================================================
+    // create_symlink — single existence probe (B2, REQ: No Redundant
+    // Existence Probe). One `symlink_metadata` lstat must decide the branch;
+    // behavior for broken symlinks (symlink path, never backup) is preserved.
+    // ==========================================================================
+
+    #[test]
+    #[cfg(unix)]
+    fn create_symlink_nonexistent_dest_creates() {
+        let (_temp, linker, source, dest) = make_single_link_fixture();
+        let resolved = ResolvedSource {
+            path: source.clone(),
+            exists: true,
+        };
+
+        let result = linker
+            .create_symlink(&resolved, &dest, &SyncOptions::default())
+            .unwrap();
+
+        assert_eq!(result.created, 1);
+        assert_eq!(result.updated, 0);
+        assert_eq!(result.skipped, 0);
+        assert!(dest.is_symlink());
+        // The link must point at the resolved source.
+        let expected = linker.relative_path(&dest, &source, false).unwrap();
+        assert_eq!(fs::read_link(&dest).unwrap(), expected);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn create_symlink_regular_file_dest_backs_up() {
+        let (_temp, linker, source, dest) = make_single_link_fixture();
+        fs::write(&dest, "old content").unwrap();
+        let resolved = ResolvedSource {
+            path: source.clone(),
+            exists: true,
+        };
+
+        let result = linker
+            .create_symlink(&resolved, &dest, &SyncOptions::default())
+            .unwrap();
+
+        assert_eq!(result.updated, 1, "regular file must be backed up");
+        assert_eq!(result.created, 0);
+        // The original content survives as `<dest>.bak`.
+        let backup = backup_path_for_destination(&dest);
+        assert_eq!(fs::read_to_string(&backup).unwrap(), "old content");
+        // The destination is now a symlink to the source.
+        assert!(dest.is_symlink());
+        let expected = linker.relative_path(&dest, &source, false).unwrap();
+        assert_eq!(fs::read_link(&dest).unwrap(), expected);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn create_symlink_broken_symlink_no_backup() {
+        use std::os::unix::fs::symlink;
+
+        let (_temp, linker, source, dest) = make_single_link_fixture();
+        // A symlink whose target does not exist: `exists()` is false but the
+        // entry IS a symlink. It must take the symlink path — never the
+        // backup path — and be replaced with the correct target.
+        symlink("missing-target.md", &dest).unwrap();
+        assert!(dest.is_symlink());
+        assert!(!dest.exists());
+        let resolved = ResolvedSource {
+            path: source.clone(),
+            exists: true,
+        };
+
+        let result = linker
+            .create_symlink(&resolved, &dest, &SyncOptions::default())
+            .unwrap();
+
+        assert_eq!(result.updated, 1, "broken symlink must be updated");
+        assert_eq!(result.created, 0);
+        assert!(
+            !backup_path_for_destination(&dest).exists(),
+            "broken symlink must NOT be backed up"
+        );
+        assert!(dest.is_symlink());
+        let expected = linker.relative_path(&dest, &source, false).unwrap();
+        assert_eq!(fs::read_link(&dest).unwrap(), expected);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn create_symlink_valid_symlink_already_correct_skips() {
+        use std::os::unix::fs::symlink;
+
+        let (_temp, linker, source, dest) = make_single_link_fixture();
+        // Pre-link the destination to exactly the target create_symlink computes.
+        let expected = linker.relative_path(&dest, &source, false).unwrap();
+        symlink(&expected, &dest).unwrap();
+        assert!(dest.is_symlink());
+        assert!(dest.exists(), "target exists so this is a valid symlink");
+        let resolved = ResolvedSource {
+            path: source.clone(),
+            exists: true,
+        };
+
+        let result = linker
+            .create_symlink(&resolved, &dest, &SyncOptions::default())
+            .unwrap();
+
+        assert_eq!(result.skipped, 1);
+        assert_eq!(result.created, 0);
+        assert_eq!(result.updated, 0);
+        assert_eq!(fs::read_link(&dest).unwrap(), expected, "link unchanged");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn create_symlink_valid_symlink_wrong_target_updates() {
+        use std::os::unix::fs::symlink;
+
+        let (_temp, linker, source, dest) = make_single_link_fixture();
+        // A valid symlink (target exists) pointing at the WRONG target.
+        let stale = dest.parent().unwrap().join("stale-target.md");
+        fs::write(&stale, "stale").unwrap();
+        symlink("stale-target.md", &dest).unwrap();
+        let resolved = ResolvedSource {
+            path: source.clone(),
+            exists: true,
+        };
+
+        let result = linker
+            .create_symlink(&resolved, &dest, &SyncOptions::default())
+            .unwrap();
+
+        assert_eq!(result.updated, 1, "wrong-target symlink must be updated");
+        assert_eq!(result.created, 0);
+        assert!(
+            !backup_path_for_destination(&dest).exists(),
+            "symlink must never be backed up"
+        );
+        let expected = linker.relative_path(&dest, &source, false).unwrap();
+        assert_eq!(fs::read_link(&dest).unwrap(), expected);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn create_symlink_propagates_probe_error_on_loop_dest() {
+        use std::os::unix::fs::symlink;
+
+        let (_temp, linker, source, _) = make_single_link_fixture();
+        let root = source.parent().unwrap().parent().unwrap().to_path_buf();
+
+        // `root/loop` is a self-referential symlink, so any path through it
+        // (including `root/loop/loop/dest.md`) fails `symlink_metadata` with
+        // ELOOP. The single-probe implementation must propagate this error
+        // instead of silently claiming the destination was created.
+        let loop_link = root.join("loop");
+        symlink("loop", &loop_link).unwrap();
+        let dest = loop_link.join("loop").join("dest.md");
+        let resolved = ResolvedSource {
+            path: source,
+            exists: true,
+        };
+
+        let result = linker.create_symlink(
+            &resolved,
+            &dest,
+            &SyncOptions {
+                dry_run: true,
+                ..Default::default()
+            },
+        );
+
+        assert!(
+            result.is_err(),
+            "unprobeable destination must fail, not report created"
+        );
+    }
 
     // ==========================================================================
     // backup_path_for_destination


### PR DESCRIPTION
# Description

PR 2 of the stacked chain for #498 (measurement-first linker optimization). After the baseline proved `canonicalize` dominates link creation, this PR applies the highest-impact fix: **stop clearing the whole `path_cache` after every symlink mutation**, so `canonicalize_cached` actually works within a run.

## What changed

- **`Linker::invalidate_path(path)`** (src/linker/paths.rs) — drops the exact cache key + descendant keys (`starts_with`), replacing the full cache clear after mutations.
- **`path_cache: HashMap → BTreeMap`** — enables O(log n + m) prefix-range invalidation. The bench caught the naive `HashMap::retain` approach: O(N²), ~1855 ms regression at N=5000. Measurement-first doing its job.
- **5 mutation sites** now call scoped `invalidate_path(dest)` instead of full clears: symlinks.rs (create / handle-existing / backup), clean.rs (remove), apply.rs (compressed write).
- **Full clear kept at `Linker::sync()` start** — REQ-023 between-run cache semantics preserved.
- **TOCTOU safety preserved** — `ensure_safe_path`/`revalidate_path` use `canonicalize_uncached` (bypasses the cache), untouched.

## TDD

4 new unit tests in paths.rs (RED → GREEN):
- sibling links reuse cached `from_dir` within a run
- cache is empty at the start of a second `sync()` run
- prefix invalidation drops descendants, keeps unrelated keys
- (plus the BTreeMap range-scan behavior)

## Bench before/after (release, 5 runs/cell, warm = median 2..=5)

| Cell | Baseline | After (orchestrator-verified) | Delta |
|---|---|---|---|
| flat-5000 total | 625.6 ms | 595.9 ms | −4.8% |
| flat-5000 **canonicalize** | 134.2 ms | 101.8 ms | **−24.1%** |
| nested-5000 total | 844.7 ms | 776.0 ms | −8.1% |
| nested-5000 **canonicalize** | 199.2 ms | 136.0 ms | **−31.7%** |
| flat-4 small gate | 0.606 ms | 0.665 ms | within noise band ✓ |

The canonicalize column — the exact attribution the issue asked to measure — drops 24–32% across both repo shapes. No small-repo regression.

## Type of change

- [x] New feature (non-breaking, performance)
- [ ] Bug fix
- [ ] Breaking change

## How Has This Been Tested?

- [x] `cargo test --all-features` — 889 passed, 0 failed
- [x] `cargo test --test all_tests unit::linker_security` — 11/11 (TOCTOU gate)
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo run --release -- dev-bench --runs 5` — before/after recorded in benchmark-baseline.md

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (chain: PR 3 = B2 single existence probe)