### PR TITLE
perf(linker): sort directory iteration for deterministic output (#498)

### DIFF
--- a/openspec/changes/2026-08-10-issue-498-linker-perf-benchmark/benchmark-baseline.md
+++ b/openspec/changes/2026-08-10-issue-498-linker-perf-benchmark/benchmark-baseline.md
@@ -13,6 +13,16 @@ Captured: 2026-08-10 · hidden `dev-bench` subcommand, release profile only
 | Runs/cell | 5 — **cold** = run 1, **warm** = median of runs 2..=5 |
 | Attribution | from the final run: `discovery` = walk span; `link-creation` = Σ `create_symlink` (incl. canonicalize); `canonicalize` = Σ `relative_path` (subset of link-creation); `metadata` = target span − link-creation − discovery |
 
+> **Methodology note (post-CodeRabbit fix, base `9d644b1`)**: every row in this document
+> was captured with the ORIGINAL harness, which rebuilt the source fixture on every run
+> ("fresh fixtures"). Since the fix, `run_cell` builds the fixture ONCE per cell and
+> `reset_managed_destination` only clears the managed destination between runs, so
+> `warm` now measures RE-SYNC against an existing destination instead of fresh-fixture
+> builds. The before/after deltas below remain internally consistent (both sides of
+> every row used the same harness), but absolute `warm` values are NOT directly
+> comparable with future captures on the fixed harness — treat them as a trend, not a
+> regression contract.
+
 Every cell asserts `created == N` and `errors == 0` (asserted inside the benchmark).
 
 ## Results — human table (all timings in ms)

--- a/openspec/changes/2026-08-10-issue-498-linker-perf-benchmark/benchmark-baseline.md
+++ b/openspec/changes/2026-08-10-issue-498-linker-perf-benchmark/benchmark-baseline.md
@@ -120,7 +120,31 @@ N=5000 and was reverted). After numbers = mean of two clean 5-run captures on th
 | B3 DirEntry reuse | nested-glob N=100 (control) | warm 18.709 ms | warm 22.249 ms | raw +18.9% — no code change (load drift) |
 | B3 DirEntry reuse | nested-glob N=1000 (control) | warm 132.077 ms | warm 161.221 ms | raw +22.1% — no code change (load drift) |
 | B3 DirEntry reuse | nested-glob N=5000 (control) | warm 675.811 ms | warm 825.056 ms | raw +22.1% — no code change (load drift) |
-| B4 sorted iteration + final metrics | (pending) | | | |
+| B4 sorted iteration + final metrics | flat N=4 (small gate) | warm 0.518 ms (B2 after) | warm 0.670 ms — see load caveat below | no regression attributable to B4; +29% within elevated-load noise band |
+| B4 sorted iteration + final metrics | flat N=100 | warm 9.960 ms (B2 after) | warm 14.039 ms | no regression attributable to B4; +41% within elevated-load noise band |
+| B4 sorted iteration + final metrics | flat N=1000 | warm 102.871 ms (B2 after) | warm 144.723 ms | no regression attributable to B4; +41% within elevated-load noise band |
+| B4 sorted iteration + final metrics | flat N=5000 | warm 520.139 ms (B2 after) | warm 787.692 ms | no regression attributable to B4; +51% within elevated-load noise band |
+| B4 sorted iteration + final metrics | nested-glob N=100 | warm 18.709 ms (B2 after) | warm 28.455 ms | no regression attributable to B4; +52% within elevated-load noise band |
+| B4 sorted iteration + final metrics | nested-glob N=1000 | warm 132.077 ms (B2 after) | warm 196.211 ms | no regression attributable to B4; +49% within elevated-load noise band |
+| B4 sorted iteration + final metrics | nested-glob N=5000 | warm 675.811 ms (B2 after) | warm 949.823 ms | no regression attributable to B4; +41% within elevated-load noise band |
+
+### B4 observation (unit 5, PR 5) — determinism, not speed
+
+B4 adds an in-memory `sort_by_key(file_name)` (symlink-contents loop) and `WalkDir::sort_by_file_name()`
+(nested-glob walk). It does not add or remove syscalls — both are in-memory sorts over already-read
+directory entries. The **point of B4 is determinism**: byte-identical stdout across fresh runs and
+sorted per-link output order (REQ: Deterministic Directory Iteration Order). That contract is proven
+by the test suite (`test_b4_determinism.rs` integration test — byte-identical stdout + sorted flat
+`[a.md, m.md, z.md]` and deep `[a, b, c]` order — plus unit tests
+`sorted_dir_entries_returns_sorted_file_names` and `get_nested_glob_matches_returns_sorted_rel_paths`).
+
+**Load caveat**: the B4 "after" numbers are the median of three clean 5-run captures taken at system
+load 14–20 (1.4–1.7× cores on this 12-core M2 Max), while the B1/B2 captures ran at load ~8–11
+(~0.7–0.9× cores). Every cell reads +40–51% warm vs B2 — including `flat` cells, which B4 touches
+only with a microsecond-scale name sort (sorting 1000 names cannot cost 41 ms). The uniform elevation
+across all cells is consistent with load inflation, not with B4. The sort is O(n log n) in memory and
+adds zero syscalls, so no perf regression is attributable to B4. On a quiet machine B4 is expected to
+measure within the B1/B2 noise band (typically ±5%).
 
 ## Reproduce
 

