### PR TITLE
fix(security): enforce 10MB file size limit on config loading

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -292,6 +292,19 @@ fn is_false(v: &bool) -> bool {
 impl Config {
     /// Load configuration from a file
     pub fn load(path: &Path) -> Result<Self> {
+        // SECURITY: Limit config file size to prevent DoS via memory exhaustion when parsing untrusted TOML
+        const MAX_CONFIG_FILE_SIZE: u64 = 10 * 1024 * 1024; // 10 MB
+        let metadata = fs::metadata(path)
+            .with_context(|| format!("Failed to stat config file: {}", path.display()))?;
+        if metadata.len() > MAX_CONFIG_FILE_SIZE {
+            anyhow::bail!(
+                "Config file size ({} bytes) exceeds maximum limit of {} bytes: {}",
+                metadata.len(),
+                MAX_CONFIG_FILE_SIZE,
+                path.display()
+            );
+        }
+
         let content = fs::read_to_string(path)
             .with_context(|| format!("Failed to read config file: {}", path.display()))?;
 
@@ -682,6 +695,20 @@ mod tests {
 
         let result = Config::load(&config_path);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_load_config_exceeds_max_size() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("agentsync.toml");
+
+        let file = fs::File::create(&config_path).unwrap();
+        file.set_len(10 * 1024 * 1024 + 1).unwrap();
+
+        let result = Config::load(&config_path);
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("exceeds maximum limit"));
     }
 
     // ==========================================================================


### PR DESCRIPTION
Adds a 10 MB file size limit check in `Config::load` (`src/config.rs`) using `fs::metadata` before reading file content into memory, mitigating Denial of Service (DoS) risks when loading untrusted configuration files. Includes unit test `test_load_config_exceeds_max_size`.

---
*PR created automatically by Jules for task [840904027323936278](https://jules.google.com/task/840904027323936278) started by @yacosta738*