### PR TITLE
ci: fix Renovate dependency lookup failure in stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,5 +10,5 @@ permissions:
 
 jobs:
   stale:
-    uses: dallay/common-actions/.github/workflows/stale.yml@6ecd716dcfb6a9e8a9c494d1eac210cc1d73d75f # v2
+    uses: dallay/common-actions/.github/workflows/stale.yml@v2.2.3
     secrets: inherit

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,5 +10,5 @@ permissions:
 
 jobs:
   stale:
-    uses: dallay/common-actions/.github/workflows/stale.yml@v2.2.3
+    uses: dallay/common-actions/.github/workflows/stale.yml@87129475c06d9f3354d398426926ba4345a4644d # v2.2.3
     secrets: inherit


### PR DESCRIPTION
Update `dallay/common-actions` reference in `.github/workflows/stale.yml` from commit SHA to explicit semantic release tag `@v2.2.3` so Renovate's `github-tags` datasource can resolve updates.

---
*PR created automatically by Jules for task [2925272561411988463](https://jules.google.com/task/2925272561411988463) started by @yacosta738*