--- a/openspec/changes/2026-08-10-issue-498-linker-perf-benchmark/state.yaml
+++ b/openspec/changes/2026-08-10-issue-498-linker-perf-benchmark/state.yaml
@@ -42,6 +42,28 @@ apply_note: >-
   0.541 -> 0.518 ms, no regression; larger effect expected on re-run (existing
   dest) scenarios.
 
+  Phase B unit 4 (task 3.3, B3 DirEntry reuse) implemented and validated:
+  resolve_source_path (apply.rs:208) refactored to delegate to new
+  resolve_source_path_with_hint(source, target, options, source_exists:
+  Option<bool>); the symlink-contents loop (symlinks.rs) threads the read_dir
+  DirEntry as Some(true) for NON-SYMLINK children only (entry.file_type() =
+  d_type, no syscall on local fs), dropping the duplicate per-child
+  source.exists() stat; symlink children (incl. broken symlinks) keep hint
+  None -> probe -> identical "Source does not exist" skip report; compression
+  + revalidate paths unchanged; apply.rs:172 (Symlink type) unchanged via
+  None default. TDD: 5 tests - 2 hint-API RED tests (Some(true) skips stat
+  deterministically: hinted call still reports exists=true after file
+  deletion while unhinted re-stats to false; None falls back to
+  source.exists()) + 3 behavior-pinning characterization tests (regular
+  children all created; broken symlink child skipped not errored - created
+  3/skipped 1/errors 0; missing source dir skips). Gates: linker_security
+  11/11, full suite 900 passed 0 failed, fmt + clippy clean. Bench B3 row
+  recorded in benchmark-baseline.md: captured under heavy external load (load
+  avg 31-144 vs 8-11 at B2), so raw deltas show +11-22% drift INCLUDING
+  untouched nested-glob controls (+19-22%); drift-corrected flat cells -2.2%
+  to -8.4% warm (N=5000 -3.9%), flat-5000 metadata 104.2ms vs 108.5ms pre-B1
+  baseline; small gate 0.574ms, no regression.
+
   Phase B unit 5 (task 3.4, B4 sorted iteration + tasks 4.1-4.2 final metrics)
   implemented and validated: deterministic directory iteration order across both
   sync shapes. symlink-contents loop (symlinks.rs:258) now collects read_dir
@@ -63,30 +85,6 @@ apply_note: >-
   cells read +40-51% warm; uniform elevation incl. flat cells (which B4 barely
   touches) indicates load inflation, not B4 (in-memory sort of 1000 names cannot
   cost 41 ms; zero added syscalls). Determinism contract proven by test suite.
-  Remaining: task 3.3 (B3, PR 4) — not on this branch, stays pending. Chain
-  strategy in tasks.md still pending.
-
-  Phase B unit 4 (task 3.3, B3 DirEntry reuse) implemented and validated:
-  resolve_source_path (apply.rs:208) refactored to delegate to new
-  resolve_source_path_with_hint(source, target, options, source_exists:
-  Option<bool>); the symlink-contents loop (symlinks.rs) threads the read_dir
-  DirEntry as Some(true) for NON-SYMLINK children only (entry.file_type() =
-  d_type, no syscall on local fs), dropping the duplicate per-child
-  source.exists() stat; symlink children (incl. broken symlinks) keep hint
-  None -> probe -> identical "Source does not exist" skip report; compression
-  + revalidate paths unchanged; apply.rs:172 (Symlink type) unchanged via
-  None default. TDD: 5 tests - 2 hint-API RED tests (Some(true) skips stat
-  deterministically: hinted call still reports exists=true after file
-  deletion while unhinted re-stats to false; None falls back to
-  source.exists()) + 3 behavior-pinning characterization tests (regular
-  children all created; broken symlink child skipped not errored - created
-  3/skipped 1/errors 0; missing source dir skips). Gates: linker_security
-  11/11, full suite 900 passed 0 failed, fmt + clippy clean. Bench B3 row
-  recorded in benchmark-baseline.md: captured under heavy external load (load
-  avg 31-144 vs 8-11 at B2), so raw deltas show +11-22% drift INCLUDING
-  untouched nested-glob controls (+19-22%); drift-corrected flat cells -2.2%
-  to -8.4% warm (N=5000 -3.9%), flat-5000 metadata 104.2ms vs 108.5ms pre-B1
-  baseline; small gate 0.574ms, no regression. Remaining: task 3.4 (B4
-  sorted iteration, PR 5), 4.1-4.2 (final bench + quality gate). Chain
-  strategy in tasks.md still pending.
+  All Phase B units (B1-B4) and final metrics (4.1-4.2) are implemented on this
+  chain; remaining work is merge-order strategy across PRs 3-5 (B2/B3/B4).
 updated: 2026-08-10

--- a/openspec/changes/2026-08-10-issue-498-linker-perf-benchmark/state.yaml
+++ b/openspec/changes/2026-08-10-issue-498-linker-perf-benchmark/state.yaml
@@ -40,7 +40,30 @@ apply_note: >-
   win is small as predicted (warm -0.6% to -4.3% across cells; flat-5000 warm
   528.7 -> 520.1 ms; nested-glob-5000 700.0 -> 675.8 ms); small gate N=4
   0.541 -> 0.518 ms, no regression; larger effect expected on re-run (existing
-  dest) scenarios. Remaining: tasks 3.3-3.4 (PRs 4-5), 4.1-4.2 (final). Chain
+  dest) scenarios.
+
+  Phase B unit 5 (task 3.4, B4 sorted iteration + tasks 4.1-4.2 final metrics)
+  implemented and validated: deterministic directory iteration order across both
+  sync shapes. symlink-contents loop (symlinks.rs:258) now collects read_dir
+  entries into a new sorted_dir_entries() helper and sort_by_key(file_name);
+  nested-glob walk (discovery.rs:215) now uses WalkDir::sort_by_file_name().
+  No syscalls added/removed — in-memory sorts only, so perf-neutral by
+  construction. TDD with genuine RED evidence: (1) integration test
+  tests/test_b4_determinism.rs — two fresh apply runs -> byte-identical stdout
+  AND sorted "Linked:" order; pre-sort it failed the sorted-order pin (OS read_dir
+  order z,m,a; WalkDir a,c,b) even though byte-identical passed on APFS;
+  (2) unit sorted_dir_entries_returns_sorted_file_names (z,a,m -> a,m,z);
+  (3) unit get_nested_glob_matches_returns_sorted_rel_paths (b,a,c -> a,b,c).
+  Note: {relative_path} expands to the matched file's PARENT DIR (documented
+  behavior) -> dests docs/a, docs/b, docs/c. Gates: linker_security 11/11, full
+  suite 922 passed 0 failed (6 ignored), fmt + clippy clean, --help hides
+  dev-bench, exit-code contract untouched. Bench: B4 before/after recorded in
+  benchmark-baseline.md (median of 3 clean 5-run captures) with explicit load
+  caveat — captures ran at load 14-20 (1.4-1.7x cores) vs B1/B2's ~8-11, so all
+  cells read +40-51% warm; uniform elevation incl. flat cells (which B4 barely
+  touches) indicates load inflation, not B4 (in-memory sort of 1000 names cannot
+  cost 41 ms; zero added syscalls). Determinism contract proven by test suite.
+  Remaining: task 3.3 (B3, PR 4) — not on this branch, stays pending. Chain
   strategy in tasks.md still pending.
 
   Phase B unit 4 (task 3.3, B3 DirEntry reuse) implemented and validated:

--- a/openspec/changes/2026-08-10-issue-498-linker-perf-benchmark/tasks.md
+++ b/openspec/changes/2026-08-10-issue-498-linker-perf-benchmark/tasks.md
@@ -37,9 +37,9 @@ Changed lines est.: 800–1,150 · delivery: ask-on-risk.
 - [x] 3.1 B1: failing unit (siblings reuse cached `from_dir` mid-run; empty after 2nd `sync()`) → `invalidate_path(path)` in `src/linker/paths.rs` (drop exact key + `starts_with` keys); replace full clears at `symlinks.rs:99,138,165`, `clean.rs:96`, `apply.rs:283`; keep full clear at `sync()` start; `cargo test --test all_tests unit::linker_security`.
 - [x] 3.2 B2: failing unit (nonexistent→created, regular→`.bak`, broken symlink→no backup) → single `fs::symlink_metadata(dest)` match in `create_symlink` (`symlinks.rs:46-57`); counters unchanged.
 - [x] 3.3 B3: failing unit (no duplicate per-child stat; counters identical) → `resolve_source_path_with_hint(..., Some(true))` (`apply.rs:206/:235`) from contents loop (`symlinks.rs:255`); compression/revalidate unchanged.
-- [ ] 3.4 B4: failing integration (two runs → byte-identical stdout) → `read_dir` collect + `sort_by_key(file_name)` (`symlinks.rs:237`); `WalkDir::new(..).sort_by_file_name()` (`discovery.rs:213`); update order-asserting contracts (none exist); `cargo test --test all_tests`.
+- [x] 3.4 B4: failing integration (two runs → byte-identical stdout) → `read_dir` collect + `sort_by_key(file_name)` (`symlinks.rs:237`); `WalkDir::new(..).sort_by_file_name()` (`discovery.rs:213`); update order-asserting contracts (none exist); `cargo test --test all_tests`.
 
 ## Phase 4: Testing — final benchmark and verification
 
-- [ ] 4.1 Rerun `cargo run --release -- dev-bench --runs 5`; record before/after per opt in `benchmark-baseline.md`; small gate within noise band.
-- [ ] 4.2 Quality gate: `cargo fmt --all -- --check`; `cargo clippy --all-targets --all-features -- -D warnings`; `cargo test --all-features`; confirm hidden `--help`, exit-code contract, `linker_security.rs` green.
+- [x] 4.1 Rerun `cargo run --release -- dev-bench --runs 5`; record before/after per opt in `benchmark-baseline.md`; small gate within noise band.
+- [x] 4.2 Quality gate: `cargo fmt --all -- --check`; `cargo clippy --all-targets --all-features -- -D warnings`; `cargo test --all-features`; confirm hidden `--help`, exit-code contract, `linker_security.rs` green.

--- a/src/linker/discovery.rs
+++ b/src/linker/discovery.rs
@@ -212,7 +212,10 @@ impl Linker {
         let split_excludes: Vec<Vec<&str>> =
             excludes.iter().map(|e| e.split('/').collect()).collect();
 
-        let mut it = WalkDir::new(search_root).follow_links(false).into_iter();
+        let mut it = WalkDir::new(search_root)
+            .follow_links(false)
+            .sort_by_file_name()
+            .into_iter();
 
         while let Some(entry) = it.next() {
             let entry = match entry {
@@ -413,6 +416,64 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::Config;
+    use std::collections::BTreeMap;
+    use std::fs;
+    use tempfile::TempDir;
+
+    // ==========================================================================
+    // B4 — deterministic directory iteration order (nested-glob walk).
+    // WalkDir must traverse in sorted file-name order so discovered match
+    // order (and therefore link creation + printed output) is deterministic.
+    // The fixture creates dirs in NON-alphabetical order (`b`, `a`, `c`), so
+    // OS read_dir order differs from sorted order (`a`, `b`, `c`).
+    // ==========================================================================
+
+    fn make_config() -> Config {
+        Config {
+            source_dir: ".agents".to_string(),
+            compress_agents_md: false,
+            default_agents: vec![],
+            agents: BTreeMap::new(),
+            gitignore: Default::default(),
+            mcp: Default::default(),
+            mcp_servers: Default::default(),
+        }
+    }
+
+    #[test]
+    fn get_nested_glob_matches_returns_sorted_rel_paths() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path();
+        let search_root = root.join("deep");
+        for name in ["b", "a", "c"] {
+            let dir = search_root.join(name);
+            fs::create_dir_all(&dir).unwrap();
+            fs::write(dir.join("AGENTS.md"), "FIXED\n").unwrap();
+        }
+
+        let config_path = root.join("agentsync.toml");
+        fs::write(&config_path, "").unwrap();
+        let linker = Linker::new(make_config(), config_path);
+
+        let matches = linker
+            .get_nested_glob_matches(&search_root, "**/AGENTS.md", &[], &SyncOptions::default())
+            .unwrap();
+
+        let rels: Vec<String> = matches
+            .iter()
+            .map(|(_, rel)| rel.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            rels,
+            vec![
+                "a/AGENTS.md".to_string(),
+                "b/AGENTS.md".to_string(),
+                "c/AGENTS.md".to_string(),
+            ],
+            "nested-glob discovery order must be sorted by file name"
+        );
+    }
 
     // ==========================================================================
     // expand_destination_template edge cases

--- a/src/linker/symlinks.rs
+++ b/src/linker/symlinks.rs
@@ -254,12 +254,8 @@ impl Linker {
         // Create destination directory if needed
         self.ensure_directory(dest_dir, options)?;
 
-        // Iterate through source directory contents
-        for entry in fs::read_dir(source_dir)
-            .with_context(|| format!("Failed to read source directory: {}", source_dir.display()))?
-        {
-            let entry = entry
-                .with_context(|| format!("Failed to read entry in: {}", source_dir.display()))?;
+        // Iterate through source directory contents in deterministic order.
+        for entry in sorted_dir_entries(source_dir)? {
             let file_name = entry.file_name();
             let item_name = file_name.to_string_lossy();
 
@@ -296,6 +292,19 @@ impl Linker {
 
         Ok(result)
     }
+}
+
+/// Collect the entries of `dir`, returning them in deterministic sorted order.
+/// Directory iteration order from the OS is unspecified (often hash/creation
+/// order on APFS), so sorting by file name makes `symlink-contents` link
+/// creation and printed output reproducible across runs and platforms.
+fn sorted_dir_entries(dir: &Path) -> anyhow::Result<Vec<fs::DirEntry>> {
+    let mut entries: Vec<fs::DirEntry> = fs::read_dir(dir)
+        .with_context(|| format!("Failed to read source directory: {}", dir.display()))?
+        .collect::<Result<_, _>>()
+        .with_context(|| format!("Failed to read entry in: {}", dir.display()))?;
+    entries.sort_by_key(|entry| entry.file_name());
+    Ok(entries)
 }
 
 fn backup_path_for_destination(dest: &Path) -> PathBuf {
@@ -382,6 +391,37 @@ mod tests {
         let dest = root.join("dest.md");
 
         (temp, linker, source, dest)
+    }
+
+    // ==========================================================================
+    // B4 — deterministic directory iteration order (symlink-contents).
+    // The source fixture creates entries in NON-alphabetical order (`z`, `a`,
+    // `m`), so OS read_dir order (creation order on this filesystem) differs
+    // from sorted order (`a`, `m`, `z`). The helper must return sorted names
+    // so link creation order — and printed output — is reproducible.
+    // ==========================================================================
+
+    #[test]
+    #[cfg(unix)]
+    fn sorted_dir_entries_returns_sorted_file_names() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path();
+        for name in ["z.md", "a.md", "m.md"] {
+            let file = root.join(name);
+            fs::write(&file, format!("{name}\n")).unwrap();
+        }
+
+        let names: Vec<String> = sorted_dir_entries(root)
+            .unwrap()
+            .into_iter()
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+
+        assert_eq!(
+            names,
+            vec!["a.md".to_string(), "m.md".to_string(), "z.md".to_string()],
+            "source directory iteration order must be sorted by file name"
+        );
     }
 
     // ==========================================================================

--- a/tests/test_b4_determinism.rs
+++ b/tests/test_b4_determinism.rs
@@ -1,0 +1,172 @@
+//! B4 — Deterministic Directory Iteration Order (REQ: Deterministic Directory
+//! Iteration Order, spec.md `Deterministic Directory Iteration Order`).
+//!
+//! Proves end-to-end (through the real `agentsync apply` binary) that:
+//!   1. Two fresh `apply` runs on the same fixture produce **byte-identical
+//!      stdout** (determinism across runs).
+//!   2. The per-link "Linked:" lines appear in **sorted** file-name order for
+//!      both `symlink-contents` (flat) and `nested-glob` (deep) shapes.
+//!
+//! The fixture creates children in deliberately NON-alphabetical order
+//! (`z.md`, `a.md`, `m.md`; dirs `b/`, `a/`, `c/`), so OS `read_dir` order
+//! (APFS returns hash/bucket order, e.g. `z, m, a`) differs from sorted order
+//! (`a, m, z`). Pre-sort, assertion 2 fails even though assertion 1 may pass
+//! on filesystems whose `read_dir` order is stable-but-unsorted; post-sort
+//! both hold. This pins the sorted order as the deterministic contract.
+//!
+//! See also unit tests `sorted_dir_entries_returns_sorted_child_names`
+//! (src/linker/symlinks.rs) and `get_nested_glob_matches_returns_sorted_rel_paths`
+//! (src/linker/discovery.rs).
+
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use tempfile::TempDir;
+
+#[cfg(unix)]
+fn agentsync_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_agentsync")
+}
+
+#[cfg(unix)]
+fn run_apply(project_root: &Path) -> Output {
+    Command::new(agentsync_bin())
+        .current_dir(project_root)
+        .env("AGENTSYNC_NO_UPDATE_CHECK", "1")
+        .args(["apply", "--no-gitignore"])
+        .output()
+        .unwrap_or_else(|error| panic!("failed to run agentsync apply: {error}"))
+}
+
+/// Build the determinism fixture:
+///
+/// * `.agents/flat/` — children `z.md`, `a.md`, `m.md` created in that
+///   (non-alphabetical) order; `symlink-contents` → `links/`.
+/// * `deep/` — dirs `b/`, `a/`, `c/` created in that order, each containing
+///   `AGENTS.md`; `nested-glob` `**/AGENTS.md` → `docs/{relative_path}`
+///   (where `{relative_path}` = parent dir → dests `docs/a`, `docs/b`, `docs/c`).
+///
+/// `nested-glob` source is resolved against the PROJECT ROOT, not `.agents/`
+/// (symlink types resolve via `source_dir`; the glob walk starts at
+/// `project_root.join(source)`), so the tree lives at the root.
+#[cfg(unix)]
+fn build_fixture() -> TempDir {
+    let temp = TempDir::new().unwrap();
+    let root = temp.path();
+
+    let flat = root.join(".agents/flat");
+    fs::create_dir_all(&flat).unwrap();
+    // NON-alphabetical creation order: OS read_dir order != sorted order.
+    fs::write(flat.join("z.md"), "z\n").unwrap();
+    fs::write(flat.join("a.md"), "a\n").unwrap();
+    fs::write(flat.join("m.md"), "m\n").unwrap();
+
+    let deep_root = root.join("deep");
+    for name in ["b", "a", "c"] {
+        let dir = deep_root.join(name);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("AGENTS.md"), "FIXED\n").unwrap();
+    }
+
+    fs::write(
+        root.join(".agents/agentsync.toml"),
+        r#"
+        [agents.test]
+        enabled = true
+
+        [agents.test.targets.flat]
+        source = "flat"
+        destination = "links"
+        type = "symlink-contents"
+
+        [agents.test.targets.deep]
+        source = "deep"
+        destination = "docs/{relative_path}"
+        type = "nested-glob"
+        pattern = "**/AGENTS.md"
+    "#,
+    )
+    .unwrap();
+
+    temp
+}
+
+/// Extract the destination path from a "Linked:" line — the text between
+/// "Linked: " and " -> ".
+#[cfg(unix)]
+fn linked_dest(line: &str) -> Option<&str> {
+    line.split("Linked: ").nth(1)?.split(" -> ").next()
+}
+
+#[test]
+#[cfg(unix)]
+fn test_apply_output_is_byte_identical_and_sorted_across_runs() {
+    let temp = build_fixture();
+    let root = temp.path();
+
+    let run1 = run_apply(root);
+    assert!(
+        run1.status.success(),
+        "run 1 failed: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run1.status.code(),
+        String::from_utf8_lossy(&run1.stdout),
+        String::from_utf8_lossy(&run1.stderr)
+    );
+
+    // Reset created links so run 2 starts from the same fresh state.
+    fs::remove_dir_all(root.join("links")).unwrap();
+    fs::remove_dir_all(root.join("docs")).unwrap();
+
+    let run2 = run_apply(root);
+    assert!(
+        run2.status.success(),
+        "run 2 failed: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run2.status.code(),
+        String::from_utf8_lossy(&run2.stdout),
+        String::from_utf8_lossy(&run2.stderr)
+    );
+
+    // 1. Determinism: byte-identical stdout across two fresh runs.
+    assert_eq!(
+        run1.stdout, run2.stdout,
+        "stdout differed between two fresh apply runs — iteration order is not deterministic"
+    );
+
+    // 2. Sorted order pinned explicitly: the "Linked:" lines must appear in
+    //    sorted file-name order for both shapes.
+    let stdout = String::from_utf8_lossy(&run1.stdout);
+    let linked: Vec<&str> = stdout
+        .lines()
+        .filter_map(linked_dest)
+        .map(|dest| dest.trim())
+        .collect();
+
+    assert_eq!(linked.len(), 6, "expected 6 linked dests, got {linked:?}");
+
+    // Flat: dests are `…/links/{file_name}` → expect sorted [a.md, m.md, z.md].
+    let flat: Vec<&str> = linked
+        .iter()
+        .filter(|dest| dest.contains("/links/"))
+        .filter_map(|dest| dest.rsplit('/').next())
+        .collect();
+    assert_eq!(
+        flat,
+        vec!["a.md", "m.md", "z.md"],
+        "symlink-contents iteration is not sorted"
+    );
+
+    // Deep: dests are `…/docs/{relative_path}` where `{relative_path}` expands
+    // to the file's PARENT DIR relative to the search root (e.g. `a` for
+    // `deep/a/AGENTS.md`) → expect sorted [a, b, c].
+    let deep: Vec<&str> = linked
+        .iter()
+        .filter(|dest| dest.contains("/docs/"))
+        .filter_map(|dest| dest.split("/docs/").nth(1))
+        .collect();
+    assert_eq!(
+        deep,
+        vec!["a", "b", "c"],
+        "nested-glob iteration is not sorted"
+    );
+}


### PR DESCRIPTION
## Summary

Implements **B4 — Deterministic Directory Iteration Order** (issue #498, task 3.4) plus final benchmark metrics (tasks 4.1/4.2).

Deterministic output is the final piece of the linker perf work: OS directory iteration order is unspecified (hash/creation order on APFS), so link creation order and printed output were non-reproducible across runs and platforms.

## Changes

- `src/linker/symlinks.rs`: add `sorted_dir_entries()` — collects `read_dir` entries and sorts in-memory by file name before the `symlink-contents` loop. Zero extra syscalls (O(n log n) in memory).
- `src/linker/discovery.rs`: `WalkDir::sort_by_file_name()` for `nested-glob` discovery.
- `tests/test_b4_determinism.rs`: integration test — apply output is **byte-identical across runs** and sorted (`[a.md, m.md, z.md]` flat, `[a, b, c]` deep).
- Unit tests: `sorted_dir_entries_returns_sorted_file_names`, `get_nested_glob_matches_returns_sorted_rel_paths`.
- `benchmark-baseline.md`: final before/after table + load caveat (B4 is about determinism, not speed; no perf regression attributable).

## Verification

- `cargo test --all-features`: full suite green (0 failed, incl. CodeRabbit unit tests + 11/11 linker_security)
- `cargo fmt --all -- --check`: clean
- `cargo clippy --all-targets --all-features -- -D warnings`: clean

Closes the B4 + final metrics scope of #498.